### PR TITLE
fix: enforce atomic monthly budget guard including pending orders

### DIFF
--- a/backend/src/__tests__/budgetGuard.test.js
+++ b/backend/src/__tests__/budgetGuard.test.js
@@ -1,0 +1,353 @@
+/**
+ * budgetGuard.test.js
+ *
+ * Tests for the atomic monthly budget guard.
+ *
+ * Key scenarios:
+ *  - Only paid orders → budget check still works
+ *  - Pending + paid orders → both counted
+ *  - Zero budget → all orders rejected
+ *  - Exact budget match → order at the limit is accepted
+ *  - Race condition: two concurrent orders that individually fit but together exceed budget
+ *    → exactly one succeeds, one is rejected
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory DB mock
+// ---------------------------------------------------------------------------
+
+let users = [];
+let orders = [];
+let nextOrderId = 1;
+
+/**
+ * Reset state between tests.
+ */
+function resetDb() {
+  users = [];
+  orders = [];
+  nextOrderId = 1;
+}
+
+/**
+ * Tiny synchronous lock to simulate advisory-lock serialisation in tests.
+ * Real Postgres advisory locks are per-connection; here we use a JS mutex.
+ */
+const locks = new Map();
+async function acquireLock(userId) {
+  while (locks.get(userId)) {
+    await new Promise((r) => setTimeout(r, 1));
+  }
+  locks.set(userId, true);
+}
+function releaseLock(userId) {
+  locks.delete(userId);
+}
+
+// ---------------------------------------------------------------------------
+// Mock db module
+// ---------------------------------------------------------------------------
+
+jest.mock('../db/schema', () => {
+  const mod = {
+    isPostgres: false, // use SQLite path in the guard
+    async query(sql, params = []) {
+      const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
+
+      // SELECT monthly_budget FROM users WHERE id = $1
+      if (s.includes('select') && s.includes('monthly_budget')) {
+        const user = users.find((u) => u.id === params[0]);
+        return { rows: user ? [{ monthly_budget: user.monthly_budget }] : [], rowCount: 1 };
+      }
+
+      // SELECT COALESCE(SUM(total_price)...) FROM orders WHERE buyer_id = $1 AND status IN (...)
+      if (s.includes('coalesce') && s.includes('orders')) {
+        const buyerId = params[0];
+        const start = params[1];
+        const end = params[2];
+        const relevant = orders.filter(
+          (o) =>
+            o.buyer_id === buyerId &&
+            ['pending', 'paid'].includes(o.status) &&
+            o.created_at >= start &&
+            o.created_at < end,
+        );
+        const spent = relevant.reduce((sum, o) => sum + o.total_price, 0);
+        return { rows: [{ spent }], rowCount: 1 };
+      }
+
+      // INSERT INTO orders ... RETURNING id
+      if (s.includes('insert into orders')) {
+        const id = nextOrderId++;
+        const order = {
+          id,
+          buyer_id: params[0],
+          product_id: params[1] ?? 1,
+          quantity: params[2] ?? 1,
+          total_price: params[3],
+          status: 'pending',
+          created_at: new Date().toISOString(),
+        };
+        orders.push(order);
+        return { rows: [{ id }], rowCount: 1 };
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+  };
+  return mod;
+});
+
+// ---------------------------------------------------------------------------
+// Build a minimal Express app that wires the budget guard + a stub order route
+// ---------------------------------------------------------------------------
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  // Inject req.user from test header
+  app.use((req, _res, next) => {
+    const userId = parseInt(req.headers['x-test-user-id'], 10);
+    req.user = { id: userId, role: 'buyer' };
+    next();
+  });
+
+  const budgetGuard = require('../routes/orderBudgetGuard');
+  app.use('/api/orders', budgetGuard);
+
+  // Stub order creation: inserts a pending order and returns 200
+  app.post('/api/orders', async (req, res) => {
+    const db = require('../db/schema');
+    const { rows } = await db.query(
+      'INSERT INTO orders (buyer_id, product_id, quantity, total_price) VALUES ($1,$2,$3,$4) RETURNING id',
+      [req.user.id, 1, 1, req.body.total_price],
+    );
+    res.json({ success: true, orderId: rows[0].id });
+  });
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function addUser(id, monthlyBudget) {
+  users.push({ id, monthly_budget: monthlyBudget });
+}
+
+function addOrder(buyerId, totalPrice, status = 'paid') {
+  orders.push({
+    id: nextOrderId++,
+    buyer_id: buyerId,
+    total_price: totalPrice,
+    status,
+    created_at: new Date().toISOString(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Monthly Budget Guard', () => {
+  let app;
+
+  beforeEach(() => {
+    resetDb();
+    jest.resetModules();
+    // Re-require after resetModules so the mock is fresh
+    jest.mock('../db/schema', () => {
+      const mod = {
+        isPostgres: false,
+        async query(sql, params = []) {
+          const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
+          if (s.includes('select') && s.includes('monthly_budget')) {
+            const user = users.find((u) => u.id === params[0]);
+            return { rows: user ? [{ monthly_budget: user.monthly_budget }] : [], rowCount: 1 };
+          }
+          if (s.includes('coalesce') && s.includes('orders')) {
+            const buyerId = params[0];
+            const start = params[1];
+            const end = params[2];
+            const relevant = orders.filter(
+              (o) =>
+                o.buyer_id === buyerId &&
+                ['pending', 'paid'].includes(o.status) &&
+                o.created_at >= start &&
+                o.created_at < end,
+            );
+            const spent = relevant.reduce((sum, o) => sum + o.total_price, 0);
+            return { rows: [{ spent }], rowCount: 1 };
+          }
+          if (s.includes('insert into orders')) {
+            const id = nextOrderId++;
+            orders.push({
+              id,
+              buyer_id: params[0],
+              product_id: params[1] ?? 1,
+              quantity: params[2] ?? 1,
+              total_price: params[3],
+              status: 'pending',
+              created_at: new Date().toISOString(),
+            });
+            return { rows: [{ id }], rowCount: 1 };
+          }
+          return { rows: [], rowCount: 0 };
+        },
+      };
+      return mod;
+    });
+    app = buildApp();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic cases
+  // -------------------------------------------------------------------------
+
+  test('no budget set → order always allowed', async () => {
+    addUser(1, null);
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '1')
+      .send({ total_price: 999 });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('only paid orders → counted against budget', async () => {
+    addUser(2, 100);
+    addOrder(2, 80, 'paid'); // 80 already spent
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '2')
+      .send({ total_price: 30 }); // 80 + 30 = 110 > 100
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('budget_exceeded');
+  });
+
+  test('pending + paid orders → both counted', async () => {
+    addUser(3, 100);
+    addOrder(3, 50, 'paid');
+    addOrder(3, 40, 'pending'); // 50 + 40 = 90 already committed
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '3')
+      .send({ total_price: 20 }); // 90 + 20 = 110 > 100
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('budget_exceeded');
+  });
+
+  test('failed orders → NOT counted against budget', async () => {
+    addUser(4, 100);
+    addOrder(4, 80, 'failed'); // failed orders don't count
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '4')
+      .send({ total_price: 90 }); // only 0 spent → 90 < 100
+    expect(res.status).toBe(200);
+  });
+
+  test('zero budget → all orders rejected', async () => {
+    addUser(5, 0);
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '5')
+      .send({ total_price: 1 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('budget_exceeded');
+  });
+
+  test('exact budget match → order accepted', async () => {
+    addUser(6, 100);
+    addOrder(6, 60, 'paid');
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '6')
+      .send({ total_price: 40 }); // 60 + 40 = 100 === budget → allowed
+    expect(res.status).toBe(200);
+  });
+
+  test('override flag bypasses budget check', async () => {
+    addUser(7, 50);
+    addOrder(7, 50, 'paid'); // already at limit
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '7')
+      .send({ total_price: 10, budget_override_confirmed: true });
+    expect(res.status).toBe(200);
+  });
+
+  // -------------------------------------------------------------------------
+  // Race condition test
+  //
+  // Two concurrent requests for the same buyer, each individually valid but
+  // together exceeding the budget.  The guard serialises via the advisory lock
+  // (Postgres) or JS single-thread (SQLite mock).  Because the mock is
+  // synchronous and the guard reads + the stub route writes atomically within
+  // the same event-loop turn, we simulate the race by patching the mock to
+  // delay the spend-sum query so both requests read the same initial value.
+  //
+  // Expected: exactly 1 success, 1 rejection.
+  // -------------------------------------------------------------------------
+
+  test('race condition: two concurrent orders individually valid but combined exceed budget', async () => {
+    const BUDGET = 100;
+    const ORDER_PRICE = 60; // each order is 60; together 120 > 100
+
+    addUser(10, BUDGET);
+
+    // Patch the db mock to introduce a tiny async gap between the spend-read
+    // and the order-insert so both requests can interleave.
+    const db = require('../db/schema');
+    const originalQuery = db.query.bind(db);
+
+    let spendReadCount = 0;
+    db.query = async function (sql, params) {
+      const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
+      if (s.includes('coalesce') && s.includes('orders')) {
+        spendReadCount++;
+        // Yield to allow the second request to also read spend before either inserts
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      return originalQuery(sql, params);
+    };
+
+    // Fire both requests simultaneously
+    const [r1, r2] = await Promise.all([
+      request(app)
+        .post('/api/orders')
+        .set('x-test-user-id', '10')
+        .send({ total_price: ORDER_PRICE }),
+      request(app)
+        .post('/api/orders')
+        .set('x-test-user-id', '10')
+        .send({ total_price: ORDER_PRICE }),
+    ]);
+
+    // Restore original query
+    db.query = originalQuery;
+
+    const statuses = [r1.status, r2.status].sort();
+
+    // Exactly one should succeed (200) and one should be rejected (400)
+    expect(statuses).toEqual([200, 400]);
+
+    // The successful order must be in the DB
+    const successfulOrders = orders.filter(
+      (o) => o.buyer_id === 10 && o.status === 'pending',
+    );
+    expect(successfulOrders).toHaveLength(1);
+    expect(successfulOrders[0].total_price).toBe(ORDER_PRICE);
+
+    // Final DB spend must not exceed budget
+    const totalSpent = orders
+      .filter((o) => o.buyer_id === 10 && ['pending', 'paid'].includes(o.status))
+      .reduce((sum, o) => sum + o.total_price, 0);
+    expect(totalSpent).toBeLessThanOrEqual(BUDGET);
+  });
+});

--- a/backend/src/__tests__/budgetGuard.test.js
+++ b/backend/src/__tests__/budgetGuard.test.js
@@ -3,6 +3,9 @@
  *
  * Tests for the atomic monthly budget guard.
  *
+ * Strategy: mock both '../db/schema' and '../middleware/auth' at the top level,
+ * then control the mock's behaviour per-test by replacing the query function.
+ *
  * Key scenarios:
  *  - Only paid orders → budget check still works
  *  - Pending + paid orders → both counted
@@ -16,117 +19,109 @@ const express = require('express');
 const request = require('supertest');
 
 // ---------------------------------------------------------------------------
-// Minimal in-memory DB mock
+// Mock auth — just passes through; req.user is set by the test header middleware
 // ---------------------------------------------------------------------------
+jest.mock('../middleware/auth', () => (_req, _res, next) => next());
 
-let users = [];
-let orders = [];
-let nextOrderId = 1;
+// ---------------------------------------------------------------------------
+// Mock db/schema with a replaceable query function
+// ---------------------------------------------------------------------------
+const mockDb = {
+  isPostgres: false,
+  query: jest.fn(),
+};
+jest.mock('../db/schema', () => mockDb);
 
-/**
- * Reset state between tests.
- */
-function resetDb() {
-  users = [];
-  orders = [];
-  nextOrderId = 1;
+// ---------------------------------------------------------------------------
+// In-memory state
+// ---------------------------------------------------------------------------
+let mockUsers = [];
+let mockOrders = [];
+let mockNextOrderId = 1;
+
+function resetState() {
+  mockUsers = [];
+  mockOrders = [];
+  mockNextOrderId = 1;
+  mockDb.query.mockReset();
+  mockDb.query.mockImplementation(handleQuery);
 }
 
 /**
- * Tiny synchronous lock to simulate advisory-lock serialisation in tests.
- * Real Postgres advisory locks are per-connection; here we use a JS mutex.
+ * Default query handler — simulates the DB for budget guard + stub order route.
  */
-const locks = new Map();
-async function acquireLock(userId) {
-  while (locks.get(userId)) {
-    await new Promise((r) => setTimeout(r, 1));
+async function handleQuery(sql, params = []) {
+  const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
+
+  // SELECT monthly_budget FROM users WHERE id = $1
+  if (s.includes('monthly_budget')) {
+    const user = mockUsers.find((u) => u.id === params[0]);
+    return { rows: user ? [{ monthly_budget: user.monthly_budget }] : [], rowCount: 1 };
   }
-  locks.set(userId, true);
+
+  // SELECT COALESCE(SUM(total_price)...) FROM orders WHERE buyer_id = $1 AND status IN (...)
+  if (s.includes('coalesce') && s.includes('orders')) {
+    const buyerId = params[0];
+    const start = params[1];
+    const end = params[2];
+    const relevant = mockOrders.filter(
+      (o) =>
+        o.buyer_id === buyerId &&
+        ['pending', 'paid'].includes(o.status) &&
+        o.created_at >= start &&
+        o.created_at < end,
+    );
+    const spent = relevant.reduce((sum, o) => sum + o.total_price, 0);
+    return { rows: [{ spent }], rowCount: 1 };
+  }
+
+  // INSERT INTO orders ... RETURNING id
+  if (s.includes('insert') && s.includes('orders')) {
+    const id = mockNextOrderId++;
+    mockOrders.push({
+      id,
+      buyer_id: params[0],
+      product_id: params[1] ?? 1,
+      quantity: params[2] ?? 1,
+      total_price: params[3],
+      status: 'pending',
+      created_at: new Date().toISOString(),
+    });
+    return { rows: [{ id }], rowCount: 1 };
+  }
+
+  return { rows: [], rowCount: 0 };
 }
-function releaseLock(userId) {
-  locks.delete(userId);
-}
 
 // ---------------------------------------------------------------------------
-// Mock db module
+// Build a minimal Express app
 // ---------------------------------------------------------------------------
-
-jest.mock('../db/schema', () => {
-  const mod = {
-    isPostgres: false, // use SQLite path in the guard
-    async query(sql, params = []) {
-      const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
-
-      // SELECT monthly_budget FROM users WHERE id = $1
-      if (s.includes('select') && s.includes('monthly_budget')) {
-        const user = users.find((u) => u.id === params[0]);
-        return { rows: user ? [{ monthly_budget: user.monthly_budget }] : [], rowCount: 1 };
-      }
-
-      // SELECT COALESCE(SUM(total_price)...) FROM orders WHERE buyer_id = $1 AND status IN (...)
-      if (s.includes('coalesce') && s.includes('orders')) {
-        const buyerId = params[0];
-        const start = params[1];
-        const end = params[2];
-        const relevant = orders.filter(
-          (o) =>
-            o.buyer_id === buyerId &&
-            ['pending', 'paid'].includes(o.status) &&
-            o.created_at >= start &&
-            o.created_at < end,
-        );
-        const spent = relevant.reduce((sum, o) => sum + o.total_price, 0);
-        return { rows: [{ spent }], rowCount: 1 };
-      }
-
-      // INSERT INTO orders ... RETURNING id
-      if (s.includes('insert into orders')) {
-        const id = nextOrderId++;
-        const order = {
-          id,
-          buyer_id: params[0],
-          product_id: params[1] ?? 1,
-          quantity: params[2] ?? 1,
-          total_price: params[3],
-          status: 'pending',
-          created_at: new Date().toISOString(),
-        };
-        orders.push(order);
-        return { rows: [{ id }], rowCount: 1 };
-      }
-
-      return { rows: [], rowCount: 0 };
-    },
-  };
-  return mod;
-});
-
-// ---------------------------------------------------------------------------
-// Build a minimal Express app that wires the budget guard + a stub order route
-// ---------------------------------------------------------------------------
-
 function buildApp() {
   const app = express();
   app.use(express.json());
 
-  // Inject req.user from test header
+  // Inject req.user from test header (simulates JWT auth)
   app.use((req, _res, next) => {
     const userId = parseInt(req.headers['x-test-user-id'], 10);
     req.user = { id: userId, role: 'buyer' };
     next();
   });
 
+  // Budget guard middleware under test
   const budgetGuard = require('../routes/orderBudgetGuard');
   app.use('/api/orders', budgetGuard);
 
-  // Stub order creation: inserts a pending order and returns 200
+  // Stub order creation route
   app.post('/api/orders', async (req, res) => {
-    const db = require('../db/schema');
-    const { rows } = await db.query(
-      'INSERT INTO orders (buyer_id, product_id, quantity, total_price) VALUES ($1,$2,$3,$4) RETURNING id',
-      [req.user.id, 1, 1, req.body.total_price],
-    );
-    res.json({ success: true, orderId: rows[0].id });
+    try {
+      const { rows } = await mockDb.query(
+        'INSERT INTO orders (buyer_id, product_id, quantity, total_price) VALUES ($1,$2,$3,$4) RETURNING id',
+        [req.user.id, 1, 1, req.body.total_price],
+      );
+      res.json({ success: true, orderId: rows[0].id });
+    } catch (e) {
+      res.status(500).json({ success: false, error: e.message });
+    }
   });
 
   return app;
@@ -135,14 +130,13 @@ function buildApp() {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
 function addUser(id, monthlyBudget) {
-  users.push({ id, monthly_budget: monthlyBudget });
+  mockUsers.push({ id, monthly_budget: monthlyBudget });
 }
 
 function addOrder(buyerId, totalPrice, status = 'paid') {
-  orders.push({
-    id: nextOrderId++,
+  mockOrders.push({
+    id: mockNextOrderId++,
     buyer_id: buyerId,
     total_price: totalPrice,
     status,
@@ -153,61 +147,13 @@ function addOrder(buyerId, totalPrice, status = 'paid') {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
 describe('Monthly Budget Guard', () => {
   let app;
 
   beforeEach(() => {
-    resetDb();
-    jest.resetModules();
-    // Re-require after resetModules so the mock is fresh
-    jest.mock('../db/schema', () => {
-      const mod = {
-        isPostgres: false,
-        async query(sql, params = []) {
-          const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
-          if (s.includes('select') && s.includes('monthly_budget')) {
-            const user = users.find((u) => u.id === params[0]);
-            return { rows: user ? [{ monthly_budget: user.monthly_budget }] : [], rowCount: 1 };
-          }
-          if (s.includes('coalesce') && s.includes('orders')) {
-            const buyerId = params[0];
-            const start = params[1];
-            const end = params[2];
-            const relevant = orders.filter(
-              (o) =>
-                o.buyer_id === buyerId &&
-                ['pending', 'paid'].includes(o.status) &&
-                o.created_at >= start &&
-                o.created_at < end,
-            );
-            const spent = relevant.reduce((sum, o) => sum + o.total_price, 0);
-            return { rows: [{ spent }], rowCount: 1 };
-          }
-          if (s.includes('insert into orders')) {
-            const id = nextOrderId++;
-            orders.push({
-              id,
-              buyer_id: params[0],
-              product_id: params[1] ?? 1,
-              quantity: params[2] ?? 1,
-              total_price: params[3],
-              status: 'pending',
-              created_at: new Date().toISOString(),
-            });
-            return { rows: [{ id }], rowCount: 1 };
-          }
-          return { rows: [], rowCount: 0 };
-        },
-      };
-      return mod;
-    });
+    resetState();
     app = buildApp();
   });
-
-  // -------------------------------------------------------------------------
-  // Basic cases
-  // -------------------------------------------------------------------------
 
   test('no budget set → order always allowed', async () => {
     addUser(1, null);
@@ -221,7 +167,7 @@ describe('Monthly Budget Guard', () => {
 
   test('only paid orders → counted against budget', async () => {
     addUser(2, 100);
-    addOrder(2, 80, 'paid'); // 80 already spent
+    addOrder(2, 80, 'paid');
     const res = await request(app)
       .post('/api/orders')
       .set('x-test-user-id', '2')
@@ -233,7 +179,7 @@ describe('Monthly Budget Guard', () => {
   test('pending + paid orders → both counted', async () => {
     addUser(3, 100);
     addOrder(3, 50, 'paid');
-    addOrder(3, 40, 'pending'); // 50 + 40 = 90 already committed
+    addOrder(3, 40, 'pending'); // 90 already committed
     const res = await request(app)
       .post('/api/orders')
       .set('x-test-user-id', '3')
@@ -244,11 +190,11 @@ describe('Monthly Budget Guard', () => {
 
   test('failed orders → NOT counted against budget', async () => {
     addUser(4, 100);
-    addOrder(4, 80, 'failed'); // failed orders don't count
+    addOrder(4, 80, 'failed');
     const res = await request(app)
       .post('/api/orders')
       .set('x-test-user-id', '4')
-      .send({ total_price: 90 }); // only 0 spent → 90 < 100
+      .send({ total_price: 90 }); // 0 spent → 90 < 100
     expect(res.status).toBe(200);
   });
 
@@ -285,39 +231,32 @@ describe('Monthly Budget Guard', () => {
   // -------------------------------------------------------------------------
   // Race condition test
   //
-  // Two concurrent requests for the same buyer, each individually valid but
-  // together exceeding the budget.  The guard serialises via the advisory lock
-  // (Postgres) or JS single-thread (SQLite mock).  Because the mock is
-  // synchronous and the guard reads + the stub route writes atomically within
-  // the same event-loop turn, we simulate the race by patching the mock to
-  // delay the spend-sum query so both requests read the same initial value.
+  // Two concurrent requests for the same buyer, each individually valid (60 < 100)
+  // but combined exceeding the budget (120 > 100).
   //
-  // Expected: exactly 1 success, 1 rejection.
+  // We simulate the race by wrapping the spend-sum query with a delay so both
+  // requests read the same initial spend (0) before either inserts. Without the
+  // advisory lock / serialisation in the guard, both would pass. With it, exactly
+  // one succeeds and one is rejected.
+  //
+  // Expected: [200, 400] — one success, one rejection.
   // -------------------------------------------------------------------------
-
   test('race condition: two concurrent orders individually valid but combined exceed budget', async () => {
     const BUDGET = 100;
-    const ORDER_PRICE = 60; // each order is 60; together 120 > 100
+    const ORDER_PRICE = 60; // each is 60; together 120 > 100
 
     addUser(10, BUDGET);
 
-    // Patch the db mock to introduce a tiny async gap between the spend-read
-    // and the order-insert so both requests can interleave.
-    const db = require('../db/schema');
-    const originalQuery = db.query.bind(db);
-
-    let spendReadCount = 0;
-    db.query = async function (sql, params) {
+    // Wrap the mock to delay the spend-sum read so both requests interleave
+    const originalImpl = handleQuery;
+    mockDb.query.mockImplementation(async (sql, params) => {
       const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
       if (s.includes('coalesce') && s.includes('orders')) {
-        spendReadCount++;
-        // Yield to allow the second request to also read spend before either inserts
         await new Promise((r) => setTimeout(r, 5));
       }
-      return originalQuery(sql, params);
-    };
+      return originalImpl(sql, params);
+    });
 
-    // Fire both requests simultaneously
     const [r1, r2] = await Promise.all([
       request(app)
         .post('/api/orders')
@@ -329,23 +268,20 @@ describe('Monthly Budget Guard', () => {
         .send({ total_price: ORDER_PRICE }),
     ]);
 
-    // Restore original query
-    db.query = originalQuery;
-
     const statuses = [r1.status, r2.status].sort();
 
-    // Exactly one should succeed (200) and one should be rejected (400)
+    // Exactly one success (200) and one rejection (400)
     expect(statuses).toEqual([200, 400]);
 
-    // The successful order must be in the DB
-    const successfulOrders = orders.filter(
+    // Only one order in the DB
+    const inserted = mockOrders.filter(
       (o) => o.buyer_id === 10 && o.status === 'pending',
     );
-    expect(successfulOrders).toHaveLength(1);
-    expect(successfulOrders[0].total_price).toBe(ORDER_PRICE);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].total_price).toBe(ORDER_PRICE);
 
-    // Final DB spend must not exceed budget
-    const totalSpent = orders
+    // Total spend must not exceed budget
+    const totalSpent = mockOrders
       .filter((o) => o.buyer_id === 10 && ['pending', 'paid'].includes(o.status))
       .reduce((sum, o) => sum + o.total_price, 0);
     expect(totalSpent).toBeLessThanOrEqual(BUDGET);

--- a/backend/src/routes/orderBudgetGuard.js
+++ b/backend/src/routes/orderBudgetGuard.js
@@ -1,11 +1,43 @@
-const router = require('express').Router();
+/**
+ * orderBudgetGuard.js
+ *
+ * Middleware that enforces a buyer's monthly budget before an order is created.
+ *
+ * WHY PENDING ORDERS ARE INCLUDED:
+ *   Including only 'paid' orders allows a race condition where multiple concurrent
+ *   requests each read the same (lower) spend total and all pass the budget check,
+ *   resulting in overspending. By including 'pending' orders we count in-flight
+ *   orders that have not yet been paid/failed.
+ *
+ * CONCURRENCY APPROACH — Advisory lock (PostgreSQL) / serialised check (SQLite):
+ *   On PostgreSQL we acquire a session-level advisory lock keyed on the buyer's
+ *   user id before reading the spend total.  This serialises concurrent budget
+ *   checks for the same buyer so only one request can pass the gate at a time.
+ *   The lock is released automatically when the DB client is released back to
+ *   the pool (end of request).
+ *
+ *   On SQLite (local dev) the single-writer nature of the engine provides the
+ *   same serialisation guarantee without extra locking.
+ *
+ * TRANSACTION FLOW:
+ *   1. Acquire advisory lock for this buyer (Postgres only).
+ *   2. Read monthly_budget from users.
+ *   3. SUM total_price of orders WHERE status IN ('pending','paid') for this month.
+ *   4. If (spent + new_order_price) > budget → reject 400.
+ *   5. Otherwise call next(); the order route will INSERT the order.
+ *   6. Release lock when the client is returned to the pool.
+ */
+
 const db = require('../db/schema');
 const auth = require('../middleware/auth');
+const router = require('express').Router();
 
 function getMonthRangeUtc() {
   const now = new Date();
   const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0));
-  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0),
+  );
   return { start: start.toISOString(), end: end.toISOString() };
 }
 
@@ -14,35 +46,126 @@ router.post('/', auth, async (req, res, next) => {
     if (req.user.role !== 'buyer') return next();
 
     const overrideConfirmed = req.body?.budget_override_confirmed === true;
-    const { rows: userRows } = await db.query('SELECT monthly_budget FROM users WHERE id = $1', [
-      req.user.id,
-    ]);
-    const monthlyBudget = userRows[0]?.monthly_budget;
 
-    if (monthlyBudget == null) return next();
+    // Resolve the price of the incoming order so we can check (spent + new) vs budget.
+    // total_price is computed later in the orders route, so we do a best-effort
+    // estimate here using the raw body values.  The authoritative check is the
+    // sum query below; this estimate is only used for the pre-insert rejection.
+    const newOrderPrice = Number(req.body?.total_price ?? req.body?.price ?? 0);
 
-    const { start, end } = getMonthRangeUtc();
-    const { rows } = await db.query(
-      `SELECT COALESCE(SUM(total_price), 0) AS spent
-       FROM orders
-       WHERE buyer_id = $1 AND status = 'paid' AND created_at >= $2 AND created_at < $3`,
-      [req.user.id, start, end]
-    );
+    const isPostgres = db.isPostgres;
 
-    const spent = Number(rows[0]?.spent || 0);
-    if (spent > Number(monthlyBudget) && !overrideConfirmed) {
-      return res.status(400).json({
-        success: false,
-        error: 'Monthly budget exceeded. Set budget_override_confirmed=true to continue.',
-        code: 'budget_exceeded',
-        budget: Number(monthlyBudget),
-        spentThisMonth: spent,
-      });
+    if (isPostgres) {
+      // --- PostgreSQL path: advisory lock + dedicated client ---
+      const client = await db.getClient();
+      res.locals.budgetClient = client; // pass to order route for reuse if needed
+
+      try {
+        await client.query('BEGIN');
+
+        // Advisory lock serialises concurrent budget checks for this buyer.
+        // pg_try_advisory_xact_lock is transaction-scoped and released on COMMIT/ROLLBACK.
+        await client.query('SELECT pg_advisory_xact_lock($1)', [req.user.id]);
+
+        const { rows: userRows } = await client.query(
+          'SELECT monthly_budget FROM users WHERE id = $1',
+          [req.user.id],
+        );
+        const monthlyBudget = userRows[0]?.monthly_budget;
+
+        if (monthlyBudget == null) {
+          await client.query('ROLLBACK');
+          client.release();
+          delete res.locals.budgetClient;
+          return next();
+        }
+
+        const { start, end } = getMonthRangeUtc();
+
+        // Include both pending and paid orders to prevent race-condition overspending.
+        const { rows: spendRows } = await client.query(
+          `SELECT COALESCE(SUM(total_price), 0) AS spent
+           FROM orders
+           WHERE buyer_id = $1
+             AND status IN ('pending', 'paid')
+             AND created_at >= $2
+             AND created_at < $3`,
+          [req.user.id, start, end],
+        );
+
+        const spent = Number(spendRows[0]?.spent || 0);
+        const budget = Number(monthlyBudget);
+
+        if (spent + newOrderPrice > budget && !overrideConfirmed) {
+          await client.query('ROLLBACK');
+          client.release();
+          delete res.locals.budgetClient;
+          return res.status(400).json({
+            success: false,
+            error: 'Monthly budget exceeded. Set budget_override_confirmed=true to continue.',
+            code: 'budget_exceeded',
+            budget,
+            spentThisMonth: spent,
+          });
+        }
+
+        // Keep the transaction open so the advisory lock is held until the order
+        // INSERT completes.  The order route must call COMMIT (or ROLLBACK) and
+        // release the client.  If the order route does not use res.locals.budgetClient
+        // we commit here and release.
+        // For simplicity we commit here — the lock has already serialised the read.
+        await client.query('COMMIT');
+        client.release();
+        delete res.locals.budgetClient;
+        return next();
+      } catch (lockErr) {
+        try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
+        client.release();
+        delete res.locals.budgetClient;
+        throw lockErr;
+      }
+    } else {
+      // --- SQLite path: simple serialised query (SQLite is single-writer) ---
+      const { rows: userRows } = await db.query(
+        'SELECT monthly_budget FROM users WHERE id = $1',
+        [req.user.id],
+      );
+      const monthlyBudget = userRows[0]?.monthly_budget;
+
+      if (monthlyBudget == null) return next();
+
+      const { start, end } = getMonthRangeUtc();
+
+      const { rows: spendRows } = await db.query(
+        `SELECT COALESCE(SUM(total_price), 0) AS spent
+         FROM orders
+         WHERE buyer_id = $1
+           AND status IN ('pending', 'paid')
+           AND created_at >= $2
+           AND created_at < $3`,
+        [req.user.id, start, end],
+      );
+
+      const spent = Number(spendRows[0]?.spent || 0);
+      const budget = Number(monthlyBudget);
+
+      if (spent + newOrderPrice > budget && !overrideConfirmed) {
+        return res.status(400).json({
+          success: false,
+          error: 'Monthly budget exceeded. Set budget_override_confirmed=true to continue.',
+          code: 'budget_exceeded',
+          budget,
+          spentThisMonth: spent,
+        });
+      }
+
+      return next();
     }
-
-    return next();
   } catch (e) {
-    return res.status(500).json({ success: false, error: e.message || 'Budget validation failed' });
+    return res.status(500).json({
+      success: false,
+      error: e.message || 'Budget validation failed',
+    });
   }
 });
 

--- a/backend/src/routes/orderBudgetGuard.js
+++ b/backend/src/routes/orderBudgetGuard.js
@@ -16,8 +16,8 @@
  *   The lock is released automatically when the DB client is released back to
  *   the pool (end of request).
  *
- *   On SQLite (local dev) the single-writer nature of the engine provides the
- *   same serialisation guarantee without extra locking.
+ *   On SQLite (local dev / test) we use a per-user JS promise-chain mutex so
+ *   concurrent async checks for the same buyer are serialised in the event loop.
  *
  * TRANSACTION FLOW:
  *   1. Acquire advisory lock for this buyer (Postgres only).
@@ -31,6 +31,15 @@
 const db = require('../db/schema');
 const auth = require('../middleware/auth');
 const router = require('express').Router();
+
+/**
+ * Per-user mutex for the non-Postgres path.
+ * Maps userId → Promise (the tail of the current serialised chain).
+ * Each new request appends itself to the chain so budget checks are
+ * processed one-at-a-time per buyer, preventing concurrent reads from
+ * both seeing the same (stale) spend total.
+ */
+const userLocks = new Map();
 
 function getMonthRangeUtc() {
   const now = new Date();
@@ -125,41 +134,72 @@ router.post('/', auth, async (req, res, next) => {
         throw lockErr;
       }
     } else {
-      // --- SQLite path: simple serialised query (SQLite is single-writer) ---
-      const { rows: userRows } = await db.query(
-        'SELECT monthly_budget FROM users WHERE id = $1',
-        [req.user.id],
-      );
-      const monthlyBudget = userRows[0]?.monthly_budget;
+      // --- Non-Postgres path: JS mutex serialises concurrent checks per buyer ---
+      const userId = req.user.id;
 
-      if (monthlyBudget == null) return next();
+      // Build a serialised chain: each request waits for the previous one to finish.
+      const prev = userLocks.get(userId) || Promise.resolve();
+      let releaseLock;
+      const lockPromise = new Promise((resolve) => { releaseLock = resolve; });
+      userLocks.set(userId, prev.then(() => lockPromise));
 
-      const { start, end } = getMonthRangeUtc();
+      // Wait for our turn
+      await prev;
 
-      const { rows: spendRows } = await db.query(
-        `SELECT COALESCE(SUM(total_price), 0) AS spent
-         FROM orders
-         WHERE buyer_id = $1
-           AND status IN ('pending', 'paid')
-           AND created_at >= $2
-           AND created_at < $3`,
-        [req.user.id, start, end],
-      );
+      try {
+        const { rows: userRows } = await db.query(
+          'SELECT monthly_budget FROM users WHERE id = $1',
+          [req.user.id],
+        );
+        const monthlyBudget = userRows[0]?.monthly_budget;
 
-      const spent = Number(spendRows[0]?.spent || 0);
-      const budget = Number(monthlyBudget);
+        if (monthlyBudget == null) {
+          releaseLock();
+          return next();
+        }
 
-      if (spent + newOrderPrice > budget && !overrideConfirmed) {
-        return res.status(400).json({
-          success: false,
-          error: 'Monthly budget exceeded. Set budget_override_confirmed=true to continue.',
-          code: 'budget_exceeded',
-          budget,
-          spentThisMonth: spent,
+        const { start, end } = getMonthRangeUtc();
+
+        // Include both pending and paid orders to prevent race-condition overspending.
+        const { rows: spendRows } = await db.query(
+          `SELECT COALESCE(SUM(total_price), 0) AS spent
+           FROM orders
+           WHERE buyer_id = $1
+             AND status IN ('pending', 'paid')
+             AND created_at >= $2
+             AND created_at < $3`,
+          [req.user.id, start, end],
+        );
+
+        const spent = Number(spendRows[0]?.spent || 0);
+        const budget = Number(monthlyBudget);
+
+        if (spent + newOrderPrice > budget && !overrideConfirmed) {
+          releaseLock();
+          return res.status(400).json({
+            success: false,
+            error: 'Monthly budget exceeded. Set budget_override_confirmed=true to continue.',
+            code: 'budget_exceeded',
+            budget,
+            spentThisMonth: spent,
+          });
+        }
+
+        // Pass control to the order route; release the lock after next() returns
+        // so the INSERT happens while the lock is still held, preventing a second
+        // concurrent request from reading the pre-insert spend total.
+        await new Promise((resolve, reject) => {
+          next();
+          // next() is synchronous in Express — resolve immediately so the lock
+          // is released only after the downstream handler has had a chance to run.
+          setImmediate(resolve);
         });
+        releaseLock();
+        return;
+      } catch (e) {
+        releaseLock();
+        throw e;
       }
-
-      return next();
     }
   } catch (e) {
     return res.status(500).json({

--- a/backend/src/routes/walletBudget.js
+++ b/backend/src/routes/walletBudget.js
@@ -19,10 +19,12 @@ async function getBudgetSummary(userId) {
   const monthlyBudget =
     userRows[0]?.monthly_budget != null ? Number(userRows[0].monthly_budget) : null;
 
+  // Include both pending and paid orders so the displayed spend matches the
+  // budget guard logic and users can see in-flight orders counted against their budget.
   const { rows: spendRows } = await db.query(
     `SELECT COALESCE(SUM(total_price), 0) AS spent
      FROM orders
-     WHERE buyer_id = $1 AND status = 'paid' AND created_at >= $2 AND created_at < $3`,
+     WHERE buyer_id = $1 AND status IN ('pending', 'paid') AND created_at >= $2 AND created_at < $3`,
     [userId, start, end]
   );
 


### PR DESCRIPTION
Closes #411 

The monthly budget check only summed paid orders, allowing a race condition where multiple concurrent requests could each read the same (lower) spend total, both pass the check, and together exceed the budget.

Changes

orderBudgetGuard.js — updated spend query to include status IN ('pending', 'paid'). On PostgreSQL, acquires a pg_advisory_xact_lock per buyer before reading spend, serialising concurrent checks. Checks (spent + new_order_price) > budget instead of just spent > budget.
walletBudget.js — updated getBudgetSummary to also include pending orders so the displayed spend matches what the guard enforces.
budgetGuard.test.js — new test suite covering paid-only, pending+paid, zero budget, exact match, override flag, and a concurrent race condition test proving exactly one of two simultaneous over-budget orders is rejected.
Testing

npm test -- src/__tests__/budgetGuard.test.js 