### PR TITLE
Map Stellar Horizon operation result codes to user-friendly messages and update fallback to include raw error code

### DIFF
--- a/frontend/src/test/stellarErrors.test.jsx
+++ b/frontend/src/test/stellarErrors.test.jsx
@@ -55,14 +55,70 @@ describe('getStellarErrorMessage', () => {
       .toBe('Stellar authorization failed. Please log in again.');
   });
 
+  it('maps op_underfunded error code', () => {
+    const err = new Error('operation failed');
+    err.code = 'op_underfunded';
+    expect(getStellarErrorMessage(err))
+      .toBe('The account does not have enough funds to perform this operation.');
+  });
+
+  it('maps op_src_not_authorized error code', () => {
+    const err = new Error('operation failed');
+    err.code = 'op_src_not_authorized';
+    expect(getStellarErrorMessage(err))
+      .toBe('The source account is not authorized to perform this operation.');
+  });
+
+  it('maps op_no_destination error code', () => {
+    const err = new Error('operation failed');
+    err.code = 'op_no_destination';
+    expect(getStellarErrorMessage(err))
+      .toBe('The destination account does not exist.');
+  });
+
+  it('maps op_no_trust error code', () => {
+    const err = new Error('operation failed');
+    err.code = 'op_no_trust';
+    expect(getStellarErrorMessage(err))
+      .toBe('The account does not have a trustline for this asset.');
+  });
+
+  it('maps op_line_full error code', () => {
+    const err = new Error('operation failed');
+    err.code = 'op_line_full';
+    expect(getStellarErrorMessage(err))
+      .toBe('The trustline limit has been reached.');
+  });
+
+  it('maps tx_bad_seq error code', () => {
+    const err = new Error('transaction failed');
+    err.code = 'tx_bad_seq';
+    expect(getStellarErrorMessage(err))
+      .toBe('Invalid transaction sequence number.');
+  });
+
+  it('maps tx_insufficient_fee error code', () => {
+    const err = new Error('transaction failed');
+    err.code = 'tx_insufficient_fee';
+    expect(getStellarErrorMessage(err))
+      .toBe('The transaction fee is insufficient.');
+  });
+
   it('returns original message for unknown errors', () => {
     expect(getStellarErrorMessage(new Error('some unknown error')))
       .toBe('some unknown error');
   });
 
+  it('returns fallback with code for unknown errors without message', () => {
+    const err = new Error();
+    err.code = 'unknown_code';
+    expect(getStellarErrorMessage(err))
+      .toBe('An unexpected error occurred (unknown_code). Please try again.');
+  });
+
   it('returns fallback for null/undefined', () => {
     expect(getStellarErrorMessage(null))
-      .toBe('An unexpected error occurred. Please try again.');
+      .toBe('An unexpected error occurred (unknown). Please try again.');
   });
 });
 

--- a/frontend/src/utils/stellarErrors.js
+++ b/frontend/src/utils/stellarErrors.js
@@ -9,6 +9,16 @@ const STELLAR_ERROR_MAP = [
   { match: /bad_auth|unauthorized/i, message: 'Stellar authorization failed. Please log in again.' },
 ];
 
+const STELLAR_ERROR_CODE_MAP = {
+  op_underfunded: 'The account does not have enough funds to perform this operation.',
+  op_src_not_authorized: 'The source account is not authorized to perform this operation.',
+  op_no_destination: 'The destination account does not exist.',
+  op_no_trust: 'The account does not have a trustline for this asset.',
+  op_line_full: 'The trustline limit has been reached.',
+  tx_bad_seq: 'Invalid transaction sequence number.',
+  tx_insufficient_fee: 'The transaction fee is insufficient.',
+};
+
 export function getStellarErrorMessage(err) {
   const raw = (err?.message || String(err));
   const code = err?.code;
@@ -18,8 +28,13 @@ export function getStellarErrorMessage(err) {
     return 'Please fund your wallet before purchasing. <a href="/wallet" style="color: #2d6a4f; text-decoration: underline;">Go to Wallet</a>';
   }
   
+  // Check for specific Stellar error codes
+  if (code && STELLAR_ERROR_CODE_MAP[code]) {
+    return STELLAR_ERROR_CODE_MAP[code];
+  }
+  
   for (const { match, message } of STELLAR_ERROR_MAP) {
     if (match.test(raw)) return message;
   }
-  return err?.message || 'An unexpected error occurred. Please try again.';
+  return err?.message || `An unexpected error occurred (${err?.code || 'unknown'}). Please try again.`;
 }


### PR DESCRIPTION
closes #444 

Mapped Stellar Horizon error codes to friendly messages and added a fallback that includes the raw error code.