### PR TITLE
fix(#370): replace db.prepare() with db.query() in disputes.js

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -50,8 +50,6 @@ app.use(helmet({
   } : false
 }));
 
-const corsOrigins = process.env.CORS_ORIGIN || process.env.FRONTEND_ORIGIN || 'http://localhost:3000';
-const allowedOrigins = corsOrigins.split(',').map(o => o.trim());
 const corsOrigins =
   process.env.CORS_ORIGIN || process.env.FRONTEND_ORIGIN || 'http://localhost:3000';
 const allowedOrigins = corsOrigins.split(',').map((o) => o.trim());

--- a/backend/src/middleware/error.js
+++ b/backend/src/middleware/error.js
@@ -24,9 +24,6 @@ function errorHandler(error, req, res, next) { // eslint-disable-line no-unused-
     method: req.method,
     url: req.url
   });
-function errorHandler(error, req, res, next) {
-  // eslint-disable-line no-unused-vars
-  console.error(error);
   return err(res, 500, 'Internal server error', 'internal_error');
 }
 

--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -238,4 +238,18 @@ module.exports = {
       mnemonic: z.string().min(1, 'mnemonic is required'),
     })
   ),
+
+  dispute: validate(
+    z.object({
+      order_id: z.coerce.number().int().positive('order_id must be a positive integer'),
+      reason: z.string().min(1, 'reason is required').max(1000, 'reason must be 1000 characters or fewer').trim(),
+    })
+  ),
+
+  resolveDispute: validate(
+    z.object({
+      status: z.enum(['under_review', 'resolved']),
+      resolution: z.string().max(1000, 'resolution must be 1000 characters or fewer').optional(),
+    })
+  ),
 };

--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -5,122 +5,113 @@ const validate = require('../middleware/validate');
 const { sendDisputeResolvedEmail } = require('../utils/mailer');
 
 // POST /api/disputes — buyer files a dispute on a paid order
-router.post('/', auth, validate.dispute, (req, res) => {
-  if (req.user.role !== 'buyer')
-    return res.status(403).json({ error: 'Only buyers can file disputes' });
+router.post('/', auth, validate.dispute, async (req, res, next) => {
+  try {
+    if (req.user.role !== 'buyer')
+      return res.status(403).json({ error: 'Only buyers can file disputes' });
 
-  const order_id = parseInt(req.body.order_id, 10);
-  const { reason } = req.body;
+    const order_id = parseInt(req.body.order_id, 10);
+    const { reason } = req.body;
 
-  // Verify the order exists, belongs to this buyer, and is paid
-  const order = db.prepare(
-    'SELECT * FROM orders WHERE id = ? AND buyer_id = ?'
-  ).get(order_id, req.user.id);
-  const order = db
-    .prepare('SELECT * FROM orders WHERE id = ? AND buyer_id = ?')
-    .get(order_id, req.user.id);
+    const { rows: orderRows } = await db.query(
+      'SELECT * FROM orders WHERE id = $1 AND buyer_id = $2',
+      [order_id, req.user.id]
+    );
+    const order = orderRows[0];
 
-  if (!order) return res.status(404).json({ error: 'Order not found' });
-  if (order.status !== 'paid')
-    return res.status(400).json({ error: 'Disputes can only be filed on paid orders' });
+    if (!order) return res.status(404).json({ error: 'Order not found' });
+    if (order.status !== 'paid')
+      return res.status(400).json({ error: 'Disputes can only be filed on paid orders' });
 
-  // Enforce one dispute per order
-  const existing = db.prepare('SELECT id FROM disputes WHERE order_id = ?').get(order_id);
-  if (existing) return res.status(409).json({ error: 'A dispute already exists for this order' });
+    const { rows: existingRows } = await db.query(
+      'SELECT id FROM disputes WHERE order_id = $1',
+      [order_id]
+    );
+    if (existingRows[0])
+      return res.status(409).json({ error: 'A dispute already exists for this order' });
 
-  const result = db.prepare(
-    'INSERT INTO disputes (order_id, buyer_id, reason) VALUES (?, ?, ?)'
-  ).run(order_id, req.user.id, reason.trim());
+    const { rows: inserted } = await db.query(
+      'INSERT INTO disputes (order_id, buyer_id, reason) VALUES ($1, $2, $3) RETURNING id',
+      [order_id, req.user.id, reason.trim()]
+    );
 
-  res.status(201).json({ id: result.lastInsertRowid, order_id, status: 'open', message: 'Dispute filed' });
-  const result = db
-    .prepare('INSERT INTO disputes (order_id, buyer_id, reason) VALUES (?, ?, ?)')
-    .run(order_id, req.user.id, reason.trim());
-
-  res
-    .status(201)
-    .json({ id: result.lastInsertRowid, order_id, status: 'open', message: 'Dispute filed' });
+    res.status(201).json({ id: inserted[0].id, order_id, status: 'open', message: 'Dispute filed' });
+  } catch (err) {
+    next(err);
+  }
 });
 
 // GET /api/disputes — admin lists all disputes (with order + buyer info)
-router.get('/', auth, (req, res) => {
-  if (req.user.role !== 'admin')
-    return res.status(403).json({ error: 'Admins only' });
+router.get('/', auth, async (req, res, next) => {
+  try {
+    if (req.user.role !== 'admin')
+      return res.status(403).json({ error: 'Admins only' });
 
-  const disputes = db.prepare(`
-  if (req.user.role !== 'admin') return res.status(403).json({ error: 'Admins only' });
+    const { rows } = await db.query(`
+      SELECT d.*, u.name as buyer_name, u.email as buyer_email,
+             o.total_price, o.quantity, p.name as product_name
+      FROM disputes d
+      JOIN users u ON d.buyer_id = u.id
+      JOIN orders o ON d.order_id = o.id
+      JOIN products p ON o.product_id = p.id
+      ORDER BY d.created_at DESC
+    `);
 
-  const disputes = db
-    .prepare(
-      `
-    SELECT d.*, u.name as buyer_name, u.email as buyer_email,
-           o.total_price, o.quantity, p.name as product_name
-    FROM disputes d
-    JOIN users u ON d.buyer_id = u.id
-    JOIN orders o ON d.order_id = o.id
-    JOIN products p ON o.product_id = p.id
-    ORDER BY d.created_at DESC
-  `).all();
-  `
-    )
-    .all();
-
-  res.json(disputes);
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
 });
 
 // PATCH /api/disputes/:id — admin resolves a dispute
-router.patch('/:id', auth, validate.resolveDispute, async (req, res) => {
-  if (req.user.role !== 'admin')
-    return res.status(403).json({ error: 'Admins only' });
-  if (req.user.role !== 'admin') return res.status(403).json({ error: 'Admins only' });
+router.patch('/:id', auth, validate.resolveDispute, async (req, res, next) => {
+  try {
+    if (req.user.role !== 'admin')
+      return res.status(403).json({ error: 'Admins only' });
 
-  const dispute = db.prepare('SELECT * FROM disputes WHERE id = ?').get(req.params.id);
-  if (!dispute) return res.status(404).json({ error: 'Dispute not found' });
+    const { rows: disputeRows } = await db.query(
+      'SELECT * FROM disputes WHERE id = $1',
+      [req.params.id]
+    );
+    const dispute = disputeRows[0];
+    if (!dispute) return res.status(404).json({ error: 'Dispute not found' });
 
-  const { status, resolution } = req.body;
+    const { status, resolution } = req.body;
 
-  // Enforce valid status transitions: open → under_review → resolved
-  const transitions = { open: ['under_review'], under_review: ['resolved'], resolved: [] };
-  if (!transitions[dispute.status].includes(status))
-    return res.status(400).json({ error: `Cannot transition from '${dispute.status}' to '${status}'` });
+    const transitions = { open: ['under_review'], under_review: ['resolved'], resolved: [] };
+    if (!transitions[dispute.status].includes(status))
+      return res.status(400).json({ error: `Cannot transition from '${dispute.status}' to '${status}'` });
 
-  if (status === 'resolved' && (!resolution || !resolution.trim()))
-    return res.status(400).json({ error: 'A resolution note is required when resolving a dispute' });
+    if (status === 'resolved' && (!resolution || !resolution.trim()))
+      return res.status(400).json({ error: 'A resolution note is required when resolving a dispute' });
 
-  db.prepare(
-    'UPDATE disputes SET status = ?, resolution = ? WHERE id = ?'
-  ).run(status, resolution ? resolution.trim() : dispute.resolution, dispute.id);
-    return res
-      .status(400)
-      .json({ error: `Cannot transition from '${dispute.status}' to '${status}'` });
+    await db.query(
+      'UPDATE disputes SET status = $1, resolution = $2 WHERE id = $3',
+      [status, resolution ? resolution.trim() : dispute.resolution, dispute.id]
+    );
 
-  if (status === 'resolved' && (!resolution || !resolution.trim()))
-    return res
-      .status(400)
-      .json({ error: 'A resolution note is required when resolving a dispute' });
+    if (status === 'resolved') {
+      const [{ rows: buyerRows }, { rows: orderRows }] = await Promise.all([
+        db.query('SELECT * FROM users WHERE id = $1', [dispute.buyer_id]),
+        db.query('SELECT * FROM orders WHERE id = $1', [dispute.order_id]),
+      ]);
+      const { rows: productRows } = await db.query(
+        'SELECT * FROM products WHERE id = $1',
+        [orderRows[0].product_id]
+      );
 
-  db.prepare('UPDATE disputes SET status = ?, resolution = ? WHERE id = ?').run(
-    status,
-    resolution ? resolution.trim() : dispute.resolution,
-    dispute.id
-  );
+      sendDisputeResolvedEmail({
+        dispute: { ...dispute, resolution: resolution.trim() },
+        order: orderRows[0],
+        product: productRows[0],
+        buyer: buyerRows[0],
+      }).catch((err) => console.error('Dispute email failed:', err.message));
+    }
 
-  // Send email notification to buyer when resolved
-  if (status === 'resolved') {
-    const buyer = db.prepare('SELECT * FROM users WHERE id = ?').get(dispute.buyer_id);
-    const order = db.prepare('SELECT * FROM orders WHERE id = ?').get(dispute.order_id);
-    const product = db.prepare('SELECT * FROM products WHERE id = ?').get(order.product_id);
-
-    sendDisputeResolvedEmail({
-      dispute: { ...dispute, resolution: resolution.trim() },
-      order,
-      product,
-      buyer,
-    }).catch(err => console.error('Dispute email failed:', err.message));
-    }).catch((err) => console.error('Dispute email failed:', err.message));
+    res.json({ id: dispute.id, status, message: 'Dispute updated' });
+  } catch (err) {
+    next(err);
   }
-
-  res.json({ id: dispute.id, status, message: 'Dispute updated' });
 });
 
 module.exports = router;

--- a/backend/tests/disputes.test.js
+++ b/backend/tests/disputes.test.js
@@ -1,37 +1,22 @@
 const jwt = require('jsonwebtoken');
-const { request, app, mockGet, mockAll, mockRun } = require('./setup');
+const { request, app, mockDb } = require('./setup');
 const mailer = jest.requireMock('../src/utils/mailer');
 
 beforeEach(() => jest.clearAllMocks());
 
-const SECRET     = process.env.JWT_SECRET || 'secret';
-const buyerToken = jwt.sign({ id: 2, role: 'buyer'  }, SECRET);
-const adminToken = jwt.sign({ id: 9, role: 'admin'  }, SECRET);
-const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
-
-const paidOrder = { id: 10, buyer_id: 2, product_id: 5, quantity: 2, total_price: 10, status: 'paid' };
 const SECRET = process.env.JWT_SECRET || 'secret';
 const buyerToken = jwt.sign({ id: 2, role: 'buyer' }, SECRET);
 const adminToken = jwt.sign({ id: 9, role: 'admin' }, SECRET);
 const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
 
-const paidOrder = {
-  id: 10,
-  buyer_id: 2,
-  product_id: 5,
-  quantity: 2,
-  total_price: 10,
-  status: 'paid',
-};
+const paidOrder = { id: 10, buyer_id: 2, product_id: 5, quantity: 2, total_price: 10, status: 'paid' };
 
 describe('POST /api/disputes', () => {
   it('buyer files a dispute on a paid order', async () => {
-    mockGet
-      .mockReturnValueOnce(paidOrder)   // order lookup
-      .mockReturnValueOnce(undefined);  // no existing dispute
-      .mockReturnValueOnce(paidOrder) // order lookup
-      .mockReturnValueOnce(undefined); // no existing dispute
-    mockRun.mockReturnValueOnce({ lastInsertRowid: 1 });
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [paidOrder], rowCount: 1 })   // order lookup
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })             // no existing dispute
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });  // INSERT RETURNING
 
     const res = await request(app)
       .post('/api/disputes')
@@ -57,7 +42,7 @@ describe('POST /api/disputes', () => {
   });
 
   it('returns 404 for order not belonging to buyer', async () => {
-    mockGet.mockReturnValueOnce(undefined);
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     const res = await request(app)
       .post('/api/disputes')
       .set('Authorization', `Bearer ${buyerToken}`)
@@ -66,7 +51,7 @@ describe('POST /api/disputes', () => {
   });
 
   it('returns 400 for non-paid order', async () => {
-    mockGet.mockReturnValueOnce({ ...paidOrder, status: 'pending' });
+    mockDb.query.mockResolvedValueOnce({ rows: [{ ...paidOrder, status: 'pending' }], rowCount: 1 });
     const res = await request(app)
       .post('/api/disputes')
       .set('Authorization', `Bearer ${buyerToken}`)
@@ -75,10 +60,9 @@ describe('POST /api/disputes', () => {
   });
 
   it('returns 409 when dispute already exists for order', async () => {
-    mockGet
-      .mockReturnValueOnce(paidOrder)
-      .mockReturnValueOnce({ id: 5 }); // existing dispute
-    mockGet.mockReturnValueOnce(paidOrder).mockReturnValueOnce({ id: 5 }); // existing dispute
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [paidOrder], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 }); // existing dispute
     const res = await request(app)
       .post('/api/disputes')
       .set('Authorization', `Bearer ${buyerToken}`)
@@ -97,7 +81,10 @@ describe('POST /api/disputes', () => {
 
 describe('GET /api/disputes', () => {
   it('admin can list all disputes', async () => {
-    mockAll.mockReturnValueOnce([{ id: 1, status: 'open', reason: 'Not delivered' }]);
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: 1, status: 'open', reason: 'Not delivered' }],
+      rowCount: 1,
+    });
     const res = await request(app)
       .get('/api/disputes')
       .set('Authorization', `Bearer ${adminToken}`);
@@ -122,15 +109,9 @@ describe('GET /api/disputes', () => {
 
 describe('PATCH /api/disputes/:id', () => {
   it('admin moves dispute from open to under_review', async () => {
-    mockGet.mockReturnValueOnce({ id: 1, status: 'open', buyer_id: 2, order_id: 10, resolution: null });
-    mockGet.mockReturnValueOnce({
-      id: 1,
-      status: 'open',
-      buyer_id: 2,
-      order_id: 10,
-      resolution: null,
-    });
-    mockRun.mockReturnValueOnce({ changes: 1 });
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 1, status: 'open', buyer_id: 2, order_id: 10, resolution: null }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // UPDATE
 
     const res = await request(app)
       .patch('/api/disputes/1')
@@ -142,22 +123,12 @@ describe('PATCH /api/disputes/:id', () => {
   });
 
   it('admin resolves dispute with resolution note and triggers email', async () => {
-    mockGet
-      .mockReturnValueOnce({ id: 1, status: 'under_review', buyer_id: 2, order_id: 10, resolution: null })
-      .mockReturnValueOnce({ id: 2, email: 'buyer@test.com', name: 'Buyer' })  // buyer
-      .mockReturnValueOnce({ id: 10, product_id: 5 })                          // order
-      .mockReturnValueOnce({ id: 5, name: 'Apples' });                         // product
-      .mockReturnValueOnce({
-        id: 1,
-        status: 'under_review',
-        buyer_id: 2,
-        order_id: 10,
-        resolution: null,
-      })
-      .mockReturnValueOnce({ id: 2, email: 'buyer@test.com', name: 'Buyer' }) // buyer
-      .mockReturnValueOnce({ id: 10, product_id: 5 }) // order
-      .mockReturnValueOnce({ id: 5, name: 'Apples' }); // product
-    mockRun.mockReturnValueOnce({ changes: 1 });
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 1, status: 'under_review', buyer_id: 2, order_id: 10, resolution: null }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })                                          // UPDATE
+      .mockResolvedValueOnce({ rows: [{ id: 2, email: 'buyer@test.com', name: 'Buyer' }], rowCount: 1 }) // buyer
+      .mockResolvedValueOnce({ rows: [{ id: 10, product_id: 5 }], rowCount: 1 })                // order
+      .mockResolvedValueOnce({ rows: [{ id: 5, name: 'Apples' }], rowCount: 1 });               // product
 
     const res = await request(app)
       .patch('/api/disputes/1')
@@ -166,14 +137,15 @@ describe('PATCH /api/disputes/:id', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('resolved');
-    // Email is fire-and-forget, just verify it was called
-    await new Promise(r => setTimeout(r, 10));
     await new Promise((r) => setTimeout(r, 10));
     expect(mailer.sendDisputeResolvedEmail).toHaveBeenCalled();
   });
 
   it('returns 400 when resolving without a resolution note', async () => {
-    mockGet.mockReturnValueOnce({ id: 1, status: 'under_review', buyer_id: 2, order_id: 10 });
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: 1, status: 'under_review', buyer_id: 2, order_id: 10 }],
+      rowCount: 1,
+    });
     const res = await request(app)
       .patch('/api/disputes/1')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -182,7 +154,10 @@ describe('PATCH /api/disputes/:id', () => {
   });
 
   it('returns 400 for invalid status transition (open → resolved)', async () => {
-    mockGet.mockReturnValueOnce({ id: 1, status: 'open', buyer_id: 2, order_id: 10 });
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: 1, status: 'open', buyer_id: 2, order_id: 10 }],
+      rowCount: 1,
+    });
     const res = await request(app)
       .patch('/api/disputes/1')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -191,7 +166,10 @@ describe('PATCH /api/disputes/:id', () => {
   });
 
   it('returns 400 when trying to update a resolved dispute', async () => {
-    mockGet.mockReturnValueOnce({ id: 1, status: 'resolved', buyer_id: 2, order_id: 10 });
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: 1, status: 'resolved', buyer_id: 2, order_id: 10 }],
+      rowCount: 1,
+    });
     const res = await request(app)
       .patch('/api/disputes/1')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -200,7 +178,7 @@ describe('PATCH /api/disputes/:id', () => {
   });
 
   it('returns 404 for unknown dispute', async () => {
-    mockGet.mockReturnValueOnce(undefined);
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     const res = await request(app)
       .patch('/api/disputes/9999')
       .set('Authorization', `Bearer ${adminToken}`)


### PR DESCRIPTION
disputes.js was calling db.prepare().get/all/run() directly, which only works with SQLite (better-sqlite3). The pg pool has no .prepare() method, so any PostgreSQL path threw immediately.

Changes:
- Replace every db.prepare().get/all/run() call with await db.query($1, ...)
- Make all route handlers async and forward errors to next(err)
- Add missing validate.dispute and validate.resolveDispute zod validators
- Update disputes.test.js to mock db.query (async) instead of db.prepare
- Fix pre-existing duplicate declarations in app.js and error.js that blocked the test suite from loading

Closes #370