### PR TITLE
feat: integrate farm location map into ProductDetail and add related …

### DIFF
--- a/frontend/src/components/MapView.jsx
+++ b/frontend/src/components/MapView.jsx
@@ -37,9 +37,12 @@ function groupByFarmer(products) {
   return Array.from(map.values());
 }
 
-export default function MapView({ products, onBuy }) {
+export default function MapView({ products = [], lat, lng, farmerName, onBuy }) {
   const navigate = useNavigate();
-  const groups = groupByFarmer(products);
+  const hasSingleLocation = lat != null && lng != null;
+  const groups = hasSingleLocation
+    ? [{ lat, lng, farmerName, products: [] }]
+    : groupByFarmer(products);
 
   if (groups.length === 0) {
     return (
@@ -51,7 +54,6 @@ export default function MapView({ products, onBuy }) {
     );
   }
 
-  // Center map on average of all markers
   const avgLat = groups.reduce((s, g) => s + g.lat, 0) / groups.length;
   const avgLng = groups.reduce((s, g) => s + g.lng, 0) / groups.length;
 
@@ -69,15 +71,22 @@ export default function MapView({ products, onBuy }) {
         <Marker key={i} position={[group.lat, group.lng]}>
           <Popup>
             <div style={s.popup}>
-              {group.products.map(p => (
-                <div key={p.id} style={{ marginBottom: group.products.length > 1 ? 12 : 0, paddingBottom: group.products.length > 1 ? 12 : 0, borderBottom: group.products.length > 1 ? '1px solid #eee' : 'none' }}>
-                  <div style={s.name}>{p.name}</div>
-                  <div style={s.price}>{p.price} XLM / {p.unit}</div>
-                  <div style={s.farmer}>🌾 {p.farmer_name}</div>
-                  {p.farmer_farm_address && <div style={s.address}>📍 {p.farmer_farm_address}</div>}
-                  <button style={s.btn} onClick={() => navigate(`/products/${p.id}`)}>View &amp; Buy</button>
+              {group.products && group.products.length > 0 ? (
+                group.products.map(p => (
+                  <div key={p.id} style={{ marginBottom: group.products.length > 1 ? 12 : 0, paddingBottom: group.products.length > 1 ? 12 : 0, borderBottom: group.products.length > 1 ? '1px solid #eee' : 'none' }}>
+                    <div style={s.name}>{p.name}</div>
+                    <div style={s.price}>{p.price} XLM / {p.unit}</div>
+                    <div style={s.farmer}>🌾 {p.farmer_name}</div>
+                    {p.farmer_farm_address && <div style={s.address}>📍 {p.farmer_farm_address}</div>}
+                    <button style={s.btn} onClick={() => navigate(`/products/${p.id}`)}>View &amp; Buy</button>
+                  </div>
+                ))
+              ) : (
+                <div>
+                  <div style={s.name}>{group.farmerName || 'Farm location'}</div>
+                  <div style={s.farmer}>🌾 {group.farmerName || 'Farmer'}</div>
                 </div>
-              ))}
+              )}
             </div>
           </Popup>
         </Marker>

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -11,6 +11,7 @@ import Spinner from '../components/Spinner';
 import FlashSaleCountdown from '../components/FlashSaleCountdown';
 import ShareButtons from '../components/ShareButtons';
 import PriceHistoryChart from '../components/PriceHistoryChart';
+import MapView from '../components/MapView';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import QRCode from 'qrcode.react';
@@ -572,6 +573,17 @@ export default function ProductDetail() {
         <div style={s.desc}>
           {product.description || "Fresh from the farm."}
         </div>
+
+        {product.farm_lat != null && product.farm_lng != null ? (
+          <div style={{ marginBottom: 20 }}>
+            <div style={{ fontSize: 16, fontWeight: 700, color: '#2d6a4f', marginBottom: 12 }}>Farm Location</div>
+            <MapView lat={product.farm_lat} lng={product.farm_lng} farmerName={product.farmer_name} />
+          </div>
+        ) : (
+          <div style={{ marginBottom: 20, padding: '16px', borderRadius: 10, background: '#f8fdf9', color: '#555' }}>
+            Location not provided
+          </div>
+        )}
 
         <ShareButtons
           title={shareTitle}

--- a/frontend/src/test/ProductDetailLocation.test.jsx
+++ b/frontend/src/test/ProductDetailLocation.test.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+import ProductDetail from '../pages/ProductDetail';
+
+if (typeof globalThis.EventSource === 'undefined') {
+  globalThis.EventSource = class {
+    constructor() {
+      this.onmessage = null;
+    }
+    close() {}
+  };
+}
+
+vi.mock('../api/client', () => ({
+  api: {
+    getProduct: vi.fn(),
+    getProductReviews: vi.fn().mockResolvedValue({ data: [] }),
+    getProductShareMeta: vi.fn().mockResolvedValue({ data: null }),
+    getProductImages: vi.fn().mockResolvedValue({ data: [] }),
+    getProductTiers: vi.fn().mockResolvedValue({ data: [] }),
+    getPriceHistory: vi.fn().mockResolvedValue({ data: [] }),
+    getCalendar: vi.fn().mockResolvedValue({ data: [] }),
+    getAddresses: vi.fn().mockResolvedValue({ data: [] }),
+    getMyAlert: vi.fn().mockResolvedValue({ subscribed: false }),
+    getOrders: vi.fn().mockResolvedValue({ data: [] }),
+    getWalletAssets: vi.fn().mockResolvedValue({ data: [] }),
+    getFeePreview: vi.fn().mockResolvedValue(null),
+    getXlmRate: vi.fn().mockResolvedValue({ usd: () => '' }),
+    trackShareEvent: vi.fn(),
+  },
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 1, role: 'buyer', username: 'testuser' } }),
+}));
+
+vi.mock('../context/FavoritesContext', () => ({
+  useFavorites: () => ({ isFavorited: () => false, toggleFavorite: vi.fn() }),
+}));
+
+vi.mock('../components/StarRating', () => ({ default: () => null }));
+vi.mock('../components/Spinner', () => ({ default: () => <div data-testid="spinner">Loading...</div> }));
+vi.mock('../components/FlashSaleCountdown', () => ({ default: () => null }));
+vi.mock('../components/ShareButtons', () => ({ default: () => null }));
+vi.mock('../components/PriceHistoryChart', () => ({ default: () => null }));
+vi.mock('qrcode.react', () => ({ QRCode: () => null, default: () => null }));
+vi.mock('../components/MapView', () => ({
+  default: ({ lat, lng, farmerName }) => (
+    <div data-testid="map-view" data-lat={lat} data-lng={lng} data-farmer-name={farmerName}>
+      {lat != null && lng != null ? 'Map' : 'No map'}
+    </div>
+  ),
+}));
+
+import { api } from '../api/client';
+
+function renderProductDetail(id = '1') {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={[`/product/${id}`]}>
+        <Routes>
+          <Route path="/product/:id" element={<ProductDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+describe('ProductDetail – farm location map', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getProductReviews.mockResolvedValue({ data: [] });
+    api.getProductShareMeta.mockResolvedValue({ data: null });
+    api.getProductImages.mockResolvedValue({ data: [] });
+    api.getProductTiers.mockResolvedValue({ data: [] });
+    api.getPriceHistory.mockResolvedValue({ data: [] });
+    api.getCalendar.mockResolvedValue({ data: [] });
+    api.getAddresses.mockResolvedValue({ data: [] });
+    api.getMyAlert.mockResolvedValue({ subscribed: false });
+    api.getOrders.mockResolvedValue({ data: [] });
+    api.getWalletAssets.mockResolvedValue({ data: [] });
+    api.getFeePreview.mockResolvedValue(null);
+    api.getXlmRate.mockResolvedValue({ usd: () => '' });
+  });
+
+  it('renders the map when farm coordinates are provided', async () => {
+    api.getProduct.mockResolvedValue({
+      id: 1,
+      name: 'Herbs',
+      price: 3,
+      unit: 'bundle',
+      quantity: 8,
+      farmer_name: 'Farmer Maria',
+      description: 'Aromatic herbs',
+      farm_lat: 34.123,
+      farm_lng: -118.456,
+    });
+
+    renderProductDetail();
+
+    await waitFor(() => expect(screen.getByText('Herbs')).toBeInTheDocument());
+    const mapView = screen.getByTestId('map-view');
+
+    expect(mapView).toBeInTheDocument();
+    expect(mapView).toHaveAttribute('data-lat', '34.123');
+    expect(mapView).toHaveAttribute('data-lng', '-118.456');
+    expect(mapView).toHaveAttribute('data-farmer-name', 'Farmer Maria');
+  });
+
+  it('shows fallback text when farm coordinates are missing', async () => {
+    api.getProduct.mockResolvedValue({
+      id: 1,
+      name: 'Herbs',
+      price: 3,
+      unit: 'bundle',
+      quantity: 8,
+      farmer_name: 'Farmer Maria',
+      description: 'Aromatic herbs',
+      farm_lat: null,
+      farm_lng: null,
+    });
+
+    renderProductDetail();
+
+    await waitFor(() => expect(screen.getByText('Herbs')).toBeInTheDocument());
+    expect(screen.queryByTestId('map-view')).not.toBeInTheDocument();
+    expect(screen.getByText('Location not provided')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,3 +1,14 @@
 import '@testing-library/jest-dom';
 import i18n from '../i18n/index.js';
 import '../i18n/index.js'; // ensure i18n is initialized
+
+if (typeof globalThis.EventSource === 'undefined') {
+  globalThis.EventSource = class {
+    constructor() {
+      this.onmessage = null;
+      this.onopen = null;
+      this.onerror = null;
+    }
+    close() {}
+  };
+}

--- a/frontend/src/test/stellarErrors.test.jsx
+++ b/frontend/src/test/stellarErrors.test.jsx
@@ -87,6 +87,9 @@ vi.mock('../api/client', () => ({
     getWalletAssets: vi.fn().mockResolvedValue({ data: [] }),
     getFeePreview: vi.fn().mockResolvedValue(null),
     getXlmRate: vi.fn().mockResolvedValue({ usd: 0.1 }),
+    getNetwork: vi.fn().mockResolvedValue({ network: 'Test SDF Network ; September 2015' }),
+    getBudget: vi.fn().mockResolvedValue({ balance: 0 }),
+    getAlerts: vi.fn().mockResolvedValue({ data: [], unreadCount: 0 }),
   },
 }));
 


### PR DESCRIPTION
close #452 

### Description
- Passes `product.farm_lat` and `product.farm_lng` from ProductDetail.jsx into `MapView`
- Shows a fallback panel with `Location not provided` when farm coordinates are missing
- Displays a single farm marker popup with the farmer name on the detail map
- Added focused unit tests in ProductDetailLocation.test.jsx
- Added shared `EventSource` stub in setup.js for stable DOM test execution
- Extended stellarErrors.test.jsx mocks with `getNetwork`, `getBudget`, and `getAlerts` so the broader frontend suite runs cleanly

### Files changed
- MapView.jsx
- ProductDetail.jsx
- ProductDetailLocation.test.jsx
- setup.js
- stellarErrors.test.jsx

### Testing
- Full frontend Vitest suite passed:
  - `6 passed`
  - `31 passed`

### Notes
- Existing Vite warnings in Wallet.jsx are unrelated duplicate object key warnings and did not block the test run.