### PR TITLE
fix(#429): add password strength indicator to Settings password change form

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../context/AuthContext';
+import { validatePassword } from '../utils/validation';
 
 const s = {
   page:    { maxWidth: 640, margin: '0 auto', padding: 24 },
@@ -43,6 +44,86 @@ const s = {
 };
 
 const CONFIRM_PHRASE = 'delete my account';
+
+function PasswordStrengthBar({ password }) {
+  if (!password) return null;
+  const issues = validatePassword(password);
+  const score = 4 - issues.length; // 0–4
+  const colors = ['#c0392b', '#e67e22', '#f1c40f', '#27ae60', '#2d6a4f'];
+  const labels = ['Weak', 'Weak', 'Fair', 'Good', 'Strong'];
+  return (
+    <div style={{ marginTop: 6 }}>
+      <div style={{ display: 'flex', gap: 3 }}>
+        {[0, 1, 2, 3].map(i => (
+          <div key={i} style={{ flex: 1, height: 4, borderRadius: 2, background: i < score ? colors[score] : '#e0e0e0' }} />
+        ))}
+      </div>
+      <div style={{ fontSize: 11, color: colors[score], marginTop: 3 }}>{labels[score]}</div>
+      {issues.length > 0 && (
+        <div style={{ fontSize: 11, color: '#888', marginTop: 2 }}>Needs: {issues.join(', ')}</div>
+      )}
+    </div>
+  );
+}
+
+function PasswordChangeForm() {
+  const [form, setForm] = useState({ current: '', newPw: '', confirm: '' });
+  const [msg, setMsg] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const newPwIssues = validatePassword(form.newPw);
+  const isStrong = form.newPw.length > 0 && newPwIssues.length === 0;
+  const canSubmit = isStrong && form.current.length > 0 && form.newPw === form.confirm;
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSaving(true);
+    setMsg(null);
+    try {
+      await api.changePassword({ current_password: form.current, new_password: form.newPw });
+      setMsg({ type: 'ok', text: 'Password updated successfully.' });
+      setForm({ current: '', newPw: '', confirm: '' });
+    } catch (err) {
+      setMsg({ type: 'err', text: err.message || 'Failed to update password.' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={s.card}>
+      <div style={s.section}>Change Password</div>
+      <div style={s.desc}>Update your account password. Must be at least 8 characters with 1 uppercase letter and 1 number.</div>
+      <form onSubmit={handleSubmit} noValidate>
+        <label style={s.label} htmlFor="cp-current">Current Password</label>
+        <input id="cp-current" style={s.input} type="password" value={form.current}
+          onChange={e => setForm(f => ({ ...f, current: e.target.value }))} autoComplete="current-password" />
+
+        <label style={{ ...s.label, marginTop: 12 }} htmlFor="cp-new">New Password</label>
+        <input id="cp-new" style={s.input} type="password" value={form.newPw}
+          onChange={e => setForm(f => ({ ...f, newPw: e.target.value }))} autoComplete="new-password" />
+        <PasswordStrengthBar password={form.newPw} />
+
+        <label style={{ ...s.label, marginTop: 12 }} htmlFor="cp-confirm">Confirm New Password</label>
+        <input id="cp-confirm" style={s.input} type="password" value={form.confirm}
+          onChange={e => setForm(f => ({ ...f, confirm: e.target.value }))} autoComplete="new-password" />
+        {form.confirm && form.newPw !== form.confirm && (
+          <div style={{ fontSize: 12, color: '#c0392b', marginTop: 3 }}>Passwords do not match</div>
+        )}
+
+        {msg && (
+          <div style={{ ...s.err, ...(msg.type === 'ok' ? { color: '#2d6a4f', background: '#d8f3dc' } : {}), marginTop: 10 }}>
+            {msg.text}
+          </div>
+        )}
+        <button style={{ ...s.btn, opacity: canSubmit ? 1 : 0.5 }} type="submit" disabled={!canSubmit || saving}>
+          {saving ? 'Saving…' : 'Save Password'}
+        </button>
+      </form>
+    </div>
+  );
+}
 
 function SettingsAccountBody() {
   const { user, logout } = useAuth();
@@ -497,6 +578,7 @@ export default function Settings() {
       {user ? (
         <>
           <SettingsAccountBody />
+          <PasswordChangeForm />
           <SeedPhraseBackup />
         </>
       ) : (

--- a/frontend/src/test/SettingsPasswordStrength.test.js
+++ b/frontend/src/test/SettingsPasswordStrength.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { validatePassword } from '../utils/validation';
+
+/**
+ * Mirrors the canSubmit logic in PasswordChangeForm:
+ * strong password + current filled + passwords match → enabled.
+ */
+function canSubmit(current, newPw, confirm) {
+  const issues = validatePassword(newPw);
+  const isStrong = newPw.length > 0 && issues.length === 0;
+  return isStrong && current.length > 0 && newPw === confirm;
+}
+
+describe('Settings password change form strength (#429)', () => {
+  it('disables submit for a weak password (too short)', () => {
+    expect(canSubmit('old', 'abc', 'abc')).toBe(false);
+  });
+
+  it('disables submit when password has no uppercase', () => {
+    expect(canSubmit('old', 'password1', 'password1')).toBe(false);
+  });
+
+  it('disables submit when password has no number', () => {
+    expect(canSubmit('old', 'Password', 'Password')).toBe(false);
+  });
+
+  it('disables submit when passwords do not match', () => {
+    expect(canSubmit('old', 'Password1', 'Password2')).toBe(false);
+  });
+
+  it('disables submit when current password is empty', () => {
+    expect(canSubmit('', 'Password1', 'Password1')).toBe(false);
+  });
+
+  it('enables submit for a strong password that meets all requirements', () => {
+    expect(canSubmit('old', 'Password1', 'Password1')).toBe(true);
+  });
+
+  it('enables submit for another valid strong password', () => {
+    expect(canSubmit('myOldPw', 'Secure99pass', 'Secure99pass')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #429

Settings had no password change form at all, so users had no way to update their password client-side with strength feedback.

## Changes

- **Settings.jsx**:
  - Added `PasswordStrengthBar` component — reuses `validatePassword()` from `utils/validation` to show a 4-segment colour bar (weak → strong) as the user types.
  - Added `PasswordChangeForm` component with current password, new password (+ strength bar), and confirm fields. The Save button is disabled until the new password passes all rules (min 8 chars, 1 uppercase, 1 number) and both new-password fields match.
  - Rendered `<PasswordChangeForm />` inside the authenticated `Settings` view.
- **SettingsPasswordStrength.test.js**: Unit tests covering weak/no-uppercase/no-number/mismatch/empty-current all disable submit, and a fully valid input enables it.

## Testing

```
cd frontend && node_modules/.bin/vitest run src/test/SettingsPasswordStrength.test.js
# 7 tests passed
```