### PR TITLE
fix(#428): sync order status filter tabs with URL query string

### DIFF
--- a/frontend/src/pages/Orders.jsx
+++ b/frontend/src/pages/Orders.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { useSearchParams } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../context/AuthContext';
 import Spinner from '../components/Spinner';
 
-const ALL_STATUSES = ['pending', 'paid', 'processing', 'shipped', 'delivered', 'failed'];
+const ALL_STATUSES = ['pending', 'paid', 'processing', 'shipped', 'delivered', 'disputed', 'cancelled', 'refunded', 'failed'];
 const FILTER_TABS = ['all', ...ALL_STATUSES];
 
 const STATUS_STYLE = {
@@ -14,10 +15,14 @@ const STATUS_STYLE = {
   shipped:    { bg: '#d1ecf1', color: '#0c5460' },
   delivered:  { bg: '#d4edda', color: '#155724' },
   failed:     { bg: '#fee',    color: '#c0392b' },
+  disputed:   { bg: '#ffe4cc', color: '#a04000' },
+  cancelled:  { bg: '#f0f0f0', color: '#555' },
+  refunded:   { bg: '#e8d5f5', color: '#6a0dad' },
 };
 
 const STATUS_ICON = {
   pending: '⏳', paid: '✅', processing: '⚙️', shipped: '🚚', delivered: '📦', failed: '❌',
+  disputed: '⚠️', cancelled: '🚫', refunded: '↩️',
 };
 
 // Timeline steps shown in order detail
@@ -77,7 +82,9 @@ function StatusTimeline({ status }) {
 
 export default function Orders() {
   const [allOrders, setAllOrders] = useState([]);
-  const [activeTab, setActiveTab]  = useState('all');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = FILTER_TABS.includes(searchParams.get('status')) ? searchParams.get('status') : 'all';
+  const setActiveTab = (tab) => setSearchParams(tab === 'all' ? {} : { status: tab }, { replace: true });
   const [loading, setLoading]      = useState(true);
   const [error, setError]          = useState(null);
   const [hovered, setHovered]      = useState(null);

--- a/frontend/src/test/OrdersFilter.test.jsx
+++ b/frontend/src/test/OrdersFilter.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+
+vi.mock('../api/client', () => ({
+  api: {
+    getOrders: vi.fn().mockResolvedValue({ data: [
+      { id: 1, product_name: 'Tomatoes', quantity: 2, unit: 'kg', farmer_name: 'Bob', status: 'paid', total_price: '10', created_at: '2024-01-01T00:00:00Z' },
+      { id: 2, product_name: 'Carrots', quantity: 1, unit: 'kg', farmer_name: 'Alice', status: 'disputed', total_price: '5', created_at: '2024-01-02T00:00:00Z' },
+      { id: 3, product_name: 'Apples', quantity: 3, unit: 'kg', farmer_name: 'Charlie', status: 'pending', total_price: '15', created_at: '2024-01-03T00:00:00Z' },
+    ]}),
+    getBundleOrders: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock('../context/AuthContext', () => ({ useAuth: () => ({ user: { role: 'buyer' } }) }));
+
+import Orders from '../pages/Orders';
+
+function renderOrders(initialUrl = '/orders') {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <Orders />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+describe('#428 Orders status filter', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('shows all orders by default', async () => {
+    renderOrders();
+    await waitFor(() => expect(screen.getByText('Tomatoes')).toBeInTheDocument());
+    expect(screen.getByText('Carrots')).toBeInTheDocument();
+    expect(screen.getByText('Apples')).toBeInTheDocument();
+  });
+
+  it('selecting "Disputed" filter shows only disputed orders', async () => {
+    renderOrders();
+    await waitFor(() => expect(screen.getByText('Tomatoes')).toBeInTheDocument());
+
+    const disputedTab = screen.getByRole('button', { name: /disputed/i });
+    fireEvent.click(disputedTab);
+
+    await waitFor(() => {
+      expect(screen.getByText('Carrots')).toBeInTheDocument();
+      expect(screen.queryByText('Tomatoes')).toBeNull();
+      expect(screen.queryByText('Apples')).toBeNull();
+    });
+  });
+
+  it('filter tabs exist for all required statuses', async () => {
+    renderOrders();
+    await waitFor(() => expect(screen.getByText('Tomatoes')).toBeInTheDocument());
+    for (const status of ['All', 'Pending', 'Paid', 'Disputed', 'Cancelled', 'Refunded']) {
+      expect(screen.getByRole('button', { name: new RegExp(status, 'i') })).toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #428

The orders page had filter tabs but the active filter was not reflected in the URL, making it impossible to share or bookmark a filtered view. This PR syncs the active tab with `?status=` in the URL.

## Changes

- **`frontend/src/pages/Orders.jsx`**
  - Import `useSearchParams` from `react-router-dom`
  - `activeTab` reads from `?status=` query param (falls back to `'all'`)
  - `setActiveTab` updates the URL param (`?status=paid`, etc.)
  - Expanded `ALL_STATUSES` to include `disputed`, `cancelled`, `refunded`
  - Added `STATUS_STYLE` and `STATUS_ICON` entries for the new statuses

## Tests

- `src/test/OrdersFilter.test.jsx`:
  - All required tabs (All, Pending, Paid, Disputed, Cancelled, Refunded) are present
  - Selecting 'Disputed' shows only disputed orders
  - Default view shows all orders