### PR TITLE
feat: enforce per-user coupon usage limit

### DIFF
--- a/backend/migrations/016_coupon_uses.sql
+++ b/backend/migrations/016_coupon_uses.sql
@@ -1,0 +1,13 @@
+-- Migration: 016_coupon_uses
+-- Description: Track per-user coupon redemptions and add max_uses_per_user limit
+
+ALTER TABLE coupons ADD COLUMN max_uses_per_user INTEGER;
+
+CREATE TABLE IF NOT EXISTS coupon_uses (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  coupon_id  INTEGER NOT NULL REFERENCES coupons(id) ON DELETE CASCADE,
+  user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  used_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_coupon_uses_coupon_user ON coupon_uses(coupon_id, user_id);

--- a/backend/migrations/016_coupon_uses.undo.sql
+++ b/backend/migrations/016_coupon_uses.undo.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS coupon_uses;
+ALTER TABLE coupons DROP COLUMN IF EXISTS max_uses_per_user;

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -60,7 +60,6 @@ app.use(helmet({
 
 const corsOrigins = process.env.CORS_ORIGIN || process.env.FRONTEND_ORIGIN || 'http://localhost:3000';
 const allowedOrigins = corsOrigins.split(',').map((o) => o.trim());
-const allowedOrigins = corsOrigins.split(',').map(o => o.trim());
 
 app.use(
   cors({

--- a/backend/src/routes/coupons.js
+++ b/backend/src/routes/coupons.js
@@ -25,7 +25,8 @@ async function getTierPrice(productId, quantity) {
 }
 
 // Resolve a coupon row and validate it against a farmer + total
-function resolveCoupon(code, farmerId) {
+// userId is optional; when provided, per-user limit is enforced
+function resolveCoupon(code, farmerId, userId) {
   const coupon = db.prepare('SELECT * FROM coupons WHERE code = ?').get(code.toUpperCase());
   if (!coupon) return { error: 'Invalid coupon code', code: 'invalid_coupon' };
   if (coupon.farmer_id !== farmerId)
@@ -34,6 +35,13 @@ function resolveCoupon(code, farmerId) {
     return { error: 'Coupon has expired', code: 'coupon_expired' };
   if (coupon.max_uses !== null && coupon.used_count >= coupon.max_uses)
     return { error: 'Coupon usage limit reached', code: 'coupon_exhausted' };
+  if (userId != null && coupon.max_uses_per_user != null) {
+    const uses = db
+      .prepare('SELECT COUNT(*) as cnt FROM coupon_uses WHERE coupon_id = ? AND user_id = ?')
+      .get(coupon.id, userId);
+    if (uses.cnt >= coupon.max_uses_per_user)
+      return { error: 'Coupon already used', code: 'coupon_already_used' };
+  }
   return { coupon };
 }
 
@@ -123,8 +131,8 @@ router.post('/validate', auth, async (req, res) => {
   const unitPrice = await getTierPrice(product_id, quantity);
   const subtotal = unitPrice * quantity;
 
-  const { coupon, error, code: errCode } = resolveCoupon(code, product.farmer_id);
-  if (error) return err(res, 400, error, errCode);
+  const { coupon, error, code: errCode } = resolveCoupon(code, product.farmer_id, req.user.id);
+  if (error) return err(res, errCode === 'coupon_already_used' ? 409 : 400, error, errCode);
 
   const discount = calcDiscount(coupon, subtotal);
   res.json({

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -153,6 +153,14 @@ router.post('/', auth, validate.order, async (req, res) => {
     );
     if (!cRows[0]) return err(res, 400, 'Invalid or expired coupon', 'invalid_coupon');
     appliedCoupon = cRows[0];
+    if (appliedCoupon.max_uses_per_user != null) {
+      const { rows: useRows } = await db.query(
+        'SELECT COUNT(*) as cnt FROM coupon_uses WHERE coupon_id = $1 AND user_id = $2',
+        [appliedCoupon.id, req.user.id]
+      );
+      if (parseInt(useRows[0].cnt, 10) >= appliedCoupon.max_uses_per_user)
+        return err(res, 409, 'Coupon already used', 'coupon_already_used');
+    }
     discount = appliedCoupon.discount_type === 'percent'
       ? parseFloat((subtotal * appliedCoupon.discount_value / 100).toFixed(7))
       : Math.min(parseFloat(appliedCoupon.discount_value), subtotal);
@@ -197,7 +205,7 @@ router.post('/', auth, validate.order, async (req, res) => {
   let appliedCoupon = null;
 
   if (coupon_code) {
-    const { coupon, error, code: errCode } = resolveCoupon(coupon_code, product.farmer_id);
+    const { coupon, error, code: errCode } = resolveCoupon(coupon_code, product.farmer_id, req.user.id);
     if (!error) {
        discount = calcDiscount(coupon, subtotal);
        appliedCoupon = coupon;
@@ -257,6 +265,7 @@ router.post('/', auth, validate.order, async (req, res) => {
   if (payment_method === 'sep7') {
     if (appliedCoupon) {
       db.prepare('UPDATE coupons SET used_count = used_count + 1 WHERE id = ?').run(appliedCoupon.id);
+      db.prepare('INSERT INTO coupon_uses (coupon_id, user_id) VALUES (?, ?)').run(appliedCoupon.id, req.user.id);
     }
 
     const responseData = {
@@ -432,6 +441,7 @@ router.post('/', auth, validate.order, async (req, res) => {
     // Cleanup and notifications
     if (appliedCoupon) {
       await db.query('UPDATE coupons SET used_count = used_count + 1 WHERE id = $1', [appliedCoupon.id]);
+      await db.query('INSERT INTO coupon_uses (coupon_id, user_id) VALUES ($1, $2)', [appliedCoupon.id, req.user.id]);
     }
 
     if (idempotencyKey) await cacheResponse(idempotencyKey, responseData);

--- a/backend/tests/coupons.test.js
+++ b/backend/tests/coupons.test.js
@@ -348,3 +348,40 @@ describe('POST /api/coupons/validate', () => {
     expect(res.body.final_total).toBe(0); // capped at 0
   });
 });
+
+// ── Per-user coupon usage (max_uses_per_user) ─────────────────────────────────
+describe('resolveCoupon — per-user limit', () => {
+  const { resolveCoupon } = require('../src/routes/coupons');
+
+  const validCoupon = {
+    id: 10,
+    farmer_id: 1,
+    discount_type: 'percent',
+    discount_value: 10,
+    expires_at: null,
+    max_uses: null,
+    used_count: 0,
+    max_uses_per_user: 1,
+  };
+
+  it('first use succeeds when user has not used the coupon yet', () => {
+    mockDb.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(validCoupon) })   // coupon lookup
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ cnt: 0 }) });   // coupon_uses count = 0
+
+    const result = resolveCoupon('ONCE', 1, 2);
+    expect(result.coupon).toBeDefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  it('second use by same buyer returns coupon_already_used', () => {
+    mockDb.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(validCoupon) })   // coupon lookup
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ cnt: 1 }) });   // coupon_uses count = 1
+
+    const result = resolveCoupon('ONCE', 1, 2);
+    expect(result.error).toBe('Coupon already used');
+    expect(result.code).toBe('coupon_already_used');
+  });
+});
+


### PR DESCRIPTION
Closes #395

---

## Summary

Fixes the bug where a buyer could apply the same coupon to every order indefinitely.

## Changes

- **Migration 016**: adds `coupon_uses(coupon_id, user_id, used_at)` tracking table and `max_uses_per_user` column on `coupons`
- **`resolveCoupon()`**: accepts optional `userId`; when `max_uses_per_user` is set, queries `coupon_uses` and returns `409 coupon_already_used` if the limit is reached
- **Orders route**: passes `req.user.id` to `resolveCoupon` and inserts into `coupon_uses` on successful redemption (both SQLite/SEP-7 and PG paths)
- **Tests**: two unit tests — first use succeeds, second use by same buyer returns `coupon_already_used`
- **Fix**: removed pre-existing duplicate `const allowedOrigins` in `app.js`

## Testing

```
cd backend && npm test -- --testPathPatterns=coupons
```

New tests pass under `resolveCoupon — per-user limit`.