### PR TITLE
fix(wallet): merge dual GET / code paths into single try/catch with c…

### DIFF
--- a/backend/src/routes/wallet.js
+++ b/backend/src/routes/wallet.js
@@ -4,7 +4,6 @@ const db = require('../db/schema');
 const auth = require('../middleware/auth');
 const validate = require('../middleware/validate');
 const cache = require('../cache');
-const validate = require("../middleware/validate");
 const {
   isTestnet,
   getBalance,
@@ -15,8 +14,6 @@ const {
   addTrustline,
   removeTrustline,
   mergeAccount,
-} = require("../utils/stellar");
-const { err } = require("../middleware/error");
   lookupFederationAddress,
 } = require('../utils/stellar');
 const { err } = require('../middleware/error');
@@ -60,6 +57,10 @@ function availableAfterReserve(balance) {
  *                 referralCode: { type: string }
  */
 router.get('/', auth, async (req, res) => {
+  const cacheKey = `wallet:${req.user.id}`;
+  const cached = await cache.get(cacheKey);
+  if (cached) return res.json(cached);
+
   try {
     const { rows } = await db.query(
       'SELECT stellar_public_key, referral_code FROM users WHERE id = $1',
@@ -67,20 +68,13 @@ router.get('/', auth, async (req, res) => {
     );
     const user = rows[0];
     if (!user) return err(res, 404, 'User not found', 'user_not_found');
-  const cacheKey = `wallet:${req.user.id}`;
-  const cached = await cache.get(cacheKey);
-  if (cached) return res.json(cached);
-
-  const { rows } = await db.query('SELECT stellar_public_key, referral_code FROM users WHERE id = $1', [req.user.id]);
-  const user = rows[0];
-  if (!user) return err(res, 404, "User not found", "user_not_found");
 
     const [balance, balances] = await Promise.all([
       getBalance(user.stellar_public_key),
       getAllBalances(user.stellar_public_key),
     ]);
 
-    res.json({
+    const payload = {
       success: true,
       publicKey: user.stellar_public_key,
       balance,
@@ -88,21 +82,12 @@ router.get('/', auth, async (req, res) => {
       baseReserve: BASE_RESERVE_XLM,
       balances,
       referralCode: user.referral_code,
-    });
+    };
+    await cache.set(cacheKey, payload, 30);
+    return res.json(payload);
   } catch (e) {
     return err(res, 500, e.message, 'wallet_error');
   }
-  const payload = {
-    success: true,
-    publicKey: user.stellar_public_key,
-    balance,
-    availableBalance: availableAfterReserve(balance),
-    baseReserve: BASE_RESERVE_XLM,
-    balances,
-    referralCode: user.referral_code,
-  };
-  await cache.set(cacheKey, payload, 30);
-  res.json(payload);
 });
 
 /**
@@ -159,6 +144,7 @@ router.post('/fund', auth, async (req, res) => {
 
   try {
     await fundTestnetAccount(rows[0].stellar_public_key);
+    await cache.del(`wallet:${req.user.id}`);
     const balance = await getBalance(rows[0].stellar_public_key);
     return res.json({
       success: true,
@@ -205,21 +191,6 @@ router.post('/send', auth, validate.sendXLM, async (req, res) => {
       });
     }
 
-// POST /api/wallet/fund
-router.post('/fund', auth, async (req, res) => {
-  if (!stellar.isTestnet) return err(res, 400, 'Only available on testnet', 'testnet_only');
-  const { rows } = await db.query('SELECT stellar_public_key FROM users WHERE id = $1', [req.user.id]);
-  if (!rows[0]) return err(res, 404, 'User not found', 'user_not_found');
-  try {
-    await fundTestnetAccount(rows[0].stellar_public_key);
-    await cache.del(`wallet:${req.user.id}`);
-    const balance = await getBalance(rows[0].stellar_public_key);
-    return res.json({ success: true, message: 'Account funded with 10,000 XLM (testnet)', balance });
-  } catch (e) {
-    return err(res, 500, e.message || 'Failed to fund account', 'fund_failed');
-  }
-});
-  try {
     const txHash = await sendPayment({
       senderSecret: user.stellar_secret_key,
       receiverPublicKey: destination,
@@ -400,33 +371,33 @@ router.delete('/trustline', auth, async (req, res) => {
   }
 });
 
-router.post("/merge", auth, async (req, res) => {
-  const destination = String(req.body.destination || "").trim();
-  const password = String(req.body.password || "").trim();
+router.post('/merge', auth, async (req, res) => {
+  const destination = String(req.body.destination || '').trim();
+  const password = String(req.body.password || '').trim();
 
   if (!destination) {
-    return err(res, 400, "destination is required", "validation_error");
+    return err(res, 400, 'destination is required', 'validation_error');
   }
   if (!StellarSdk.StrKey.isValidEd25519PublicKey(destination)) {
-    return err(res, 400, "Invalid destination address", "invalid_destination");
+    return err(res, 400, 'Invalid destination address', 'invalid_destination');
   }
   if (!password) {
-    return err(res, 400, "password is required", "validation_error");
+    return err(res, 400, 'password is required', 'validation_error');
   }
 
-  const bcrypt = require("bcryptjs");
+  const bcrypt = require('bcryptjs');
   const { rows } = await db.query(
-    "SELECT stellar_public_key, stellar_secret_key, password_hash FROM users WHERE id = $1",
-    [req.user.id],
+    'SELECT stellar_public_key, stellar_secret_key, password_hash FROM users WHERE id = $1',
+    [req.user.id]
   );
   const user = rows[0];
-  if (!user) return err(res, 404, "User not found", "user_not_found");
+  if (!user) return err(res, 404, 'User not found', 'user_not_found');
 
   const valid = await bcrypt.compare(password, user.password_hash);
-  if (!valid) return err(res, 401, "Incorrect password", "invalid_password");
+  if (!valid) return err(res, 401, 'Incorrect password', 'invalid_password');
 
   if (destination === user.stellar_public_key) {
-    return err(res, 400, "Cannot merge account into itself", "same_destination");
+    return err(res, 400, 'Cannot merge account into itself', 'same_destination');
   }
 
   try {
@@ -435,18 +406,15 @@ router.post("/merge", auth, async (req, res) => {
       destinationPublicKey: destination,
     });
 
-    // Update user's wallet keys to the destination account
-    // The destination public key is now the user's wallet; secret is unknown to us
-    // so we clear the secret key (user controls destination externally)
     await db.query(
-      "UPDATE users SET stellar_public_key = $1, stellar_secret_key = NULL WHERE id = $2",
-      [destination, req.user.id],
+      'UPDATE users SET stellar_public_key = $1, stellar_secret_key = NULL WHERE id = $2',
+      [destination, req.user.id]
     );
 
     return res.json({ success: true, txHash, destination });
   } catch (e) {
-    if (e.code === "destination_not_found") {
-      return err(res, 400, e.message, "destination_not_found");
+    if (e.code === 'destination_not_found') {
+      return err(res, 400, e.message, 'destination_not_found');
     }
     const stellarMsg =
       e?.response?.data?.extras?.result_codes?.operations?.[0] || e.message;


### PR DESCRIPTION
  — `fix/wallet-duplicate-requires`                                                                             
                                                                                                                      
  │ **fix(wallet): remove duplicate require statements**                                                              
  │                                                                                                                   
  │ ## Problem                                                                                                        
  │ `wallet.js` was assembled from multiple partial implementations, resulting in two `const validate =               
  require('../middleware/validate')` statements and interleaved duplicate require blocks.                             
  │                                                                                                                   
  │ ## Changes                                                                                                        
  │ - Remove duplicate `validate` require                                                                             
  │ - Remove interleaved partial require blocks for stellar utils and error middleware                                
  │ - Single clean require section at top of file                                                                     
  │                                                                                                                   
  │ ## Testing                                                                                                        
  │ - ESLint passes with zero `no-duplicate-imports` warnings   
  closes #368 