### PR TITLE
fix(#410): delete push subscription on 410/404 and add daily cleanup job

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ const cron = require('node-cron');
 const { startSubscriptionJob } = require('./jobs/processSubscriptions');
 const { startFreshnessJob } = require('./jobs/processFreshnessAlerts');
 const { startContractMonitor } = require('./jobs/contractMonitor');
+const { startPushSubscriptionCleanup } = require('./jobs/cleanupPushSubscriptions');
 const { createBackup } = require('./scripts/backup');
 const PORT = process.env.PORT || 4000;
 
@@ -13,6 +14,7 @@ app.listen(PORT, () => {
   startSubscriptionJob();
   startFreshnessJob();
   startContractMonitor();
+  startPushSubscriptionCleanup();
   
   // Schedule daily backup at midnight
   cron.schedule('0 0 * * *', async () => {

--- a/backend/src/jobs/cleanupPushSubscriptions.js
+++ b/backend/src/jobs/cleanupPushSubscriptions.js
@@ -1,0 +1,28 @@
+const cron = require('node-cron');
+const logger = require('../logger');
+const db = require('../db/schema');
+
+async function cleanupExpiredPushSubscriptions() {
+  const query = db.isPostgres
+    ? "DELETE FROM push_subscriptions WHERE created_at < NOW() - INTERVAL '90 days'"
+    : "DELETE FROM push_subscriptions WHERE created_at < datetime('now', '-90 days')";
+
+  const result = await db.query(query);
+  const count = db.isPostgres ? result.rowCount : result.changes;
+  if (count > 0) {
+    logger.info(`[push-cleanup] Removed ${count} expired push subscription(s)`);
+  }
+  return count;
+}
+
+function startPushSubscriptionCleanup() {
+  // Run daily at 02:00 UTC
+  cron.schedule('0 2 * * *', () => {
+    cleanupExpiredPushSubscriptions().catch((e) =>
+      logger.error('[push-cleanup] Job error:', { error: e.message })
+    );
+  });
+  logger.info('[push-cleanup] Daily cleanup job scheduled (02:00 UTC)');
+}
+
+module.exports = { startPushSubscriptionCleanup, cleanupExpiredPushSubscriptions };


### PR DESCRIPTION
pr close #410 
- sendPushToUser already deletes subscription on 410/404 Gone (existing)
- Add cleanupPushSubscriptions job: deletes records older than 90 days
- Schedule cleanup daily at 02:00 UTC in index.js
- Supports both SQLite and PostgreSQL