### PR TITLE
feat(db): add unique index on contracts_registry.contract_id

### DIFF
--- a/backend/migrations/018_contracts_registry_contract_id_index.sql
+++ b/backend/migrations/018_contracts_registry_contract_id_index.sql
@@ -1,0 +1,6 @@
+-- Migration: 018_contracts_registry_contract_id_index
+-- Adds a unique index on contracts_registry(contract_id) to avoid full table
+-- scans when looking up a contract by its Soroban contract ID.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contracts_registry_contract_id
+  ON contracts_registry (contract_id);

--- a/backend/migrations/018_contracts_registry_contract_id_index.undo.sql
+++ b/backend/migrations/018_contracts_registry_contract_id_index.undo.sql
@@ -1,0 +1,2 @@
+-- Rollback: 018_contracts_registry_contract_id_index
+DROP INDEX IF EXISTS idx_contracts_registry_contract_id;


### PR DESCRIPTION
## Summary

Adds a unique index on `contracts_registry(contract_id)` so queries that look up a contract by its Soroban contract ID use an index scan instead of a full table scan.

## Changes

- `backend/migrations/018_contracts_registry_contract_id_index.sql`: `CREATE UNIQUE INDEX IF NOT EXISTS idx_contracts_registry_contract_id ON contracts_registry(contract_id)`
- `backend/migrations/018_contracts_registry_contract_id_index.undo.sql`: `DROP INDEX IF EXISTS idx_contracts_registry_contract_id`

## Notes

- Compatible with both SQLite and PostgreSQL
- The `contract_id` column already has a `UNIQUE` constraint from migration 008, so this index is consistent with the existing schema intent and will be created without conflicts

Closes #480