### PR TITLE
Fix #454: Add toast notifications for settings saves

### DIFF
--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+
+const toastStyles = {
+  container: {
+    position: 'fixed',
+    bottom: 24,
+    right: 24,
+    zIndex: 9999,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+    pointerEvents: 'none'
+  },
+  toast: {
+    background: '#2d6a4f',
+    color: '#fff',
+    borderRadius: 10,
+    padding: '12px 18px',
+    boxShadow: '0 4px 16px #0003',
+    fontSize: 14,
+    minWidth: 260,
+    maxWidth: 360,
+    pointerEvents: 'auto',
+    animation: 'slideIn 0.3s ease-out'
+  },
+  toastError: {
+    background: '#c0392b'
+  },
+  toastTitle: {
+    fontWeight: 700,
+    marginBottom: 3
+  },
+  toastSub: {
+    fontSize: 12,
+    opacity: 0.85
+  }
+};
+
+// Add animation styles to document head
+if (typeof document !== 'undefined' && !document.getElementById('toast-style')) {
+  const style = document.createElement('style');
+  style.id = 'toast-style';
+  style.textContent = `
+    @keyframes slideIn {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes slideOut {
+      from { opacity: 1; transform: translateY(0); }
+      to { opacity: 0; transform: translateY(12px); }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState([]);
+
+  const addToast = (message, type = 'success', duration = 3000) => {
+    const id = Date.now();
+    const newToast = { id, message, type, duration };
+    
+    setToasts(prev => [...prev, newToast]);
+    
+    // Auto remove after duration
+    if (duration > 0) {
+      setTimeout(() => {
+        setToasts(prev => prev.filter(t => t.id !== id));
+      }, duration);
+    }
+    
+    return id;
+  };
+
+  const removeToast = (id) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  };
+
+  const showSuccess = (message, duration = 3000) => {
+    return addToast(message, 'success', duration);
+  };
+
+  const showError = (message, duration = 5000) => {
+    return addToast(message, 'error', duration);
+  };
+
+  return { toasts, addToast, removeToast, showSuccess, showError };
+}
+
+export default function Toast({ toasts }) {
+  return (
+    <div style={toastStyles.container} aria-live="polite" aria-atomic="true">
+      {toasts.map(t => (
+        <div 
+          key={t.id} 
+          style={{
+            ...toastStyles.toast,
+            ...(t.type === 'error' ? toastStyles.toastError : {})
+          }} 
+          role="status"
+          aria-label={t.type === 'error' ? `Error: ${t.message}` : `Success: ${t.message}`}
+        >
+          <div style={toastStyles.toastTitle}>
+            {t.type === 'error' ? 'Error' : 'Success'}
+          </div>
+          <div style={toastStyles.toastSub}>{t.message}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/Toast.test.js
+++ b/frontend/src/components/__tests__/Toast.test.js
@@ -1,0 +1,232 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Toast, { useToast } from '../Toast';
+
+// Mock the document object for style injection
+Object.defineProperty(window, 'document', {
+  value: {
+    getElementById: jest.fn(() => null),
+    head: {
+      appendChild: jest.fn()
+    }
+  }
+});
+
+// Test component that uses the useToast hook
+function TestComponent() {
+  const { showSuccess, showError, toasts } = useToast();
+  
+  return (
+    <div>
+      <button onClick={() => showSuccess('Success message')}>Show Success</button>
+      <button onClick={() => showError('Error message')}>Show Error</button>
+      <Toast toasts={toasts} />
+    </div>
+  );
+}
+
+describe('Toast Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders success toast with correct message', async () => {
+    render(<TestComponent />);
+    
+    const successButton = screen.getByText('Show Success');
+    fireEvent.click(successButton);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Success')).toBeInTheDocument();
+      expect(screen.getByText('Success message')).toBeInTheDocument();
+    });
+  });
+
+  test('renders error toast with correct message', async () => {
+    render(<TestComponent />);
+    
+    const errorButton = screen.getByText('Show Error');
+    fireEvent.click(errorButton);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('Error message')).toBeInTheDocument();
+    });
+  });
+
+  test('toast has correct accessibility attributes', async () => {
+    render(<TestComponent />);
+    
+    const successButton = screen.getByText('Show Success');
+    fireEvent.click(successButton);
+    
+    await waitFor(() => {
+      const toastContainer = screen.getByRole('status');
+      expect(toastContainer).toHaveAttribute('aria-live', 'polite');
+      expect(toastContainer).toHaveAttribute('aria-atomic', 'true');
+    });
+  });
+
+  test('multiple toasts can be displayed simultaneously', async () => {
+    render(<TestComponent />);
+    
+    const successButton = screen.getByText('Show Success');
+    const errorButton = screen.getByText('Show Error');
+    
+    fireEvent.click(successButton);
+    fireEvent.click(errorButton);
+    
+    await waitFor(() => {
+      expect(screen.getByText('Success')).toBeInTheDocument();
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(screen.getAllByRole('status')).toHaveLength(2);
+    });
+  });
+
+  test('toast auto-removes after duration', async () => {
+    jest.useFakeTimers();
+    render(<TestComponent />);
+    
+    const successButton = screen.getByText('Show Success');
+    fireEvent.click(successButton);
+    
+    // Toast should be visible initially
+    await waitFor(() => {
+      expect(screen.getByText('Success')).toBeInTheDocument();
+    });
+    
+    // Fast-forward time
+    jest.advanceTimersByTime(3000);
+    
+    // Toast should be removed after 3 seconds
+    await waitFor(() => {
+      expect(screen.queryByText('Success')).not.toBeInTheDocument();
+    });
+    
+    jest.useRealTimers();
+  });
+
+  test('error toast stays longer than success toast', async () => {
+    jest.useFakeTimers();
+    render(<TestComponent />);
+    
+    const errorButton = screen.getByText('Show Error');
+    fireEvent.click(errorButton);
+    
+    // Toast should be visible initially
+    await waitFor(() => {
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+    
+    // Fast-forward 3 seconds (success toast duration)
+    jest.advanceTimersByTime(3000);
+    
+    // Error toast should still be visible
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    
+    // Fast-forward 2 more seconds (total 5 seconds)
+    jest.advanceTimersByTime(2000);
+    
+    // Error toast should now be removed
+    await waitFor(() => {
+      expect(screen.queryByText('Error')).not.toBeInTheDocument();
+    });
+    
+    jest.useRealTimers();
+  });
+});
+
+describe('useToast Hook', () => {
+  test('showSuccess adds success toast', () => {
+    let toasts;
+    function HookTest() {
+      const { showSuccess, toasts: toastList } = useToast();
+      toasts = toastList;
+      
+      React.useEffect(() => {
+        showSuccess('Test success');
+      }, [showSuccess]);
+      
+      return null;
+    }
+    
+    render(<HookTest />);
+    
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toMatchObject({
+      message: 'Test success',
+      type: 'success'
+    });
+  });
+
+  test('showError adds error toast', () => {
+    let toasts;
+    function HookTest() {
+      const { showError, toasts: toastList } = useToast();
+      toasts = toastList;
+      
+      React.useEffect(() => {
+        showError('Test error');
+      }, [showError]);
+      
+      return null;
+    }
+    
+    render(<HookTest />);
+    
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toMatchObject({
+      message: 'Test error',
+      type: 'error'
+    });
+  });
+
+  test('addToast returns toast ID', () => {
+    let toastId;
+    function HookTest() {
+      const { addToast } = useToast();
+      
+      React.useEffect(() => {
+        toastId = addToast('Test message', 'success');
+      }, [addToast]);
+      
+      return null;
+    }
+    
+    render(<HookTest />);
+    
+    expect(typeof toastId).toBe('number');
+    expect(toastId).toBeGreaterThan(0);
+  });
+
+  test('removeToast removes specific toast', () => {
+    let toasts, removeToast;
+    function HookTest() {
+      const { addToast, toasts: toastList, removeToast: remove } = useToast();
+      toasts = toastList;
+      removeToast = remove;
+      
+      React.useEffect(() => {
+        const id1 = addToast('Toast 1', 'success');
+        const id2 = addToast('Toast 2', 'success');
+        
+        // Remove the first toast
+        setTimeout(() => remove(id1), 100);
+      }, [addToast, remove]);
+      
+      return null;
+    }
+    
+    render(<HookTest />);
+    
+    // Should have 2 toasts initially
+    expect(toasts).toHaveLength(2);
+    
+    // After removal, should have 1 toast
+    setTimeout(() => {
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0].message).toBe('Toast 2');
+    }, 150);
+  });
+});

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { api } from '../api/client';
+import Toast, { useToast } from '../components/Toast';
 
 const s = {
   page: { maxWidth: 900, margin: '0 auto', padding: 16 },
@@ -74,6 +75,7 @@ export default function Dashboard() {
   // profile state
   const [profile, setProfile]       = useState({ bio: '', location: '', avatar_url: '', federation_name: '', latitude: '', longitude: '', farm_address: '' });
   const [profileMsg, setProfileMsg] = useState(null);
+  const { showSuccess, showError, toasts } = useToast();
   const [avatarFile, setAvatarFile] = useState(null);
   const [avatarPreview, setAvatarPreview] = useState(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
@@ -398,6 +400,7 @@ export default function Dashboard() {
       } catch (err) {
         setAvatarUploading(false);
         setProfileMsg({ type: 'err', text: `Avatar upload failed: ${getErrorMessage(err)}` });
+        showError(`Avatar upload failed: ${getErrorMessage(err)}`);
         return;
       }
       setAvatarUploading(false);
@@ -416,8 +419,10 @@ export default function Dashboard() {
       const d = res.data;
       setProfile({ bio: d.bio || '', location: d.location || '', avatar_url: d.avatar_url || '', federation_name: d.federation_name || '', latitude: d.latitude ?? '', longitude: d.longitude ?? '', farm_address: d.farm_address || '' });
       setProfileMsg({ type: 'ok', text: t('dashboard.profileUpdated') });
+      showSuccess('Settings saved successfully.');
     } catch (err) {
       setProfileMsg({ type: 'err', text: getErrorMessage(err) });
+      showError(getErrorMessage(err));
     }
   }
 
@@ -506,6 +511,7 @@ export default function Dashboard() {
 
   return (
     <div style={s.page}>
+      <Toast toasts={toasts} />
       <div style={s.title}>🌾 Farmer Dashboard</div>
       <div style={{ ...s.card, marginBottom: 24 }}>
         <h3 style={{ marginBottom: 12, color: '#333' }}>Flash Sales</h3>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../context/AuthContext';
+import Toast, { useToast } from '../components/Toast';
 
 const s = {
   page:    { maxWidth: 640, margin: '0 auto', padding: 24 },
@@ -28,6 +29,7 @@ const CONFIRM_PHRASE = 'delete my account';
 export default function Settings() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const { showSuccess, showError, toasts } = useToast();
 
   const [showModal, setShowModal]       = useState(false);
   const [step, setStep]                 = useState('confirm'); // 'confirm' | 'balance_warning'
@@ -72,6 +74,7 @@ export default function Settings() {
 
   return (
     <div style={s.page}>
+      <Toast toasts={toasts} />
       <div style={s.title}>Settings</div>
       <div style={s.sub}>Manage your account preferences.</div>
 
@@ -217,6 +220,7 @@ function SeedPhraseBackup() {
   const [loading, setLoading]     = useState(false);
   const [error, setError]         = useState('');
   const [confirmed, setConfirmed] = useState(false);
+  const { showSuccess, showError } = useToast();
 
   async function handleReveal(e) {
     e.preventDefault();
@@ -237,7 +241,10 @@ function SeedPhraseBackup() {
   function handleCopy() {
     navigator.clipboard.writeText(mnemonic).then(() => {
       setCopied(true);
+      showSuccess('Seed phrase copied to clipboard');
       setTimeout(() => setCopied(false), 2500);
+    }).catch(() => {
+      showError('Failed to copy seed phrase to clipboard');
     });
   }
 
@@ -324,6 +331,7 @@ function AccountRecovery() {
   const [loading, setLoading] = useState(false);
   const [error, setError]     = useState('');
   const [success, setSuccess] = useState('');
+  const { showSuccess, showError } = useToast();
 
   function handleChange(field, value) {
     setForm(f => ({ ...f, [field]: value }));
@@ -346,9 +354,11 @@ function AccountRecovery() {
       const data = await api.recoverAccount({ email, password, mnemonic: mnemonic.trim() });
       login(data.token, data.user);
       setSuccess('Wallet recovered successfully. Redirecting…');
+      showSuccess('Settings saved successfully.');
       setTimeout(() => navigate(data.user.role === 'farmer' ? '/dashboard' : '/marketplace'), 1500);
     } catch (err) {
       setError(err.message || 'Recovery failed. Check your credentials and seed phrase.');
+      showError(err.message || 'Recovery failed. Check your credentials and seed phrase.');
     } finally {
       setLoading(false);
     }
@@ -408,9 +418,11 @@ function AccountRecovery() {
 // ── Main Settings Page ────────────────────────────────────────────────────────
 export default function Settings() {
   const { user } = useAuth();
+  const { showSuccess, showError, toasts } = useToast();
 
   return (
     <div style={s.page}>
+      <Toast toasts={toasts} />
       <div style={s.title}>⚙️ Settings</div>
       <SeedPhraseBackup />
       {!user && <AccountRecovery />}


### PR DESCRIPTION
- Create reusable Toast component with success/error notifications
- Implement toast notifications for profile settings in Dashboard.jsx
- Add toast functionality to Settings.jsx components
- Include screen reader accessibility with aria-live attributes
- Add comprehensive unit tests for toast functionality
- Show success toast for 3 seconds after successful saves
- Display error toast with API error messages when saves fail

Fixes #454
closes #454 