### PR TITLE
fix(#427): show loading skeleton in FarmerProfile while fetching

### DIFF
--- a/frontend/src/pages/FarmerProfile.jsx
+++ b/frontend/src/pages/FarmerProfile.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
-import Spinner from '../components/Spinner';
 
 const s = {
   page:       { maxWidth: 900, margin: '0 auto', padding: 24 },
@@ -23,17 +22,70 @@ const s = {
   back:       { fontSize: 13, color: '#2d6a4f', cursor: 'pointer', marginBottom: 16, display: 'inline-block' },
 };
 
+const shimmer = `
+  @keyframes shimmer {
+    0%   { background-position: -600px 0; }
+    100% { background-position: 600px 0; }
+  }
+`;
+
+const skeletonBase = {
+  background: 'linear-gradient(90deg, #e8e8e8 25%, #f5f5f5 50%, #e8e8e8 75%)',
+  backgroundSize: '600px 100%',
+  animation: 'shimmer 1.4s infinite linear',
+  borderRadius: 6,
+};
+
+function SkeletonBlock({ width = '100%', height = 16, style = {} }) {
+  return <div style={{ ...skeletonBase, width, height, ...style }} />;
+}
+
+function ProfileSkeleton() {
+  return (
+    <div style={s.page} aria-busy="true" aria-label="Loading farmer profile">
+      <style>{shimmer}</style>
+      <SkeletonBlock width={60} height={13} style={{ marginBottom: 16 }} />
+      <div style={s.header}>
+        <SkeletonBlock width={96} height={96} style={{ borderRadius: '50%', flexShrink: 0 }} />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <SkeletonBlock width={200} height={24} />
+          <SkeletonBlock width={120} height={14} />
+          <SkeletonBlock width="80%" height={14} />
+          <SkeletonBlock width="60%" height={14} />
+          <SkeletonBlock width={100} height={12} />
+        </div>
+      </div>
+      <SkeletonBlock width={180} height={20} style={{ marginBottom: 16 }} />
+      <div style={s.grid}>
+        {[1, 2, 3].map(i => (
+          <div key={i} style={{ ...s.card, cursor: 'default' }}>
+            <SkeletonBlock width="100%" height={120} style={{ borderRadius: 8, marginBottom: 10 }} />
+            <SkeletonBlock width="70%" height={15} style={{ marginBottom: 8 }} />
+            <SkeletonBlock width="90%" height={13} style={{ marginBottom: 10 }} />
+            <SkeletonBlock width={80} height={16} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function FarmerProfile() {
   const { id } = useParams();
   const navigate = useNavigate();
   const [farmer, setFarmer] = useState(null);
+  const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {
+    setLoading(true);
     api.getFarmer(id)
       .then(res => setFarmer(res.data))
-      .catch(() => setNotFound(true));
+      .catch(() => setNotFound(true))
+      .finally(() => setLoading(false));
   }, [id]);
+
+  if (loading) return <ProfileSkeleton />;
 
   if (notFound) {
     return (
@@ -46,8 +98,6 @@ export default function FarmerProfile() {
       </div>
     );
   }
-
-  if (!farmer) return <Spinner />;
 
   return (
     <div style={s.page}>

--- a/frontend/src/test/FarmerProfileSkeleton.test.jsx
+++ b/frontend/src/test/FarmerProfileSkeleton.test.jsx
@@ -1,0 +1,54 @@
+// #427 – FarmerProfile shows skeleton while loading, then renders data
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+
+const mockGetFarmer = vi.fn();
+
+vi.mock('../api/client', () => ({
+  api: { getFarmer: (...args) => mockGetFarmer(...args) },
+}));
+
+// Import after mock is set up
+const { default: FarmerProfile } = await import('../pages/FarmerProfile');
+
+const mockFarmer = {
+  id: 1,
+  name: 'Jane Farm',
+  location: 'Nairobi',
+  bio: 'Organic produce',
+  avatar_url: null,
+  created_at: '2023-01-01T00:00:00Z',
+  listings: [],
+};
+
+function renderProfile() {
+  return render(
+    <MemoryRouter initialEntries={['/farmer/1']}>
+      <Routes>
+        <Route path="/farmer/:id" element={<FarmerProfile />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => vi.clearAllMocks());
+
+test('renders skeleton (aria-busy) while loading', () => {
+  let resolve;
+  mockGetFarmer.mockReturnValue(new Promise(r => { resolve = r; }));
+
+  renderProfile();
+
+  expect(screen.getByLabelText(/loading farmer profile/i)).toBeTruthy();
+  resolve({ data: mockFarmer });
+});
+
+test('renders farmer name after fetch resolves', async () => {
+  mockGetFarmer.mockResolvedValue({ data: mockFarmer });
+
+  renderProfile();
+
+  await waitFor(() => screen.getByText('Jane Farm'));
+  expect(screen.getByText('Jane Farm')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary

Fixes #427

`FarmerProfile.jsx` rendered a generic `<Spinner>` (or nothing) while fetching farmer data, causing layout shift and a poor experience on slow connections.

## Changes

- Added explicit `loading` state (`useState(true)`) cleared in `.finally()`
- Replaced `<Spinner>` with a `ProfileSkeleton` component that mirrors the real layout:
  - Avatar circle placeholder
  - Name, location, bio, and member-since line placeholders
  - 3 product card placeholders (image, name, description, price)
- Skeleton uses a CSS shimmer animation (`@keyframes shimmer`) injected via a `<style>` tag
- Container has `aria-busy="true"` and `aria-label="Loading farmer profile"` for accessibility
- Removed unused `Spinner` import

## Tests

- Added `FarmerProfileSkeleton.test.jsx`:
  - Asserts skeleton (`aria-busy` container) is rendered while the fetch is pending
  - Asserts farmer name is rendered after the fetch resolves