### PR TITLE
feat(db): limit contract_invocations.args to 64 KiB

### DIFF
--- a/backend/migrations/019_contract_invocations_args_limit.sql
+++ b/backend/migrations/019_contract_invocations_args_limit.sql
@@ -1,0 +1,9 @@
+-- Migration: 019_contract_invocations_args_limit
+-- Adds a CHECK constraint on contract_invocations.args to enforce a 65 535-byte
+-- (64 KiB) maximum. SQLite ignores CHECK constraints on existing rows but will
+-- enforce them on new inserts. PostgreSQL enforces immediately.
+-- The application layer truncates oversized args before insert (see contracts.js).
+
+ALTER TABLE contract_invocations
+  ADD CONSTRAINT chk_contract_invocations_args_length
+  CHECK (args IS NULL OR length(args) <= 65535);

--- a/backend/migrations/019_contract_invocations_args_limit.undo.sql
+++ b/backend/migrations/019_contract_invocations_args_limit.undo.sql
@@ -1,0 +1,5 @@
+-- Rollback: 019_contract_invocations_args_limit
+-- SQLite does not support DROP CONSTRAINT; this is a no-op for SQLite.
+-- PostgreSQL:
+ALTER TABLE contract_invocations
+  DROP CONSTRAINT IF EXISTS chk_contract_invocations_args_length;

--- a/backend/src/routes/contracts.js
+++ b/backend/src/routes/contracts.js
@@ -9,6 +9,16 @@ function validateContractId(contractId) {
   return /^[A-Z2-7]{56}$|^[0-9a-fA-F]{64}$/.test(contractId);
 }
 
+const ARGS_MAX_BYTES = 65535;
+const TRUNCATED_SUFFIX = ' [truncated]';
+
+function truncateArgs(args) {
+  if (args == null) return null;
+  const serialised = JSON.stringify(args);
+  if (serialised.length <= ARGS_MAX_BYTES) return serialised;
+  return serialised.slice(0, ARGS_MAX_BYTES - TRUNCATED_SUFFIX.length) + TRUNCATED_SUFFIX;
+}
+
 async function logInvocation({ contractId, method, args, result, txHash, success, error, userId }) {
   try {
     await db.query(
@@ -17,7 +27,7 @@ async function logInvocation({ contractId, method, args, result, txHash, success
       [
         contractId,
         method,
-        args != null ? JSON.stringify(args) : null,
+        truncateArgs(args),
         result != null ? JSON.stringify(result) : null,
         txHash || null,
         success ? 1 : 0,


### PR DESCRIPTION
## Summary

The `args` column in `contract_invocations` had no size constraint, allowing megabytes of data per row. This PR enforces a 64 KiB limit at both the application and database layers.

## Changes

- `backend/migrations/019_contract_invocations_args_limit.sql`: adds `CHECK (args IS NULL OR length(args) <= 65535)` constraint
- `backend/migrations/019_contract_invocations_args_limit.undo.sql`: drops the constraint
- `backend/src/routes/contracts.js`: `logInvocation` now truncates serialised args to 65535 bytes with a `[truncated]` suffix before inserting — the invocation record is always stored

## Behaviour

- Args within 64 KiB: stored as-is (no change)
- Args exceeding 64 KiB: stored truncated with `[truncated]` appended
- The invocation is never dropped due to large args

Closes #481