### PR TITLE
fix(#390): validate CSV column headers before processing rows

### DIFF
--- a/backend/src/__tests__/bulkUpload.test.js
+++ b/backend/src/__tests__/bulkUpload.test.js
@@ -63,6 +63,16 @@ describe('POST /api/products/bulk', () => {
     expect(res.body.message).toContain('quantity');
   });
 
+  it('returns 400 with missing_columns for empty CSV with wrong headers', async () => {
+    const csv = 'description,unit\n';
+    const res = await csvUpload(csv);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('missing_columns');
+    expect(res.body.message).toContain('name');
+    expect(res.body.message).toContain('price');
+    expect(res.body.message).toContain('quantity');
+  });
+
   it('skips invalid rows and reports them, still creates valid ones', async () => {
     const csv = [
       'name,price,quantity',

--- a/backend/src/routes/bulkUpload.js
+++ b/backend/src/routes/bulkUpload.js
@@ -28,10 +28,13 @@ router.post('/', auth, upload.single('file'), async (req, res) => {
   const results = { created: 0, skipped: 0, errors: [] };
 
   try {
+    const REQUIRED_HEADERS = ['name', 'price', 'quantity'];
+    let detectedHeaders = null;
+
     const records = await new Promise((resolve, reject) => {
       const rows = [];
       const parser = parse(req.file.buffer, {
-        columns: true,
+        columns: (hdrs) => { detectedHeaders = hdrs; return hdrs; },
         skip_empty_lines: true,
         trim: true,
       });
@@ -40,24 +43,18 @@ router.post('/', auth, upload.single('file'), async (req, res) => {
       parser.on('error', reject);
     });
 
+    if (!detectedHeaders) {
+      return err(res, 400, 'CSV file is empty or has no header row', 'validation_error');
+    }
+
+    const missingHeaders = REQUIRED_HEADERS.filter((h) => !detectedHeaders.includes(h));
+    if (missingHeaders.length > 0) {
+      return err(res, 400, `Missing required columns: ${missingHeaders.join(', ')}`, 'missing_columns');
+    }
+
     // Limit to 500 rows
     if (records.length > 500) {
       return err(res, 400, 'Maximum 500 rows per upload', 'validation_error');
-    }
-
-    // Validate required column headers
-    const REQUIRED_HEADERS = ['name', 'price', 'quantity'];
-    if (records.length > 0) {
-      const presentHeaders = Object.keys(records[0]);
-      const missingHeaders = REQUIRED_HEADERS.filter((h) => !presentHeaders.includes(h));
-      if (missingHeaders.length > 0) {
-        return err(
-          res,
-          400,
-          `Missing required columns: ${missingHeaders.join(', ')}`,
-          'missing_columns'
-        );
-      }
     }
 
     const insertStmt = db.prepare(


### PR DESCRIPTION
closes #390 

- Use csv-parse columns callback to capture headers unconditionally
- Validate required headers (name, price, quantity) before row processing
- Empty CSV with wrong headers now returns 400 missing_columns
- Add test case for empty CSV with wrong headers