### PR TITLE
fix(#423): persist wallet disclaimer dismissal to localStorage

### DIFF
--- a/frontend/src/pages/Wallet.jsx
+++ b/frontend/src/pages/Wallet.jsx
@@ -168,7 +168,7 @@ function Toast({ toasts }) {
 export default function Wallet() {
   const { t } = useTranslation();
   const { user } = useAuth();
-  const [disclaimerVisible, setDisclaimerVisible] = useState(() => !sessionStorage.getItem(DISCLAIMER_KEY));
+  const [disclaimerVisible, setDisclaimerVisible] = useState(() => localStorage.getItem(DISCLAIMER_KEY) !== 'true');
   const [wallet, setWallet]       = useState(null);
   const [txs, setTxs]             = useState([]);
   const [loading, setLoading]     = useState(true);
@@ -201,7 +201,7 @@ export default function Wallet() {
   const unmounted = useRef(false);
 
   function dismissDisclaimer() {
-    sessionStorage.setItem(DISCLAIMER_KEY, '1');
+    localStorage.setItem(DISCLAIMER_KEY, 'true');
     setDisclaimerVisible(false);
   }
 

--- a/frontend/src/test/WalletDisclaimerPersistence.test.js
+++ b/frontend/src/test/WalletDisclaimerPersistence.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const DISCLAIMER_KEY = 'testnet_disclaimer_dismissed';
+
+function shouldShowDisclaimer() {
+  return localStorage.getItem(DISCLAIMER_KEY) !== 'true';
+}
+
+function dismissDisclaimer() {
+  localStorage.setItem(DISCLAIMER_KEY, 'true');
+}
+
+describe('Wallet disclaimer localStorage persistence (#423)', () => {
+  beforeEach(() => {
+    localStorage.removeItem(DISCLAIMER_KEY);
+  });
+
+  it('shows disclaimer when key is absent (fresh session)', () => {
+    expect(shouldShowDisclaimer()).toBe(true);
+  });
+
+  it('hides disclaimer after dismissal', () => {
+    dismissDisclaimer();
+    expect(shouldShowDisclaimer()).toBe(false);
+  });
+
+  it('persists dismissal across simulated page reload', () => {
+    dismissDisclaimer();
+    // Simulate reload: re-read from localStorage
+    expect(shouldShowDisclaimer()).toBe(false);
+  });
+
+  it('shows disclaimer again after key is cleared (incognito)', () => {
+    dismissDisclaimer();
+    localStorage.removeItem(DISCLAIMER_KEY);
+    expect(shouldShowDisclaimer()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #423

The testnet disclaimer was using `sessionStorage`, so it reappeared on every page reload.

## Changes

- **Wallet.jsx**: Changed `useState` initialiser and `dismissDisclaimer` to use `localStorage` instead of `sessionStorage`. Reads `localStorage.getItem(DISCLAIMER_KEY) !== 'true'` on mount; writes `localStorage.setItem(DISCLAIMER_KEY, 'true')` on dismiss.
- **WalletDisclaimerPersistence.test.js**: Unit tests covering fresh session shows disclaimer, dismiss hides it, persists across simulated reload, and reappears after key removal (incognito).

## Testing

```
cd frontend && node_modules/.bin/vitest run src/test/WalletDisclaimerPersistence.test.js
# 4 tests passed
```