### PR TITLE
fix(#424): highlight active route in Navbar using NavLink

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { NavLink, Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 import { useTranslation } from 'react-i18next';
@@ -9,10 +9,15 @@ const s = {
   nav: { background: '#2d6a4f', padding: '12px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 },
   brand: { color: '#fff', fontWeight: 700, fontSize: 20, textDecoration: 'none' },
   link: { color: '#d8f3dc', textDecoration: 'none', fontSize: 14, minHeight: 44, display: 'flex', alignItems: 'center' },
+  activeLink: { color: '#fff', textDecoration: 'underline', fontWeight: 700, fontSize: 14, minHeight: 44, display: 'flex', alignItems: 'center' },
   btn: { background: '#95d5b2', border: 'none', borderRadius: 6, padding: '10px 14px', cursor: 'pointer', fontSize: 14, fontWeight: 600, minHeight: 44 },
   toggleBtn: { background: 'none', border: '1px solid #95d5b2', borderRadius: 6, padding: '10px', cursor: 'pointer', fontSize: 16, color: '#d8f3dc', minHeight: 44, minWidth: 44 },
   langSelect: { background: 'none', border: '1px solid #95d5b2', borderRadius: 6, padding: '6px 10px', color: '#d8f3dc', fontSize: 13, cursor: 'pointer', minHeight: 44 },
 };
+
+function navLinkStyle({ isActive }) {
+  return isActive ? s.activeLink : s.link;
+}
 
 export default function Navbar() {
   const { user, logout } = useAuth();
@@ -55,28 +60,24 @@ export default function Navbar() {
       <div className={`nav-links${open ? ' open' : ''}`}>
         {user ? (
           <>
-            <Link to="/marketplace" style={s.link}>Browse</Link>
-            {user.role === 'farmer' && <Link to="/dashboard" style={s.link}>Dashboard</Link>}
-            {user.role === 'buyer' && <Link to="/orders" style={s.link}>Orders</Link>}
-            {user.role === 'buyer' && <Link to="/subscriptions" style={s.link}>Subscriptions</Link>}
-            {user.role === 'buyer' && <Link to="/addresses" style={s.link}>Addresses</Link>}
-            {user.role === 'admin' && <Link to="/admin" style={{ ...s.link, color: '#ffeaa7' }}>Admin</Link>}
-            {user.role !== 'admin' && <Link to="/wallet" style={s.link}>Wallet</Link>}
-            <Link to="/settings" style={s.link}>Settings</Link>
-            <Link to="/marketplace" style={s.link} onClick={() => setOpen(false)}>Browse</Link>
-            {user.role === 'farmer' && <Link to="/dashboard" style={s.link} onClick={() => setOpen(false)}>Dashboard</Link>}
-            {user.role === 'buyer' && <Link to="/orders" style={s.link} onClick={() => setOpen(false)}>Orders</Link>}
-            {user.role === 'buyer' && <Link to="/addresses" style={s.link} onClick={() => setOpen(false)}>Addresses</Link>}
-            {user.role === 'admin' && <Link to="/admin" style={{ ...s.link, color: '#ffeaa7' }} onClick={() => setOpen(false)}>Admin</Link>}
-            {user.role !== 'admin' && <Link to="/wallet" style={s.link} onClick={() => setOpen(false)}>Wallet</Link>}
+            <NavLink to="/marketplace" style={navLinkStyle} onClick={() => setOpen(false)}>Browse</NavLink>
+            {user.role === 'farmer' && <NavLink to="/dashboard" style={navLinkStyle} onClick={() => setOpen(false)}>Dashboard</NavLink>}
+            {user.role === 'buyer' && <NavLink to="/orders" style={navLinkStyle} onClick={() => setOpen(false)}>Orders</NavLink>}
+            {user.role === 'buyer' && <NavLink to="/subscriptions" style={navLinkStyle} onClick={() => setOpen(false)}>Subscriptions</NavLink>}
+            {user.role === 'buyer' && <NavLink to="/addresses" style={navLinkStyle} onClick={() => setOpen(false)}>Addresses</NavLink>}
+            {user.role === 'admin' && (
+              <NavLink to="/admin" style={({ isActive }) => ({ ...(isActive ? s.activeLink : s.link), color: isActive ? '#fff' : '#ffeaa7' })} onClick={() => setOpen(false)}>Admin</NavLink>
+            )}
+            {user.role !== 'admin' && <NavLink to="/wallet" style={navLinkStyle} onClick={() => setOpen(false)}>Wallet</NavLink>}
+            <NavLink to="/settings" style={navLinkStyle} onClick={() => setOpen(false)}>Settings</NavLink>
             <span style={{ color: '#d8f3dc', fontSize: 13 }}>{user.name} ({user.role})</span>
             <button style={s.toggleBtn} onClick={toggleTheme} aria-label="Toggle dark mode">{theme === 'light' ? '🌙' : '☀️'}</button>
             <button style={s.btn} onClick={handleLogout}>Logout</button>
           </>
         ) : (
           <>
-            <Link to="/login" style={s.link} onClick={() => setOpen(false)}>Login</Link>
-            <Link to="/register" style={s.link} onClick={() => setOpen(false)}>Register</Link>
+            <NavLink to="/login" style={navLinkStyle} onClick={() => setOpen(false)}>Login</NavLink>
+            <NavLink to="/register" style={navLinkStyle} onClick={() => setOpen(false)}>Register</NavLink>
           </>
         )}
         <select

--- a/frontend/src/test/NavbarActiveRoute.test.jsx
+++ b/frontend/src/test/NavbarActiveRoute.test.jsx
@@ -1,0 +1,31 @@
+// #424 – Navbar applies active style to the current route link
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import { vi } from 'vitest';
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { name: 'Alice', role: 'buyer' }, logout: vi.fn() }),
+}));
+vi.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light', toggleTheme: vi.fn() }),
+}));
+vi.mock('../api/client', () => ({
+  api: { getNetwork: () => Promise.resolve({ network: 'testnet' }) },
+}));
+
+test('Marketplace link has active (bold/underline) style when on /marketplace', () => {
+  render(
+    <MemoryRouter initialEntries={['/marketplace']}>
+      <Navbar />
+    </MemoryRouter>
+  );
+
+  const links = screen.getAllByRole('link', { name: /browse/i });
+  const activeLink = links.find(l => l.getAttribute('href') === '/marketplace');
+  expect(activeLink).toBeTruthy();
+
+  const style = activeLink.style;
+  // Active style sets fontWeight 700 and textDecoration underline
+  expect(style.fontWeight === '700' || style.textDecoration === 'underline').toBe(true);
+});


### PR DESCRIPTION
## Summary

Fixes #424

The Navbar used plain `Link` components with no active-state awareness, so users had no visual indication of which page they were on.

## Changes

- Replaced all `Link` imports with `NavLink` from react-router-dom
- Added `navLinkStyle({ isActive })` helper: active links get `fontWeight: 700`, `textDecoration: underline`, and `color: #fff` (white on the green navbar — passes WCAG AA contrast)
- Admin link preserves its `#ffeaa7` inactive colour while still going bold/white when active
- Removed the duplicate link blocks (links were rendered twice: once without `onClick` and once with `onClick={() => setOpen(false)}`)

## Tests

- Added `NavbarActiveRoute.test.jsx`: renders Navbar at `/marketplace` and asserts the Browse link has the active style applied