### PR TITLE
fix(#432): show 'No price history available' for empty/null data

### DIFF
--- a/frontend/src/components/PriceHistoryChart.jsx
+++ b/frontend/src/components/PriceHistoryChart.jsx
@@ -4,7 +4,13 @@ import {
 } from 'recharts';
 
 export default function PriceHistoryChart({ data }) {
-  if (!data || data.length < 2) return null;
+  if (!data || data.length < 2) {
+    return (
+      <div style={{ marginBottom: 24, fontSize: 14, color: '#888' }}>
+        No price history available.
+      </div>
+    );
+  }
 
   const formatted = data.map((d) => ({
     date: new Date(d.recorded_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),

--- a/frontend/src/test/PriceHistoryChart.test.jsx
+++ b/frontend/src/test/PriceHistoryChart.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PriceHistoryChart from '../components/PriceHistoryChart';
+
+describe('PriceHistoryChart (#432)', () => {
+  it('shows "No price history available" for null data', () => {
+    render(<PriceHistoryChart data={null} />);
+    expect(screen.getByText('No price history available.')).toBeInTheDocument();
+  });
+
+  it('shows "No price history available" for empty array', () => {
+    render(<PriceHistoryChart data={[]} />);
+    expect(screen.getByText('No price history available.')).toBeInTheDocument();
+  });
+
+  it('shows "No price history available" for single data point', () => {
+    render(<PriceHistoryChart data={[{ recorded_at: '2024-01-01', price: '1.5' }]} />);
+    expect(screen.getByText('No price history available.')).toBeInTheDocument();
+  });
+
+  it('renders chart for multiple data points', () => {
+    const data = [
+      { recorded_at: '2024-01-01', price: '1.5' },
+      { recorded_at: '2024-01-02', price: '2.0' },
+    ];
+    render(<PriceHistoryChart data={data} />);
+    expect(screen.queryByText('No price history available.')).not.toBeInTheDocument();
+    // Chart title should be visible
+    expect(screen.getByText(/Price History/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #432

`PriceHistoryChart` was returning `null` when `data` was empty or had fewer than 2 points, which could cause the chart library to throw errors on newly listed products.

## Changes

- `PriceHistoryChart.jsx`: return a `'No price history available.'` message element instead of `null` when data is `null`, empty, or has only one point
- `PriceHistoryChart.test.jsx`: unit tests covering null, empty array, single data point, and multiple data points

## Tests

All 4 tests pass:
- ✅ null data → shows message
- ✅ empty array → shows message
- ✅ single data point → shows message
- ✅ multiple data points → renders chart (no message)