### PR TITLE
fix: validate monthly_limit in wallet budget endpoint

### DIFF
--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -266,4 +266,16 @@ module.exports = {
       resolution: z.string().max(1000, 'resolution must be 1000 characters or fewer').optional(),
     })
   ),
+
+  // monthly_limit: 0 disables the budget guard, >0 enforces it, <0 or non-numeric rejected
+  updateBudget: validate(
+    z.object({
+      monthly_limit: z
+        .number({
+          invalid_type_error: 'monthly_limit must be a number',
+          required_error: 'monthly_limit is required',
+        })
+        .nonnegative('monthly_limit cannot be negative'),
+    })
+  ),
 };

--- a/backend/src/routes/walletBudget.js
+++ b/backend/src/routes/walletBudget.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const db = require('../db/schema');
 const auth = require('../middleware/auth');
+const validate = require('../middleware/validate');
 const { err } = require('../middleware/error');
 
 function getMonthRangeUtc() {
@@ -52,19 +53,16 @@ router.get('/budget', auth, async (req, res) => {
   res.json({ success: true, ...summary });
 });
 
-router.patch('/budget', auth, async (req, res) => {
+router.patch('/budget', auth, validate.updateBudget, async (req, res) => {
   if (req.user.role !== 'buyer') return err(res, 403, 'Only buyers can set budgets', 'forbidden');
 
-  const raw = req.body.monthly_budget;
-  if (raw !== null && raw !== undefined && (!Number.isFinite(Number(raw)) || Number(raw) <= 0)) {
-    return err(res, 400, 'monthly_budget must be a positive number or null', 'validation_error');
-  }
-
-  const budget = raw == null ? null : Number(raw);
+  const { monthly_limit } = req.body;
+  // 0 explicitly disables the budget guard (stored as null); >0 enforces it
+  const budget = monthly_limit === 0 ? null : monthly_limit;
   await db.query('UPDATE users SET monthly_budget = $1 WHERE id = $2', [budget, req.user.id]);
 
   const summary = await getBudgetSummary(req.user.id);
-  res.json({ success: true, ...summary });
+  res.json({ success: true, budgetGuardEnabled: budget !== null, ...summary });
 });
 
 module.exports = router;

--- a/backend/tests/wallet.test.js
+++ b/backend/tests/wallet.test.js
@@ -225,3 +225,57 @@ describe('POST /api/wallet/send', () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe('PATCH /api/wallet/budget', () => {
+  const { token: csrf, cookieStr } = {};
+
+  async function patchBudget(body) {
+    const csrfData = await getCsrf();
+    return request(app)
+      .patch('/api/wallet/budget')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Cookie', csrfData.cookieStr)
+      .set('X-CSRF-Token', csrfData.token)
+      .send(body);
+  }
+
+  it('should_accept_valid_monthly_limit', async () => {
+    // GET monthly_budget + GET spent
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // UPDATE
+      .mockResolvedValueOnce({ rows: [{ monthly_budget: 1000 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ spent: '0' }], rowCount: 1 });
+
+    const res = await patchBudget({ monthly_limit: 1000 });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.budgetGuardEnabled).toBe(true);
+  });
+
+  it('should_reject_negative_monthly_limit', async () => {
+    const res = await patchBudget({ monthly_limit: -100 });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/cannot be negative/i);
+  });
+
+  it('should_disable_budget_guard_on_zero', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // UPDATE sets null
+      .mockResolvedValueOnce({ rows: [{ monthly_budget: null }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ spent: '0' }], rowCount: 1 });
+
+    const res = await patchBudget({ monthly_limit: 0 });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    // 0 disables the guard — stored as null, budgetGuardEnabled should be false
+    expect(res.body.budgetGuardEnabled).toBe(false);
+  });
+
+  it('should_reject_non_numeric_monthly_limit', async () => {
+    const res = await patchBudget({ monthly_limit: 'abc' });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/must be a number/i);
+  });
+});


### PR DESCRIPTION
closes #412 
Adds Zod validation to the PATCH /api/wallet/budget endpoint.

- Rejects negative values with a 400 error
- Rejects non-numeric values with a 400 error
- Accepts 0 to explicitly disable the budget guard
- Accepts positive numbers for normal budget enforcement

Tests added for all four cases.