### PR TITLE
fix: theme persistence and out-of-stock badge (#450, #451)

### DIFF
--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -3,7 +3,11 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 const ThemeContext = createContext();
 
 export function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
+  const [theme, setTheme] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);

--- a/frontend/src/pages/Marketplace.jsx
+++ b/frontend/src/pages/Marketplace.jsx
@@ -249,6 +249,38 @@ const s = {
     fontWeight: 600,
     fontSize: 14,
   },
+  outOfStockBadge: {
+    display: "inline-block",
+    fontSize: 11,
+    background: "#fee2e2",
+    color: "#b42318",
+    borderRadius: 4,
+    padding: "2px 7px",
+    marginBottom: 8,
+    fontWeight: 700,
+  },
+  viewBtn: {
+    marginTop: 10,
+    padding: "9px 18px",
+    borderRadius: 8,
+    border: "1px solid #2d6a4f",
+    background: "#fff",
+    color: "#2d6a4f",
+    fontWeight: 600,
+    fontSize: 14,
+    cursor: "pointer",
+  },
+  viewBtnDisabled: {
+    marginTop: 10,
+    padding: "9px 18px",
+    borderRadius: 8,
+    border: "1px solid #ccc",
+    background: "#f5f5f5",
+    color: "#aaa",
+    fontWeight: 600,
+    fontSize: 14,
+    cursor: "not-allowed",
+  },
 };
 
 const SORT_OPTIONS = [
@@ -601,6 +633,7 @@ export default function Marketplace() {
       )}
 
       <RecentlyCompared />
+      <div style={s.filters}>
         <input
           style={s.input}
           placeholder={t("marketplace.searchPlaceholder")}
@@ -923,6 +956,23 @@ export default function Marketplace() {
                 aria-pressed={isCompared(p.id)}
               >
                 {isCompared(p.id) ? "Selected for compare" : "Compare"}
+              </button>
+
+              {p.quantity === 0 && (
+                <div style={s.outOfStockBadge} aria-label="Out of stock">
+                  Out of Stock
+                </div>
+              )}
+              <button
+                style={p.quantity === 0 ? s.viewBtnDisabled : s.viewBtn}
+                disabled={p.quantity === 0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (p.quantity > 0) navigate(`/product/${p.id}`);
+                }}
+                aria-disabled={p.quantity === 0}
+              >
+                {p.quantity === 0 ? "Out of Stock" : "View"}
               </button>
 
               {/* Seller Information Section */}

--- a/frontend/src/test/Marketplace.test.jsx
+++ b/frontend/src/test/Marketplace.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+
+vi.mock('../api/client', () => ({
+  api: {
+    getProducts: vi.fn().mockResolvedValue({
+      data: [
+        { id: 1, name: 'Tomatoes', quantity: 0, price: '5', unit: 'kg', category: 'vegetables', description: 'Fresh tomatoes', farmer_name: 'Bob', farmer_id: 10, image_url: null, review_count: 0 },
+        { id: 2, name: 'Carrots', quantity: 10, price: '3', unit: 'kg', category: 'vegetables', description: 'Fresh carrots', farmer_name: 'Alice', farmer_id: 11, image_url: null, review_count: 0 },
+      ],
+      total: 2,
+      totalPages: 1,
+    }),
+    searchProducts: vi.fn(),
+    getAuctions: vi.fn().mockResolvedValue({ data: [] }),
+    getBundles: vi.fn().mockResolvedValue({ data: [] }),
+    getRecommendations: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock('../context/AuthContext', () => ({ useAuth: () => ({ user: null }) }));
+vi.mock('../context/FavoritesContext', () => ({ useFavorites: () => ({ isFavorited: () => false, toggleFavorite: vi.fn() }) }));
+vi.mock('../context/CompareContext', () => ({ useCompare: () => ({ products: [], toggleProduct: vi.fn(), isCompared: () => false }) }));
+vi.mock('../utils/useXlmRate', () => ({ useXlmRate: () => ({ usd: () => null }) }));
+vi.mock('../components/RecentlyCompared', () => ({ default: () => null }));
+
+import Marketplace from '../pages/Marketplace';
+
+describe('Marketplace out-of-stock badge (#451)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('shows Out of Stock badge for product with quantity 0', async () => {
+    render(<HelmetProvider><MemoryRouter><Marketplace /></MemoryRouter></HelmetProvider>);
+    await waitFor(() => expect(screen.getByText('Tomatoes')).toBeInTheDocument());
+    expect(screen.getAllByLabelText('Out of stock')).toHaveLength(1);
+  });
+
+  it('disables the View button for out-of-stock product', async () => {
+    render(<HelmetProvider><MemoryRouter><Marketplace /></MemoryRouter></HelmetProvider>);
+    await waitFor(() => expect(screen.getByText('Tomatoes')).toBeInTheDocument());
+    const buttons = screen.getAllByRole('button', { name: /out of stock/i });
+    expect(buttons[0]).toBeDisabled();
+  });
+
+  it('does not show Out of Stock badge for in-stock product', async () => {
+    render(<HelmetProvider><MemoryRouter><Marketplace /></MemoryRouter></HelmetProvider>);
+    await waitFor(() => expect(screen.getByText('Carrots')).toBeInTheDocument());
+    expect(screen.getAllByLabelText('Out of stock')).toHaveLength(1);
+  });
+
+  it('shows enabled View button for in-stock product', async () => {
+    render(<HelmetProvider><MemoryRouter><Marketplace /></MemoryRouter></HelmetProvider>);
+    await waitFor(() => expect(screen.getByText('Carrots')).toBeInTheDocument());
+    const viewButtons = screen.getAllByRole('button', { name: 'View' });
+    expect(viewButtons[0]).not.toBeDisabled();
+  });
+});

--- a/frontend/src/test/ThemeContext.test.jsx
+++ b/frontend/src/test/ThemeContext.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider, useTheme } from '../context/ThemeContext';
+
+function Consumer() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={toggleTheme}>toggle</button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <ThemeProvider>
+      <Consumer />
+    </ThemeProvider>
+  );
+}
+
+describe('ThemeContext (#450)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Default: no OS preference
+    vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: false });
+  });
+
+  it('defaults to light when no localStorage and no OS preference', () => {
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+  });
+
+  it('defaults to dark when OS prefers dark and no localStorage', () => {
+    window.matchMedia.mockReturnValue({ matches: true });
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+
+  it('persists theme to localStorage on toggle', async () => {
+    renderWithProvider();
+    await act(async () => { screen.getByText('toggle').click(); });
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('restores theme from localStorage on mount (simulates reload)', () => {
+    localStorage.setItem('theme', 'dark');
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+
+  it('localStorage value takes precedence over OS preference', () => {
+    localStorage.setItem('theme', 'light');
+    window.matchMedia.mockReturnValue({ matches: true }); // OS says dark
+    renderWithProvider();
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two frontend issues in a single PR.

---

### Fix #450 — ThemeContext does not persist theme across sessions

**Problem:** `ThemeContext.jsx` always defaulted to `'light'` on page load, ignoring any previously saved preference and the OS-level `prefers-color-scheme` setting.

**Changes:**
- `frontend/src/context/ThemeContext.jsx`: Updated the `useState` initializer to first read from `localStorage.getItem('theme')`, then fall back to `window.matchMedia('(prefers-color-scheme: dark)').matches`. The existing `useEffect` already writes to `localStorage` on every change — no modification needed there.
- `frontend/src/test/ThemeContext.test.jsx`: 5 unit tests covering default-light, OS-dark preference, localStorage persistence on toggle, reload restoration, and localStorage taking precedence over OS preference.

---

### Fix #451 — Marketplace product cards do not show an Out of Stock badge

**Problem:** Products with `quantity === 0` were displayed without any visual indicator, causing buyers to attempt purchases and receive confusing errors.

**Changes:**
- `frontend/src/pages/Marketplace.jsx`:
  - Added `outOfStockBadge`, `viewBtn`, and `viewBtnDisabled` styles.
  - Added an **Out of Stock** badge (`aria-label="Out of stock"`) rendered when `p.quantity === 0`.
  - Added a **View** button that is `disabled` and styled as inactive when `p.quantity === 0`.
  - Also fixed a pre-existing syntax error: missing `<div style={s.filters}>` wrapper around the filter inputs section.
- `frontend/src/test/Marketplace.test.jsx`: 4 unit tests covering badge shown for qty=0, View button disabled for qty=0, no badge for in-stock, View button enabled for in-stock.

---

### Tests

All 9 new tests pass:
```
✓ ThemeContext (#450) > defaults to light when no localStorage and no OS preference
✓ ThemeContext (#450) > defaults to dark when OS prefers dark and no localStorage
✓ ThemeContext (#450) > persists theme to localStorage on toggle
✓ ThemeContext (#450) > restores theme from localStorage on mount (simulates reload)
✓ ThemeContext (#450) > localStorage value takes precedence over OS preference
✓ Marketplace out-of-stock badge (#451) > shows Out of Stock badge for product with quantity 0
✓ Marketplace out-of-stock badge (#451) > disables the View button for out-of-stock product
✓ Marketplace out-of-stock badge (#451) > does not show Out of Stock badge for in-stock product
✓ Marketplace out-of-stock badge (#451) > shows enabled View button for in-stock product
```

Closes #450
Closes #451