### PR TITLE
fix: apply router-level auth to all analytics routes

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -60,7 +60,6 @@ app.use(helmet({
 
 const corsOrigins = process.env.CORS_ORIGIN || process.env.FRONTEND_ORIGIN || 'http://localhost:3000';
 const allowedOrigins = corsOrigins.split(',').map((o) => o.trim());
-const allowedOrigins = corsOrigins.split(',').map(o => o.trim());
 
 app.use(
   cors({

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -3,8 +3,11 @@ const db = require('../db/schema');
 const auth = require('../middleware/auth');
 const { err } = require('../middleware/error');
 
+// All analytics routes require authentication
+router.use(auth);
+
 // GET /api/analytics/farmer
-router.get('/farmer', auth, async (req, res) => {
+router.get('/farmer', async (req, res) => {
   if (req.user.role !== 'farmer') return err(res, 403, 'Farmers only', 'forbidden');
   const farmerId = req.user.id;
 
@@ -45,7 +48,7 @@ router.get('/farmer', auth, async (req, res) => {
 });
 
 // GET /api/analytics/farmer/waitlist — waitlist analytics per product (farmer only)
-router.get('/farmer/waitlist', auth, async (req, res) => {
+router.get('/farmer/waitlist', async (req, res) => {
   if (req.user.role !== 'farmer') return err(res, 403, 'Farmers only', 'forbidden');
   const farmerId = req.user.id;
 
@@ -117,7 +120,7 @@ router.get('/farmer/waitlist', auth, async (req, res) => {
 });
 
 // GET /api/analytics/farmer/forecast
-router.get('/farmer/forecast', auth, async (req, res) => {
+router.get('/farmer/forecast', async (req, res) => {
   if (req.user.role !== 'farmer') return err(res, 403, 'Farmers only', 'forbidden');
 
   const farmerId = req.user.id;
@@ -200,7 +203,7 @@ router.get('/farmer/forecast', auth, async (req, res) => {
 });
 
 // GET /api/analytics/farmer/demand-heatmap - Geographic demand heatmap
-router.get('/farmer/demand-heatmap', auth, async (req, res) => {
+router.get('/farmer/demand-heatmap', async (req, res) => {
   if (req.user.role !== 'farmer') return err(res, 403, 'Farmers only', 'forbidden');
 
   const farmerId = req.user.id;

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const jwt = require('jsonwebtoken');
+const { request, app, mockDb } = require('./setup');
+
+const SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
+const buyerToken = jwt.sign({ id: 2, role: 'buyer' }, SECRET);
+
+const FARMER_ROUTES = [
+  '/api/analytics/farmer',
+  '/api/analytics/farmer/waitlist',
+  '/api/analytics/farmer/forecast',
+  '/api/analytics/farmer/demand-heatmap',
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.query.mockResolvedValue({ rows: [], rowCount: 0 });
+  // auth middleware calls db.query to check active status
+  mockDb.query.mockResolvedValue({ rows: [{ active: 1 }], rowCount: 1 });
+});
+
+describe('Analytics routes — authentication', () => {
+  it.each(FARMER_ROUTES)('GET %s returns 401 without a token', async (route) => {
+    const res = await request(app).get(route);
+    expect(res.status).toBe(401);
+  });
+
+  it.each(FARMER_ROUTES)('GET %s returns 403 for buyers', async (route) => {
+    const res = await request(app).get(route).set('Authorization', `Bearer ${buyerToken}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/tests/jest.setup.js
+++ b/backend/tests/jest.setup.js
@@ -76,6 +76,7 @@ jest.mock('../src/routes', () => {
   const express = require('express');
   const router = express.Router();
   router.use('/api/auth', require('../src/routes/auth'));
+  router.use('/api/analytics', require('../src/routes/analytics'));
   return router;
 });
 


### PR DESCRIPTION
Closes #396

---

## Summary

All analytics endpoints were protected individually but not at the router level, leaving a gap if new routes were added without auth.

## Changes

- **`analytics.js`**: replaced per-route `auth` with `router.use(auth)` at the top
- **`analytics.test.js`** (new): 8 integration tests — unauthenticated → 401, buyer → 403 for all 4 routes
- **`jest.setup.js`**: mount `/api/analytics` in the test routes mock
- **`app.js`**: fix pre-existing duplicate `const allowedOrigins`

## Testing

```
cd backend && npm test -- --testPathPatterns=analytics
```
8/8 pass.