### PR TITLE
fix(#425): report errors via VITE_ERROR_REPORTING_URL env var

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -37,8 +37,10 @@ class ErrorBoundary extends React.Component {
   }
 
   logErrorToBackend = (error, errorInfo) => {
+    const url = import.meta.env.VITE_ERROR_REPORTING_URL;
+    if (!url) return;
     try {
-      fetch('/api/errors', {
+      fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/src/test/ErrorBoundaryReporting.test.jsx
+++ b/frontend/src/test/ErrorBoundaryReporting.test.jsx
@@ -1,0 +1,47 @@
+// #425 – ErrorBoundary reports errors to VITE_ERROR_REPORTING_URL when set
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import ErrorBoundary from '../components/ErrorBoundary';
+
+function Bomb() {
+  throw new Error('test explosion');
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_ERROR_REPORTING_URL', 'https://errors.example.com/report');
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+  // Suppress React's console.error for expected boundary errors
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+test('calls fetch with error details when VITE_ERROR_REPORTING_URL is set', () => {
+  render(
+    <ErrorBoundary>
+      <Bomb />
+    </ErrorBoundary>
+  );
+
+  expect(screen.getByText(/something went wrong/i)).toBeTruthy();
+  expect(global.fetch).toHaveBeenCalledWith(
+    'https://errors.example.com/report',
+    expect.objectContaining({ method: 'POST' })
+  );
+});
+
+test('does not call fetch when VITE_ERROR_REPORTING_URL is not set', () => {
+  vi.stubEnv('VITE_ERROR_REPORTING_URL', '');
+  global.fetch = vi.fn();
+
+  render(
+    <ErrorBoundary>
+      <Bomb />
+    </ErrorBoundary>
+  );
+
+  expect(global.fetch).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

Fixes #425

`ErrorBoundary.jsx` was hardcoded to POST to `/api/errors`, making it impossible to route errors to an external monitoring service without a code change.

## Changes

- `logErrorToBackend` now reads `import.meta.env.VITE_ERROR_REPORTING_URL`
- If the variable is not set (or empty), reporting is skipped silently — no network call, no console noise
- If set, POSTs `{ message, stack, componentStack, url, userAgent, timestamp }` to that URL
- The fallback UI is always rendered regardless of whether reporting succeeds or fails

## Configuration

Add to your `.env` (or CI secrets):
```
VITE_ERROR_REPORTING_URL=https://your-monitoring-service.example.com/errors
```

## Tests

- Added `ErrorBoundaryReporting.test.jsx`:
  - Asserts `fetch` is called with the configured URL when the env var is set
  - Asserts `fetch` is NOT called when the env var is absent