### PR TITLE
fix(#373): distinguish expired vs tampered tokens in auth middleware

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -6,9 +6,11 @@ module.exports = (req, res, next) => {
   if (!token) return err(res, 401, 'No token provided', 'missing_token');
 
   try {
-    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = jwt.verify(token, process.env.JWT_SECRET, { clockTolerance: 30 });
     next();
-  } catch {
+  } catch (e) {
+    if (e instanceof jwt.TokenExpiredError)
+      return err(res, 401, 'Token expired', 'token_expired');
     err(res, 401, 'Invalid token', 'invalid_token');
   }
 };

--- a/backend/src/middleware/error.js
+++ b/backend/src/middleware/error.js
@@ -24,9 +24,6 @@ function errorHandler(error, req, res, next) { // eslint-disable-line no-unused-
     method: req.method,
     url: req.url
   });
-function errorHandler(error, req, res, next) {
-  // eslint-disable-line no-unused-vars
-  console.error(error);
   return err(res, 500, 'Internal server error', 'internal_error');
 }
 

--- a/backend/tests/auth.middleware.test.js
+++ b/backend/tests/auth.middleware.test.js
@@ -1,0 +1,84 @@
+const jwt = require('jsonwebtoken');
+
+const SECRET = 'test-secret';
+process.env.JWT_SECRET = SECRET;
+
+// Load middleware after setting env
+const authMiddleware = require('../src/middleware/auth');
+
+function makeReq(token) {
+  return { headers: { authorization: token ? `Bearer ${token}` : undefined } };
+}
+
+function makeRes() {
+  const res = { _status: null, _body: null };
+  res.status = (s) => { res._status = s; return res; };
+  res.json = (b) => { res._body = b; return res; };
+  return res;
+}
+
+describe('auth middleware', () => {
+  it('calls next() and sets req.user for a valid token', () => {
+    const token = jwt.sign({ id: 1, role: 'buyer' }, SECRET, { expiresIn: '1h' });
+    const req = makeReq(token);
+    const res = makeRes();
+    const next = jest.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.id).toBe(1);
+  });
+
+  it('returns 401 missing_token when no Authorization header', () => {
+    const req = makeReq(null);
+    const res = makeRes();
+    const next = jest.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._status).toBe(401);
+    expect(res._body.code).toBe('missing_token');
+  });
+
+  it('returns 401 token_expired for an expired token', () => {
+    // iat/exp in the past — clockTolerance:30 should NOT save a token expired >30s ago
+    const token = jwt.sign({ id: 2 }, SECRET, { expiresIn: -60 });
+    const req = makeReq(token);
+    const res = makeRes();
+    const next = jest.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._status).toBe(401);
+    expect(res._body.code).toBe('token_expired');
+  });
+
+  it('returns 401 invalid_token for a tampered token', () => {
+    const token = jwt.sign({ id: 3 }, 'wrong-secret');
+    const req = makeReq(token);
+    const res = makeRes();
+    const next = jest.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res._status).toBe(401);
+    expect(res._body.code).toBe('invalid_token');
+  });
+
+  it('accepts a token expired within the 30s clock-skew tolerance', () => {
+    // Expired 10 seconds ago — within the 30s tolerance window
+    const token = jwt.sign({ id: 4 }, SECRET, { expiresIn: -10 });
+    const req = makeReq(token);
+    const res = makeRes();
+    const next = jest.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.id).toBe(4);
+  });
+});


### PR DESCRIPTION
jwt.verify() was catching all errors with the same 'invalid_token' code, making it impossible for the client to trigger a silent refresh on expiry.

Changes:
- Pass { clockTolerance: 30 } to jwt.verify() so tokens expired within 30 seconds are still accepted (handles clock skew between services)
- Catch jwt.TokenExpiredError separately and return code: 'token_expired' so the frontend can silently refresh without prompting re-login
- All other JWT errors (bad signature, malformed) still return code: 'invalid_token'
- Add tests/auth.middleware.test.js with 5 unit tests covering: valid token, missing token, expired token (>30s), tampered token, and clock-skew edge case (expired <30s → accepted)
- Fix pre-existing duplicate errorHandler declaration in error.js that blocked the test suite from loading

Closes #373