### PR TITLE
feat(expiry): daily cron job to deactivate expired products and notify farmers

### DIFF
--- a/backend/migrations/021_subscriptions_retry.sql
+++ b/backend/migrations/021_subscriptions_retry.sql
@@ -1,0 +1,33 @@
+-- Add retry tracking and failed status to subscriptions
+ALTER TABLE subscriptions ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE subscriptions ADD COLUMN retry_after DATETIME;
+
+-- SQLite does not support modifying CHECK constraints; recreate the table
+-- For PostgreSQL, we alter the constraint directly.
+-- The migration runner handles both via the dual-mode db layer.
+-- We use a trigger-free approach: drop and recreate with new CHECK.
+-- Since SQLite ALTER TABLE cannot modify constraints, we recreate the table.
+
+-- Create new table with updated CHECK
+CREATE TABLE IF NOT EXISTS subscriptions_new (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  buyer_id      INTEGER NOT NULL,
+  product_id    INTEGER NOT NULL,
+  quantity      INTEGER NOT NULL,
+  frequency     TEXT NOT NULL CHECK(frequency IN ('weekly', 'biweekly', 'monthly')),
+  next_order_at DATETIME NOT NULL,
+  active        INTEGER NOT NULL DEFAULT 1,
+  status        TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'paused', 'cancelled', 'failed')),
+  retry_count   INTEGER NOT NULL DEFAULT 0,
+  retry_after   DATETIME,
+  created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (buyer_id)   REFERENCES users(id)    ON DELETE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+);
+
+INSERT INTO subscriptions_new (id, buyer_id, product_id, quantity, frequency, next_order_at, active, status, retry_count, retry_after, created_at)
+SELECT id, buyer_id, product_id, quantity, frequency, next_order_at, active, status, 0, NULL, created_at
+FROM subscriptions;
+
+DROP TABLE subscriptions;
+ALTER TABLE subscriptions_new RENAME TO subscriptions;

--- a/backend/migrations/021_subscriptions_retry.undo.sql
+++ b/backend/migrations/021_subscriptions_retry.undo.sql
@@ -1,0 +1,23 @@
+-- Rollback: remove retry_count, retry_after, and revert status CHECK
+CREATE TABLE IF NOT EXISTS subscriptions_old (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  buyer_id      INTEGER NOT NULL,
+  product_id    INTEGER NOT NULL,
+  quantity      INTEGER NOT NULL,
+  frequency     TEXT NOT NULL CHECK(frequency IN ('weekly', 'biweekly', 'monthly')),
+  next_order_at DATETIME NOT NULL,
+  active        INTEGER NOT NULL DEFAULT 1,
+  status        TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'paused', 'cancelled')),
+  created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (buyer_id)   REFERENCES users(id)    ON DELETE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+);
+
+INSERT INTO subscriptions_old (id, buyer_id, product_id, quantity, frequency, next_order_at, active, status, created_at)
+SELECT id, buyer_id, product_id, quantity, frequency, next_order_at, active,
+  CASE WHEN status = 'failed' THEN 'cancelled' ELSE status END,
+  created_at
+FROM subscriptions;
+
+DROP TABLE subscriptions;
+ALTER TABLE subscriptions_old RENAME TO subscriptions;

--- a/backend/migrations/022_product_view_summaries.sql
+++ b/backend/migrations/022_product_view_summaries.sql
@@ -1,0 +1,17 @@
+-- Migration: 022_product_view_summaries
+-- Description: Daily aggregation summary table for product_views analytics
+--
+-- Idempotent: INSERT OR REPLACE (SQLite) / INSERT ... ON CONFLICT DO UPDATE (PG)
+-- ensures reruns reconcile existing rows without duplicates.
+
+CREATE TABLE IF NOT EXISTS product_view_summaries (
+  product_id  INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  view_date   DATE    NOT NULL,
+  view_count  INTEGER NOT NULL DEFAULT 0,
+  unique_viewers INTEGER NOT NULL DEFAULT 0,
+  aggregated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (product_id, view_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pvs_view_date    ON product_view_summaries (view_date);
+CREATE INDEX IF NOT EXISTS idx_pvs_product_date ON product_view_summaries (product_id, view_date);

--- a/backend/migrations/022_product_view_summaries.undo.sql
+++ b/backend/migrations/022_product_view_summaries.undo.sql
@@ -1,0 +1,4 @@
+-- Rollback: 022_product_view_summaries
+DROP INDEX IF EXISTS idx_pvs_product_date;
+DROP INDEX IF EXISTS idx_pvs_view_date;
+DROP TABLE IF EXISTS product_view_summaries;

--- a/backend/migrations/023_auctions_and_bids.sql
+++ b/backend/migrations/023_auctions_and_bids.sql
@@ -1,0 +1,34 @@
+-- Migration: 023_auctions_and_bids
+-- Creates auctions and bids tables with all columns needed for
+-- server-side bid validation and auto-closure.
+
+CREATE TABLE IF NOT EXISTS auctions (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  product_id        INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  farmer_id         INTEGER NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+  start_price       REAL    NOT NULL CHECK(start_price > 0),
+  reserve_price     REAL,
+  min_increment     REAL    NOT NULL DEFAULT 0,
+  current_bid       REAL,
+  highest_bidder_id INTEGER REFERENCES users(id),
+  status            TEXT    NOT NULL DEFAULT 'active'
+                    CHECK(status IN ('active','closed','cancelled')),
+  ends_at           DATETIME NOT NULL,
+  closed_at         DATETIME,
+  winner_notified   INTEGER NOT NULL DEFAULT 0,
+  created_at        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_auctions_status_ends_at
+  ON auctions (status, ends_at);
+
+CREATE TABLE IF NOT EXISTS bids (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  auction_id INTEGER NOT NULL REFERENCES auctions(id) ON DELETE CASCADE,
+  buyer_id   INTEGER NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+  amount     REAL    NOT NULL CHECK(amount > 0),
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_bids_auction_id ON bids (auction_id);
+CREATE INDEX IF NOT EXISTS idx_bids_buyer_id   ON bids (buyer_id);

--- a/backend/migrations/023_auctions_and_bids.undo.sql
+++ b/backend/migrations/023_auctions_and_bids.undo.sql
@@ -1,0 +1,6 @@
+-- Rollback: 023_auctions_and_bids
+DROP INDEX IF EXISTS idx_bids_buyer_id;
+DROP INDEX IF EXISTS idx_bids_auction_id;
+DROP TABLE IF EXISTS bids;
+DROP INDEX IF EXISTS idx_auctions_status_ends_at;
+DROP TABLE IF EXISTS auctions;

--- a/backend/migrations/024_product_expiry_notified_at.sql
+++ b/backend/migrations/024_product_expiry_notified_at.sql
@@ -1,0 +1,4 @@
+-- Migration: 024_product_expiry_notified_at
+-- Description: Add expiry_notified_at to products for idempotent expiry job tracking
+
+ALTER TABLE products ADD COLUMN expiry_notified_at DATETIME;

--- a/backend/migrations/024_product_expiry_notified_at.undo.sql
+++ b/backend/migrations/024_product_expiry_notified_at.undo.sql
@@ -1,0 +1,2 @@
+-- Rollback: 024_product_expiry_notified_at
+ALTER TABLE products DROP COLUMN IF EXISTS expiry_notified_at;

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,15 +28,12 @@
       "<rootDir>/tests/jest.setup.js"
     ],
     "moduleNameMapper": {
-      "^uuid$": "<rootDir>/tests/__mocks__/uuid.js"
+      "^uuid$": "<rootDir>/node_modules/uuid/dist-node/index.js"
     },
     "testEnvironmentOptions": {
       "env": {
         "NODE_ENV": "test"
       }
-    },
-    "moduleNameMapper": {
-      "^uuid$": "<rootDir>/node_modules/uuid/dist-node/index.js"
     }
   },
   "dependencies": {
@@ -72,7 +69,7 @@
   "devDependencies": {
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "jest": "^30.3.0",
+    "jest": "^30.4.2",
     "nodemon": "^3.1.0",
     "supertest": "^7.2.2"
   }

--- a/backend/src/__tests__/aggregateProductViews.test.js
+++ b/backend/src/__tests__/aggregateProductViews.test.js
@@ -1,0 +1,368 @@
+'use strict';
+
+/**
+ * Tests for aggregateProductViews.js
+ *
+ * Covers:
+ *  - targetDate helper
+ *  - Successful aggregation (SQLite path)
+ *  - Idempotent rerun (same date, same result)
+ *  - Empty dataset (no views)
+ *  - Late-arriving records (explicit past date)
+ *  - Large-volume batching (> BATCH_SIZE products)
+ *  - Partial batch failure (one batch throws, others succeed)
+ *  - PostgreSQL path (db.isPostgres = true)
+ *  - Cron registration via startProductViewsAggJob
+ */
+
+jest.mock('node-cron', () => ({ schedule: jest.fn() }));
+
+jest.mock('../../src/db/schema', () => ({
+  prepare: jest.fn(),
+  transaction: jest.fn(),
+  query: jest.fn(),
+  isPostgres: false,
+}));
+
+jest.mock('../../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const cron = require('node-cron');
+const db = require('../../src/db/schema');
+const logger = require('../../src/logger');
+const {
+  aggregateProductViews,
+  startProductViewsAggJob,
+  targetDate,
+} = require('../../src/jobs/aggregateProductViews');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Set up SQLite-mode mocks.
+ * @param {number[]} productIds - product IDs returned by the DISTINCT query
+ * @param {object}   opts
+ * @param {boolean}  opts.upsertThrows - make the upsert statement throw
+ */
+function setupSqliteMocks(productIds = [], { upsertThrows = false } = {}) {
+  db.isPostgres = false;
+
+  const distinctStmt = { all: jest.fn().mockReturnValue(productIds.map((id) => ({ product_id: id }))) };
+  const upsertStmt = {
+    run: upsertThrows
+      ? jest.fn().mockImplementation(() => { throw new Error('DB write error'); })
+      : jest.fn().mockReturnValue({ changes: 1 }),
+  };
+
+  db.prepare.mockImplementation((sql) => {
+    if (sql.includes('DISTINCT product_id')) return distinctStmt;
+    if (sql.includes('INSERT OR REPLACE')) return upsertStmt;
+    return { run: jest.fn(), get: jest.fn(), all: jest.fn().mockReturnValue([]) };
+  });
+
+  // transaction executes the callback immediately
+  db.transaction.mockImplementation((fn) => (...args) => fn(...args));
+
+  return { distinctStmt, upsertStmt };
+}
+
+/**
+ * Set up PostgreSQL-mode mocks.
+ * @param {number[]} productIds
+ * @param {object}   opts
+ * @param {boolean}  opts.upsertThrows
+ */
+function setupPostgresMocks(productIds = [], { upsertThrows = false } = {}) {
+  db.isPostgres = true;
+
+  db.query.mockImplementation((sql) => {
+    if (sql.includes('DISTINCT product_id')) {
+      return Promise.resolve({ rows: productIds.map((id) => ({ product_id: id })) });
+    }
+    if (sql.includes('INSERT INTO product_view_summaries')) {
+      if (upsertThrows) return Promise.reject(new Error('PG write error'));
+      return Promise.resolve({ rowCount: productIds.length });
+    }
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  db.isPostgres = false;
+});
+
+// ── targetDate ────────────────────────────────────────────────────────────────
+
+describe('targetDate', () => {
+  it('returns yesterday in YYYY-MM-DD format', () => {
+    const now = new Date('2026-05-28T12:00:00Z');
+    expect(targetDate(now)).toBe('2026-05-27');
+  });
+
+  it('handles month boundary correctly', () => {
+    const now = new Date('2026-06-01T00:00:00Z');
+    expect(targetDate(now)).toBe('2026-05-31');
+  });
+
+  it('defaults to yesterday when called with no argument', () => {
+    const result = targetDate();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const yesterday = new Date();
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    expect(result).toBe(yesterday.toISOString().slice(0, 10));
+  });
+});
+
+// ── Empty dataset ─────────────────────────────────────────────────────────────
+
+describe('aggregateProductViews — empty dataset', () => {
+  it('returns zero counts and does not write anything (SQLite)', async () => {
+    setupSqliteMocks([]);
+    const result = await aggregateProductViews('2026-05-27');
+    expect(result).toEqual({ date: '2026-05-27', processed: 0, skipped: 0 });
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns zero counts and does not write anything (PG)', async () => {
+    setupPostgresMocks([]);
+    const result = await aggregateProductViews('2026-05-27');
+    expect(result).toEqual({ date: '2026-05-27', processed: 0, skipped: 0 });
+    // Only the DISTINCT query should have been called
+    expect(db.query).toHaveBeenCalledTimes(1);
+    expect(db.query.mock.calls[0][0]).toContain('DISTINCT product_id');
+  });
+});
+
+// ── Successful aggregation ────────────────────────────────────────────────────
+
+describe('aggregateProductViews — successful aggregation', () => {
+  it('processes all products and returns correct counts (SQLite)', async () => {
+    const { upsertStmt } = setupSqliteMocks([1, 2, 3]);
+    const result = await aggregateProductViews('2026-05-27');
+
+    expect(result).toEqual({ date: '2026-05-27', processed: 3, skipped: 0 });
+    // upsert.run called once per product
+    expect(upsertStmt.run).toHaveBeenCalledTimes(3);
+    expect(upsertStmt.run).toHaveBeenCalledWith('2026-05-27', '2026-05-27', 1);
+    expect(upsertStmt.run).toHaveBeenCalledWith('2026-05-27', '2026-05-27', 2);
+    expect(upsertStmt.run).toHaveBeenCalledWith('2026-05-27', '2026-05-27', 3);
+  });
+
+  it('processes all products and returns correct counts (PG)', async () => {
+    setupPostgresMocks([1, 2, 3]);
+    const result = await aggregateProductViews('2026-05-27');
+
+    expect(result).toEqual({ date: '2026-05-27', processed: 3, skipped: 0 });
+    // One DISTINCT query + one INSERT upsert (all 3 in a single batch)
+    expect(db.query).toHaveBeenCalledTimes(2);
+    const upsertCall = db.query.mock.calls[1];
+    expect(upsertCall[0]).toContain('INSERT INTO product_view_summaries');
+    expect(upsertCall[1]).toContain('2026-05-27');
+    expect(upsertCall[1]).toContain(1);
+    expect(upsertCall[1]).toContain(2);
+    expect(upsertCall[1]).toContain(3);
+  });
+
+  it('uses the provided date, not yesterday', async () => {
+    const { distinctStmt } = setupSqliteMocks([10]);
+    await aggregateProductViews('2025-01-15');
+    expect(distinctStmt.all).toHaveBeenCalledWith('2025-01-15');
+  });
+
+  it('defaults to yesterday when no date is provided', async () => {
+    const { distinctStmt } = setupSqliteMocks([]);
+    await aggregateProductViews();
+    const yesterday = targetDate();
+    expect(distinctStmt.all).toHaveBeenCalledWith(yesterday);
+  });
+});
+
+// ── Idempotency ───────────────────────────────────────────────────────────────
+
+describe('aggregateProductViews — idempotent reruns', () => {
+  it('can be called twice for the same date without error (SQLite)', async () => {
+    setupSqliteMocks([1, 2]);
+    const r1 = await aggregateProductViews('2026-05-27');
+    // Reset mocks but keep same product IDs
+    jest.clearAllMocks();
+    setupSqliteMocks([1, 2]);
+    const r2 = await aggregateProductViews('2026-05-27');
+
+    expect(r1).toEqual({ date: '2026-05-27', processed: 2, skipped: 0 });
+    expect(r2).toEqual({ date: '2026-05-27', processed: 2, skipped: 0 });
+  });
+
+  it('can be called twice for the same date without error (PG)', async () => {
+    setupPostgresMocks([1, 2]);
+    const r1 = await aggregateProductViews('2026-05-27');
+    jest.clearAllMocks();
+    setupPostgresMocks([1, 2]);
+    const r2 = await aggregateProductViews('2026-05-27');
+
+    expect(r1).toEqual({ date: '2026-05-27', processed: 2, skipped: 0 });
+    expect(r2).toEqual({ date: '2026-05-27', processed: 2, skipped: 0 });
+  });
+});
+
+// ── Late-arriving records ─────────────────────────────────────────────────────
+
+describe('aggregateProductViews — late-arriving records', () => {
+  it('accepts an explicit past date and queries only that date (SQLite)', async () => {
+    const { distinctStmt, upsertStmt } = setupSqliteMocks([5, 6]);
+    const result = await aggregateProductViews('2026-01-01');
+
+    expect(result).toEqual({ date: '2026-01-01', processed: 2, skipped: 0 });
+    expect(distinctStmt.all).toHaveBeenCalledWith('2026-01-01');
+    expect(upsertStmt.run).toHaveBeenCalledWith('2026-01-01', '2026-01-01', 5);
+    expect(upsertStmt.run).toHaveBeenCalledWith('2026-01-01', '2026-01-01', 6);
+  });
+
+  it('accepts an explicit past date and queries only that date (PG)', async () => {
+    setupPostgresMocks([5, 6]);
+    const result = await aggregateProductViews('2026-01-01');
+
+    expect(result).toEqual({ date: '2026-01-01', processed: 2, skipped: 0 });
+    const distinctCall = db.query.mock.calls[0];
+    expect(distinctCall[1][0]).toBe('2026-01-01');
+  });
+});
+
+// ── Large-volume batching ─────────────────────────────────────────────────────
+
+describe('aggregateProductViews — large-volume batching', () => {
+  it('splits 1200 products into 3 batches of 500/500/200 (SQLite, BATCH_SIZE=500)', async () => {
+    const ids = Array.from({ length: 1200 }, (_, i) => i + 1);
+    const { upsertStmt } = setupSqliteMocks(ids);
+
+    const result = await aggregateProductViews('2026-05-27');
+
+    expect(result).toEqual({ date: '2026-05-27', processed: 1200, skipped: 0 });
+    expect(upsertStmt.run).toHaveBeenCalledTimes(1200);
+    // transaction should have been called 3 times (once per batch)
+    expect(db.transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('splits 600 products into 2 PG batches', async () => {
+    const ids = Array.from({ length: 600 }, (_, i) => i + 1);
+    setupPostgresMocks(ids);
+
+    const result = await aggregateProductViews('2026-05-27');
+
+    expect(result).toEqual({ date: '2026-05-27', processed: 600, skipped: 0 });
+    // 1 DISTINCT query + 2 INSERT batches
+    expect(db.query).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ── Partial failure handling ──────────────────────────────────────────────────
+
+describe('aggregateProductViews — partial batch failure', () => {
+  it('counts failed batch products as skipped and continues (SQLite)', async () => {
+    // 600 products → 2 batches; make the second batch throw
+    const ids = Array.from({ length: 600 }, (_, i) => i + 1);
+    db.isPostgres = false;
+
+    const distinctStmt = { all: jest.fn().mockReturnValue(ids.map((id) => ({ product_id: id }))) };
+    let callCount = 0;
+    const upsertStmt = {
+      run: jest.fn().mockReturnValue({ changes: 1 }),
+    };
+
+    db.prepare.mockImplementation((sql) => {
+      if (sql.includes('DISTINCT product_id')) return distinctStmt;
+      if (sql.includes('INSERT OR REPLACE')) return upsertStmt;
+      return { run: jest.fn(), all: jest.fn().mockReturnValue([]) };
+    });
+
+    // First transaction call succeeds, second throws
+    db.transaction.mockImplementation((fn) => {
+      callCount++;
+      if (callCount === 2) {
+        return () => { throw new Error('Disk full'); };
+      }
+      return (...args) => fn(...args);
+    });
+
+    const result = await aggregateProductViews('2026-05-27');
+
+    expect(result.processed).toBe(500);
+    expect(result.skipped).toBe(100);
+    expect(logger.error).toHaveBeenCalledWith(
+      '[product-views-agg] Batch failed, skipping',
+      expect.objectContaining({ date: '2026-05-27', error: 'Disk full' })
+    );
+  });
+
+  it('counts failed PG batch as skipped and continues', async () => {
+    const ids = Array.from({ length: 600 }, (_, i) => i + 1);
+    db.isPostgres = true;
+
+    let queryCount = 0;
+    db.query.mockImplementation((sql) => {
+      if (sql.includes('DISTINCT product_id')) {
+        return Promise.resolve({ rows: ids.map((id) => ({ product_id: id })) });
+      }
+      queryCount++;
+      if (queryCount === 2) return Promise.reject(new Error('PG timeout'));
+      return Promise.resolve({ rowCount: 500 });
+    });
+
+    const result = await aggregateProductViews('2026-05-27');
+
+    expect(result.processed).toBe(500);
+    expect(result.skipped).toBe(100);
+    expect(logger.error).toHaveBeenCalledWith(
+      '[product-views-agg] Batch failed, skipping',
+      expect.objectContaining({ error: 'PG timeout' })
+    );
+  });
+});
+
+// ── Logging ───────────────────────────────────────────────────────────────────
+
+describe('aggregateProductViews — logging', () => {
+  it('logs start and completion with date and counts', async () => {
+    setupSqliteMocks([1, 2]);
+    await aggregateProductViews('2026-05-27');
+
+    expect(logger.info).toHaveBeenCalledWith(
+      '[product-views-agg] Starting aggregation',
+      { date: '2026-05-27' }
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      '[product-views-agg] Aggregation complete',
+      { date: '2026-05-27', processed: 2, skipped: 0 }
+    );
+  });
+
+  it('logs a specific message when no views exist', async () => {
+    setupSqliteMocks([]);
+    await aggregateProductViews('2026-05-27');
+    expect(logger.info).toHaveBeenCalledWith(
+      '[product-views-agg] No views found, nothing to aggregate',
+      { date: '2026-05-27' }
+    );
+  });
+});
+
+// ── Cron registration ─────────────────────────────────────────────────────────
+
+describe('startProductViewsAggJob', () => {
+  it('registers a cron job at 01:00 UTC', () => {
+    startProductViewsAggJob();
+    expect(cron.schedule).toHaveBeenCalledWith('0 1 * * *', expect.any(Function));
+  });
+
+  it('logs that the job has been scheduled', () => {
+    startProductViewsAggJob();
+    expect(logger.info).toHaveBeenCalledWith(
+      '[product-views-agg] Cron job scheduled (daily at 01:00 UTC)'
+    );
+  });
+});

--- a/backend/src/__tests__/auctions.test.js
+++ b/backend/src/__tests__/auctions.test.js
@@ -1,0 +1,376 @@
+'use strict';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+process.env.NODE_ENV = 'test';
+
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+
+// Mock auth middleware to skip the DB active-user check
+jest.mock('../middleware/auth', () => {
+  const jwt = require('jsonwebtoken');
+  return (req, res, next) => {
+    const token = req.headers.authorization?.split(' ')[1];
+    if (!token) return res.status(401).json({ success: false, code: 'missing_token' });
+    try {
+      req.user = jwt.verify(token, process.env.JWT_SECRET);
+      next();
+    } catch {
+      res.status(401).json({ success: false, code: 'invalid_token' });
+    }
+  };
+});
+
+// Override the global routes mock to include the auctions router
+jest.mock('../routes', () => {
+  const express = require('express');
+  const router = express.Router();
+  router.use('/api/auctions', require('../routes/auctions'));
+  return router;
+});
+
+const app = require('../app');
+const { validateBidRules } = require('../routes/auctions');
+const mockDb = jest.requireMock('../db/schema');
+
+const SECRET = process.env.JWT_SECRET;
+const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
+const buyerToken  = jwt.sign({ id: 2, role: 'buyer'  }, SECRET);
+const buyer2Token = jwt.sign({ id: 3, role: 'buyer'  }, SECRET);
+
+// ─── validateBidRules (pure unit tests) ──────────────────────────────────────
+
+describe('validateBidRules', () => {
+  const base = {
+    id: 1,
+    status: 'active',
+    ends_at: new Date(Date.now() + 60_000).toISOString(),
+    start_price: 10,
+    current_bid: null,
+    min_increment: 0,
+    reserve_price: null,
+    highest_bidder_id: null,
+    farmer_id: 1,
+  };
+
+  it('returns ok:true for a valid first bid above start_price', () => {
+    expect(validateBidRules(base, 2, 15)).toEqual({ ok: true });
+  });
+
+  it('returns not_found when auction is null', () => {
+    const r = validateBidRules(null, 2, 15);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('not_found');
+    expect(r.status).toBe(404);
+  });
+
+  it('returns auction_cancelled for cancelled auction', () => {
+    const r = validateBidRules({ ...base, status: 'cancelled' }, 2, 15);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('auction_cancelled');
+    expect(r.status).toBe(400);
+  });
+
+  it('returns auction_closed for closed auction', () => {
+    const r = validateBidRules({ ...base, status: 'closed' }, 2, 15);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('auction_closed');
+  });
+
+  it('returns auction_ended when ends_at is in the past', () => {
+    const r = validateBidRules(
+      { ...base, ends_at: new Date(Date.now() - 1000).toISOString() },
+      2, 15
+    );
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('auction_ended');
+  });
+
+  it('returns forbidden when farmer bids on own auction', () => {
+    const r = validateBidRules(base, 1, 15); // farmer_id === buyerId
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('forbidden');
+    expect(r.status).toBe(403);
+  });
+
+  it('returns bid_too_low when amount <= start_price (no current_bid)', () => {
+    const r = validateBidRules(base, 2, 10);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('bid_too_low');
+  });
+
+  it('returns bid_too_low when amount <= current_bid', () => {
+    const r = validateBidRules({ ...base, current_bid: 20 }, 2, 20);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('bid_too_low');
+  });
+
+  it('returns bid_below_increment when amount < current_bid + min_increment', () => {
+    const r = validateBidRules({ ...base, current_bid: 20, min_increment: 5 }, 2, 24);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('bid_below_increment');
+  });
+
+  it('accepts bid exactly at current_bid + min_increment', () => {
+    expect(validateBidRules({ ...base, current_bid: 20, min_increment: 5 }, 2, 25)).toEqual({ ok: true });
+  });
+
+  it('returns already_highest when buyer is already highest bidder', () => {
+    const r = validateBidRules({ ...base, current_bid: 20, highest_bidder_id: 2 }, 2, 25);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('already_highest');
+  });
+});
+
+// ─── HTTP endpoints ───────────────────────────────────────────────────────────
+
+const activeAuction = {
+  id: 1,
+  product_id: 10,
+  farmer_id: 1,
+  start_price: 10,
+  reserve_price: null,
+  min_increment: 0,
+  current_bid: null,
+  highest_bidder_id: null,
+  status: 'active',
+  ends_at: new Date(Date.now() + 3_600_000).toISOString(),
+  closed_at: null,
+  created_at: new Date().toISOString(),
+  product_name: 'Tomatoes',
+  description: 'Fresh',
+  unit: 'kg',
+  farmer_name: 'Alice',
+  bid_count: '0',
+};
+
+describe('POST /api/auctions', () => {
+  const body = {
+    product_id: 10,
+    start_price: 10,
+    ends_at: new Date(Date.now() + 3_600_000).toISOString(),
+  };
+
+  it('creates an auction for a farmer who owns the product', async () => {
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 10 }], rowCount: 1 }) // product ownership
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })            // no active auction
+      .mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 }); // INSERT
+
+    const res = await request(app)
+      .post('/api/auctions')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send(body);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.auctionId).toBe(7);
+  });
+
+  it('returns 403 when a buyer tries to create an auction', async () => {
+    const res = await request(app)
+      .post('/api/auctions')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send(body);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).post('/api/auctions').send(body);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when ends_at is missing', async () => {
+    const res = await request(app)
+      .post('/api/auctions')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send({ product_id: 10, start_price: 10 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('returns 400 when ends_at is in the past', async () => {
+    const res = await request(app)
+      .post('/api/auctions')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send({ ...body, ends_at: new Date(Date.now() - 1000).toISOString() });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('returns 400 when start_price is zero', async () => {
+    const res = await request(app)
+      .post('/api/auctions')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send({ ...body, start_price: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when product does not belong to farmer', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // product not found
+    const res = await request(app)
+      .post('/api/auctions')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send(body);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when an active auction already exists for the product', async () => {
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 10 }], rowCount: 1 })  // product found
+      .mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 });  // existing active auction
+    const res = await request(app)
+      .post('/api/auctions')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send(body);
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('conflict');
+  });
+});
+
+describe('GET /api/auctions', () => {
+  it('returns list of active auctions', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [activeAuction], rowCount: 1 });
+    const res = await request(app).get('/api/auctions');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].product_name).toBe('Tomatoes');
+  });
+
+  it('returns empty array when no active auctions', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const res = await request(app).get('/api/auctions');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+});
+
+describe('GET /api/auctions/:id', () => {
+  it('returns auction detail', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [activeAuction], rowCount: 1 });
+    const res = await request(app).get('/api/auctions/1');
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(1);
+  });
+
+  it('returns 404 for unknown auction', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const res = await request(app).get('/api/auctions/999');
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('not_found');
+  });
+});
+
+describe('POST /api/auctions/:id/bid', () => {
+  // SQLite path: db.transaction wraps the bid logic
+  beforeEach(() => {
+    mockDb.isPostgres = false;
+    // transaction mock: immediately invoke the callback
+    mockDb.transaction.mockImplementation((fn) => () => fn());
+  });
+
+  it('places a valid bid', async () => {
+    const auctionRow = { ...activeAuction, farmer_id: 1, current_bid: null, min_increment: 0, highest_bidder_id: null };
+    mockDb.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(auctionRow) }) // SELECT auction
+      .mockReturnValueOnce({ run: jest.fn() })                              // INSERT bid
+      .mockReturnValueOnce({ run: jest.fn() });                             // UPDATE auction
+
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ amount: 15 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.currentBid).toBe(15);
+  });
+
+  it('returns 403 when a farmer tries to bid', async () => {
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send({ amount: 15 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).post('/api/auctions/1/bid').send({ amount: 15 });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when amount is missing', async () => {
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('returns 400 when amount is not positive', async () => {
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ amount: -5 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when auction does not exist', async () => {
+    mockDb.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) });
+    const res = await request(app)
+      .post('/api/auctions/999/bid')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ amount: 15 });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('not_found');
+  });
+
+  it('returns 400 when bid is too low', async () => {
+    const auctionRow = { ...activeAuction, farmer_id: 1, current_bid: 20, min_increment: 0, highest_bidder_id: null };
+    mockDb.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(auctionRow) });
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ amount: 20 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('bid_too_low');
+  });
+
+  it('returns 400 when bid is below min_increment', async () => {
+    const auctionRow = { ...activeAuction, farmer_id: 1, current_bid: 20, min_increment: 5, highest_bidder_id: null };
+    mockDb.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(auctionRow) });
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ amount: 24 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('bid_below_increment');
+  });
+
+  it('returns 400 when buyer is already the highest bidder', async () => {
+    const auctionRow = { ...activeAuction, farmer_id: 1, current_bid: 20, min_increment: 0, highest_bidder_id: 2 };
+    mockDb.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(auctionRow) });
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ amount: 25 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('already_highest');
+  });
+
+  it('returns 403 when auction owner tries to bid', async () => {
+    // farmer_id: 1, buyerId from farmerToken is also 1 — but farmerToken role is 'farmer'
+    // so the role check fires first. Test with a buyer whose id matches farmer_id.
+    const ownerBuyerToken = jwt.sign({ id: 1, role: 'buyer' }, SECRET);
+    const auctionRow = { ...activeAuction, farmer_id: 1, current_bid: null, min_increment: 0, highest_bidder_id: null };
+    mockDb.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(auctionRow) });
+    const res = await request(app)
+      .post('/api/auctions/1/bid')
+      .set('Authorization', `Bearer ${ownerBuyerToken}`)
+      .send({ amount: 15 });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('forbidden');
+  });
+});

--- a/backend/src/__tests__/deactivateExpiredProducts.test.js
+++ b/backend/src/__tests__/deactivateExpiredProducts.test.js
@@ -1,0 +1,315 @@
+'use strict';
+
+jest.mock('node-cron', () => ({ schedule: jest.fn() }));
+
+jest.mock('../../src/db/schema', () => ({
+  prepare: jest.fn(),
+  exec: jest.fn(),
+  transaction: jest.fn(),
+  query: jest.fn(),
+  isPostgres: false,
+}));
+
+jest.mock('../../src/utils/mailer', () => ({
+  sendProductExpiredEmail: jest.fn(),
+  sendOrderEmails: jest.fn(),
+  sendLowStockAlert: jest.fn(),
+  sendStatusUpdateEmail: jest.fn(),
+  sendFreshnessAlert: jest.fn(),
+  sendReturnEmail: jest.fn(),
+  sendContractAlert: jest.fn(),
+  sendBackInStockEmail: jest.fn(),
+}));
+
+jest.mock('../../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const db = require('../../src/db/schema');
+const mailerMock = require('../../src/utils/mailer');
+const { deactivateExpiredProducts, todayUTC } = require('../../src/jobs/deactivateExpiredProducts');
+
+// sendProductExpiredEmail is re-assigned in beforeEach because jest.setup.js
+// calls jest.resetAllMocks() which clears all mock implementations.
+let sendProductExpiredEmail;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeProduct(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Tomatoes',
+    best_before: '2024-01-01',
+    farmer_id: 10,
+    farmer_name: 'Alice',
+    farmer_email: 'alice@farm.com',
+    ...overrides,
+  };
+}
+
+/**
+ * Set up db mocks for SQLite mode (isPostgres=false).
+ *
+ * In SQLite mode:
+ *   - fetchExpiredBatch uses db.prepare().all()
+ *   - processProduct uses db.query() for the UPDATE
+ *
+ * Each call to db.prepare returns the next page of products (first call = products, rest = []).
+ */
+function setupSqliteMocks(products = [], updateRowCount = 1) {
+  let prepareCallCount = 0;
+  db.prepare.mockImplementation(() => {
+    prepareCallCount++;
+    return {
+      all: jest.fn().mockReturnValue(prepareCallCount === 1 ? products : []),
+    };
+  });
+  db.query.mockResolvedValue({ rows: [], rowCount: updateRowCount });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  db.isPostgres = false;
+  // After jest.resetAllMocks(), the mock function still exists but its call
+  // history is cleared. We just need to point our local variable at it.
+  // Do NOT replace mailerMock.sendProductExpiredEmail with a new jest.fn() —
+  // the job module captured the original reference at require time.
+  sendProductExpiredEmail = mailerMock.sendProductExpiredEmail;
+});
+
+describe('todayUTC', () => {
+  it('returns YYYY-MM-DD format', () => {
+    const result = todayUTC(new Date('2024-06-15T10:30:00Z'));
+    expect(result).toBe('2024-06-15');
+  });
+
+  it('uses UTC date, not local time', () => {
+    const result = todayUTC(new Date('2024-06-15T00:30:00Z'));
+    expect(result).toBe('2024-06-15');
+  });
+
+  it('defaults to current date when no argument given', () => {
+    const result = todayUTC();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('deactivateExpiredProducts', () => {
+  it('returns zero counts when no expired products exist', async () => {
+    setupSqliteMocks([]);
+    const result = await deactivateExpiredProducts('2024-06-01');
+    expect(result).toEqual({ date: '2024-06-01', deactivated: 0, notified: 0, skipped: 0 });
+    expect(sendProductExpiredEmail).not.toHaveBeenCalled();
+  });
+
+  it('deactivates an expired product and sends notification', async () => {
+    const product = makeProduct();
+    setupSqliteMocks([product]);
+
+    const result = await deactivateExpiredProducts('2024-06-01');
+
+    expect(result.deactivated).toBe(1);
+    expect(result.notified).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(sendProductExpiredEmail).toHaveBeenCalledWith({
+      product: { id: 1, name: 'Tomatoes', best_before: '2024-01-01' },
+      farmer: { name: 'Alice', email: 'alice@farm.com' },
+    });
+  });
+
+  it('uses the provided date as cutoff', async () => {
+    setupSqliteMocks([]);
+    const result = await deactivateExpiredProducts('2025-12-31');
+    expect(result.date).toBe('2025-12-31');
+  });
+
+  it('defaults to todayUTC when no date provided', async () => {
+    setupSqliteMocks([]);
+    const result = await deactivateExpiredProducts();
+    expect(result.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  describe('idempotency', () => {
+    it('skips products already processed (UPDATE returns rowCount=0)', async () => {
+      const product = makeProduct();
+      setupSqliteMocks([product], 0); // UPDATE affects 0 rows → already processed
+
+      await deactivateExpiredProducts('2024-06-01');
+
+      // Email must NOT be sent when UPDATE returns 0 (already processed)
+      expect(sendProductExpiredEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not send duplicate emails on re-run', async () => {
+      const product = makeProduct();
+
+      // First run: UPDATE succeeds
+      setupSqliteMocks([product], 1);
+      await deactivateExpiredProducts('2024-06-01');
+      expect(sendProductExpiredEmail).toHaveBeenCalledTimes(1);
+
+      // Second run: UPDATE returns 0 (already processed)
+      jest.clearAllMocks();
+      setupSqliteMocks([product], 0);
+      await deactivateExpiredProducts('2024-06-01');
+      expect(sendProductExpiredEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('missing farmer email', () => {
+    it('deactivates product but skips email when farmer_email is null', async () => {
+      const product = makeProduct({ farmer_email: null });
+      setupSqliteMocks([product]);
+
+      const result = await deactivateExpiredProducts('2024-06-01');
+
+      expect(result.deactivated).toBe(1);
+      expect(result.notified).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(sendProductExpiredEmail).not.toHaveBeenCalled();
+    });
+
+    it('deactivates product but skips email when farmer_email is empty string', async () => {
+      const product = makeProduct({ farmer_email: '' });
+      setupSqliteMocks([product]);
+
+      const result = await deactivateExpiredProducts('2024-06-01');
+
+      expect(result.notified).toBe(0);
+      expect(sendProductExpiredEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('increments skipped when db UPDATE throws', async () => {
+      const product = makeProduct();
+      let prepareCallCount = 0;
+      db.prepare.mockImplementation(() => {
+        prepareCallCount++;
+        return { all: jest.fn().mockReturnValue(prepareCallCount === 1 ? [product] : []) };
+      });
+      db.query.mockRejectedValue(new Error('DB error'));
+
+      const result = await deactivateExpiredProducts('2024-06-01');
+
+      expect(result.skipped).toBe(1);
+      expect(result.deactivated).toBe(0);
+      expect(sendProductExpiredEmail).not.toHaveBeenCalled();
+    });
+
+    it('increments skipped when email sending throws', async () => {
+      const product = makeProduct();
+      setupSqliteMocks([product], 1);
+      sendProductExpiredEmail.mockRejectedValue(new Error('SMTP error'));
+
+      const result = await deactivateExpiredProducts('2024-06-01');
+
+      expect(result.skipped).toBe(1);
+    });
+
+    it('continues processing remaining products after one failure', async () => {
+      const p1 = makeProduct({ id: 1 });
+      const p2 = makeProduct({ id: 2, name: 'Carrots' });
+      let prepareCallCount = 0;
+      db.prepare.mockImplementation(() => {
+        prepareCallCount++;
+        return { all: jest.fn().mockReturnValue(prepareCallCount === 1 ? [p1, p2] : []) };
+      });
+      let updateCallCount = 0;
+      db.query.mockImplementation(async () => {
+        updateCallCount++;
+        if (updateCallCount === 1) throw new Error('DB error on first');
+        return { rows: [], rowCount: 1 };
+      });
+
+      const result = await deactivateExpiredProducts('2024-06-01');
+
+      expect(result.skipped).toBe(1);
+      expect(result.deactivated).toBe(1);
+    });
+  });
+
+  describe('batching', () => {
+    it('processes all products in a batch', async () => {
+      const products = [makeProduct({ id: 1 }), makeProduct({ id: 2, name: 'Carrots' })];
+      let prepareCallCount = 0;
+      db.prepare.mockImplementation(() => {
+        prepareCallCount++;
+        return { all: jest.fn().mockReturnValue(prepareCallCount === 1 ? products : []) };
+      });
+      db.query.mockResolvedValue({ rows: [], rowCount: 1 });
+
+      const result = await deactivateExpiredProducts('2024-06-01');
+
+      expect(result.deactivated).toBe(2);
+      expect(result.notified).toBe(2);
+      expect(sendProductExpiredEmail).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('timezone handling', () => {
+    it('passes the cutoff date to the SQL query', async () => {
+      setupSqliteMocks([]);
+      await deactivateExpiredProducts('2024-06-15');
+
+      // Verify db.prepare was called with SQL containing the cutoff
+      const prepareCall = db.prepare.mock.calls[0];
+      expect(prepareCall).toBeDefined();
+      // The .all() call should receive the cutoff as first arg
+      const allMock = db.prepare.mock.results[0].value.all;
+      expect(allMock).toHaveBeenCalledWith('2024-06-15', expect.any(Number), expect.any(Number));
+    });
+
+    it('todayUTC returns correct UTC date regardless of local timezone', () => {
+      // Midnight UTC on Jan 1 — should be Jan 1, not Dec 31
+      expect(todayUTC(new Date('2024-01-01T00:00:00Z'))).toBe('2024-01-01');
+      // Just before midnight UTC — still Dec 31
+      expect(todayUTC(new Date('2023-12-31T23:59:59Z'))).toBe('2023-12-31');
+    });
+  });
+
+  describe('PostgreSQL mode', () => {
+    beforeEach(() => {
+      db.isPostgres = true;
+    });
+
+    afterEach(() => {
+      db.isPostgres = false;
+    });
+
+    it('deactivates and notifies in postgres mode', async () => {
+      const product = makeProduct();
+      let queryCallCount = 0;
+      db.query.mockImplementation(async (sql) => {
+        const s = sql.trim().toUpperCase();
+        if (s.startsWith('SELECT')) {
+          queryCallCount++;
+          return { rows: queryCallCount === 1 ? [product] : [], rowCount: 0 };
+        }
+        return { rows: [], rowCount: 1 };
+      });
+
+      const result = await deactivateExpiredProducts('2024-06-01');
+
+      expect(result.deactivated).toBe(1);
+      expect(result.notified).toBe(1);
+      expect(sendProductExpiredEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses $1 placeholders in postgres mode', async () => {
+      db.query.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      await deactivateExpiredProducts('2024-06-01');
+
+      const selectCall = db.query.mock.calls.find(([sql]) =>
+        sql.trim().toUpperCase().startsWith('SELECT')
+      );
+      expect(selectCall).toBeDefined();
+      expect(selectCall[0]).toContain('$1');
+    });
+  });
+});

--- a/backend/src/__tests__/processSubscriptions.test.js
+++ b/backend/src/__tests__/processSubscriptions.test.js
@@ -1,0 +1,292 @@
+'use strict';
+
+/**
+ * Tests for processSubscriptions.js
+ *
+ * Mocks: db/schema, utils/stellar, utils/idempotency, routes/subscriptions, logger
+ */
+
+jest.mock('node-cron', () => ({ schedule: jest.fn() }));
+
+jest.mock('../../src/db/schema', () => ({
+  prepare: jest.fn(),
+  transaction: jest.fn(),
+  query: jest.fn(),
+  isPostgres: false,
+}));
+
+jest.mock('../../src/utils/stellar', () => ({
+  sendPayment: jest.fn(),
+  createWallet: jest.fn(),
+  createWalletFromMnemonic: jest.fn(),
+  deriveKeypairFromMnemonic: jest.fn(),
+  getBalance: jest.fn(),
+  getTransactions: jest.fn(),
+  fundTestnetAccount: jest.fn(),
+  createClaimableBalance: jest.fn(),
+  createPreorderClaimableBalance: jest.fn(),
+  claimBalance: jest.fn(),
+  simulateContractCall: jest.fn(),
+  getContractWasmHash: jest.fn(),
+  isTestnet: true,
+}));
+
+jest.mock('../../src/routes/subscriptions', () => ({
+  nextOrderDate: jest.fn(() => '2099-01-01T00:00:00.000Z'),
+}));
+
+jest.mock('../../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const db = require('../../src/db/schema');
+const { sendPayment } = require('../../src/utils/stellar');
+const { nextOrderDate } = require('../../src/routes/subscriptions');
+const { processSubscriptions } = require('../../src/jobs/processSubscriptions');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSub(overrides = {}) {
+  return {
+    id: 1,
+    buyer_id: 10,
+    product_id: 20,
+    quantity: 2,
+    frequency: 'weekly',
+    next_order_at: '2020-01-01T00:00:00.000Z',
+    status: 'active',
+    retry_count: 0,
+    retry_after: null,
+    price: 5,
+    product_name: 'Apples',
+    buyer_wallet: 'GBUYER',
+    buyer_secret: 'SBUYER',
+    farmer_wallet: 'GFARMER',
+    ...overrides,
+  };
+}
+
+function setupDbMocks({ sub, currentStatus = 'active', currentRetryCount = 0, stockOk = true, idempotencyRows = [] } = {}) {
+  const theSub = sub || makeSub();
+
+  // db.query for idempotency check
+  db.query.mockResolvedValue({ rows: idempotencyRows, rowCount: idempotencyRows.length });
+
+  // db.prepare chains
+  const prepareMap = {};
+
+  // SELECT due subscriptions
+  prepareMap.due = { all: jest.fn().mockReturnValue([theSub]) };
+
+  // SELECT current status
+  prepareMap.current = {
+    get: jest.fn().mockReturnValue({ status: currentStatus, retry_count: currentRetryCount }),
+  };
+
+  // Stock update
+  prepareMap.stockDecrement = {
+    run: jest.fn().mockReturnValue({ changes: stockOk ? 1 : 0 }),
+  };
+
+  // INSERT order
+  prepareMap.insertOrder = {
+    run: jest.fn().mockReturnValue({ lastInsertRowid: 99 }),
+  };
+
+  // UPDATE order status
+  prepareMap.updateOrder = { run: jest.fn() };
+
+  // UPDATE subscriptions next_order_at
+  prepareMap.updateSubSuccess = { run: jest.fn() };
+
+  // UPDATE order failed
+  prepareMap.updateOrderFailed = { run: jest.fn() };
+
+  // Stock restore
+  prepareMap.stockRestore = { run: jest.fn() };
+
+  // UPDATE subscriptions failed/retry
+  prepareMap.updateSubFailed = { run: jest.fn() };
+  prepareMap.updateSubRetry = { run: jest.fn() };
+
+  // SELECT idempotency fallback (orders table)
+  prepareMap.orderCheck = { get: jest.fn().mockReturnValue(null) };
+
+  db.prepare.mockImplementation((sql) => {
+    const s = sql.replace(/\s+/g, ' ').trim();
+    if (s.includes('WHERE s.status') && s.includes('next_order_at')) return prepareMap.due;
+    if (s.startsWith('SELECT status, retry_count')) return prepareMap.current;
+    if (s.startsWith('UPDATE products SET quantity = quantity -')) return prepareMap.stockDecrement;
+    if (s.startsWith('INSERT INTO orders')) return prepareMap.insertOrder;
+    if (s.startsWith('UPDATE orders SET status = ?, stellar_tx_hash')) return prepareMap.updateOrder;
+    if (s.startsWith('UPDATE subscriptions SET next_order_at')) return prepareMap.updateSubSuccess;
+    if (s.startsWith('UPDATE orders SET status = ?') && !s.includes('stellar_tx_hash')) return prepareMap.updateOrderFailed;
+    if (s.startsWith('UPDATE products SET quantity = quantity +')) return prepareMap.stockRestore;
+    if (s.includes("status = 'failed'")) return prepareMap.updateSubFailed;
+    if (s.startsWith('UPDATE subscriptions SET retry_count')) return prepareMap.updateSubRetry;
+    if (s.startsWith('SELECT id FROM orders')) return prepareMap.orderCheck;
+    return { run: jest.fn(), get: jest.fn(), all: jest.fn().mockReturnValue([]) };
+  });
+
+  // transaction executes the callback immediately
+  db.transaction.mockImplementation((fn) => (...args) => fn(...args));
+
+  return prepareMap;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Restore nextOrderDate after jest.setup.js resetAllMocks
+  nextOrderDate.mockReturnValue('2099-01-01T00:00:00.000Z');
+});
+
+describe('processSubscriptions', () => {
+  it('does nothing when no subscriptions are due', async () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) });
+    await processSubscriptions();
+    expect(sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('processes a successful renewal', async () => {
+    const maps = setupDbMocks();
+    sendPayment.mockResolvedValue('TXHASH_OK');
+
+    await processSubscriptions();
+
+    expect(sendPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senderSecret: 'SBUYER',
+        receiverPublicKey: 'GFARMER',
+        amount: 10, // 5 * 2
+        memo: 'Sub#1',
+      })
+    );
+    expect(maps.updateOrder.run).toHaveBeenCalledWith('paid', 'TXHASH_OK', 99);
+    expect(maps.updateSubSuccess.run).toHaveBeenCalledWith('2099-01-01T00:00:00.000Z', 1);
+  });
+
+  it('skips subscriptions that are not active', async () => {
+    setupDbMocks({ currentStatus: 'paused' });
+    await processSubscriptions();
+    expect(sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('skips cancelled subscriptions', async () => {
+    setupDbMocks({ currentStatus: 'cancelled' });
+    await processSubscriptions();
+    expect(sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('skips already-processed subscriptions (idempotency key found)', async () => {
+    setupDbMocks({ idempotencyRows: [{ id: 'existing-key' }] });
+    await processSubscriptions();
+    expect(sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('skips when paid order already exists (fallback idempotency)', async () => {
+    // db.query throws (no idempotency_keys table), fallback to orders check
+    const maps = setupDbMocks();
+    db.query.mockRejectedValue(new Error('no such table'));
+    maps.orderCheck.get.mockReturnValue({ id: 55 }); // paid order found
+    await processSubscriptions();
+    expect(sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('skips when stock is insufficient', async () => {
+    setupDbMocks({ stockOk: false });
+    await processSubscriptions();
+    expect(sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('schedules retry on transient payment failure', async () => {
+    const maps = setupDbMocks();
+    const transientErr = new Error('Network timeout');
+    sendPayment.mockRejectedValue(transientErr);
+
+    await processSubscriptions();
+
+    expect(maps.updateOrderFailed.run).toHaveBeenCalledWith('failed', 99);
+    expect(maps.stockRestore.run).toHaveBeenCalledWith(2, 20);
+    expect(maps.updateSubRetry.run).toHaveBeenCalledWith(1, expect.any(String), 1);
+    expect(maps.updateSubFailed.run).not.toHaveBeenCalled();
+  });
+
+  it('marks subscription as failed on permanent error: account_not_found', async () => {
+    const maps = setupDbMocks();
+    const permErr = new Error('Account not found');
+    permErr.code = 'account_not_found';
+    sendPayment.mockRejectedValue(permErr);
+
+    await processSubscriptions();
+
+    expect(maps.updateSubFailed.run).toHaveBeenCalledWith(1, 1);
+    expect(maps.updateSubRetry.run).not.toHaveBeenCalled();
+  });
+
+  it('marks subscription as failed on permanent error: insufficient balance message', async () => {
+    const maps = setupDbMocks();
+    const permErr = new Error('insufficient balance to pay fees');
+    sendPayment.mockRejectedValue(permErr);
+
+    await processSubscriptions();
+
+    expect(maps.updateSubFailed.run).toHaveBeenCalledWith(1, 1);
+  });
+
+  it('marks subscription as failed when retry count is exhausted', async () => {
+    const maps = setupDbMocks({ currentRetryCount: 3 }); // MAX_RETRIES=3, so 3+1 > 3
+    const transientErr = new Error('Network timeout');
+    sendPayment.mockRejectedValue(transientErr);
+
+    await processSubscriptions();
+
+    expect(maps.updateSubFailed.run).toHaveBeenCalledWith(4, 1);
+    expect(maps.updateSubRetry.run).not.toHaveBeenCalled();
+  });
+
+  it('does not double-charge on duplicate execution (second run skips via idempotency)', async () => {
+    // First run succeeds
+    const maps = setupDbMocks();
+    sendPayment.mockResolvedValue('TXHASH_OK');
+    await processSubscriptions();
+    expect(sendPayment).toHaveBeenCalledTimes(1);
+
+    // Second run: idempotency key now present
+    jest.clearAllMocks();
+    setupDbMocks({ idempotencyRows: [{ id: 'key' }] });
+    await processSubscriptions();
+    expect(sendPayment).not.toHaveBeenCalled();
+  });
+
+  it('resets retry_count to 0 after successful payment', async () => {
+    const maps = setupDbMocks({ currentRetryCount: 2 });
+    sendPayment.mockResolvedValue('TXHASH_OK');
+
+    await processSubscriptions();
+
+    expect(maps.updateSubSuccess.run).toHaveBeenCalledWith('2099-01-01T00:00:00.000Z', 1);
+  });
+
+  it('does not expose buyer_secret in logs', async () => {
+    const logger = require('../../src/logger');
+    setupDbMocks();
+    const permErr = new Error('account_not_found');
+    permErr.code = 'account_not_found';
+    sendPayment.mockRejectedValue(permErr);
+
+    await processSubscriptions();
+
+    const allLogCalls = [
+      ...logger.info.mock.calls,
+      ...logger.warn.mock.calls,
+      ...logger.error.mock.calls,
+    ].flat();
+
+    const logStr = JSON.stringify(allLogCalls);
+    expect(logStr).not.toContain('SBUYER');
+  });
+});

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,6 +3,7 @@ const app = require('./app');
 const logger = require('./logger');
 const cron = require('node-cron');
 const { startSubscriptionJob } = require('./jobs/processSubscriptions');
+const { startProductViewsAggJob } = require('./jobs/aggregateProductViews');
 const { startFreshnessJob } = require('./jobs/processFreshnessAlerts');
 const { startContractMonitor } = require('./jobs/contractMonitor');
 const { startPushSubscriptionCleanup } = require('./jobs/cleanupPushSubscriptions');
@@ -12,6 +13,7 @@ const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {
   logger.info(`Backend running on http://localhost:${PORT}`);
   startSubscriptionJob();
+  startProductViewsAggJob();
   startFreshnessJob();
   startContractMonitor();
   startPushSubscriptionCleanup();

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ const { startProductViewsAggJob } = require('./jobs/aggregateProductViews');
 const { startFreshnessJob } = require('./jobs/processFreshnessAlerts');
 const { startContractMonitor } = require('./jobs/contractMonitor');
 const { startPushSubscriptionCleanup } = require('./jobs/cleanupPushSubscriptions');
+const { startExpiryJob } = require('./jobs/deactivateExpiredProducts');
 const { createBackup } = require('./scripts/backup');
 const PORT = process.env.PORT || 4000;
 
@@ -17,6 +18,7 @@ app.listen(PORT, () => {
   startFreshnessJob();
   startContractMonitor();
   startPushSubscriptionCleanup();
+  startExpiryJob();
   
   // Schedule daily backup at midnight
   cron.schedule('0 0 * * *', async () => {

--- a/backend/src/jobs/aggregateProductViews.js
+++ b/backend/src/jobs/aggregateProductViews.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const cron = require('node-cron');
+const db = require('../db/schema');
+const logger = require('../logger');
+
+/**
+ * Returns the ISO date string (YYYY-MM-DD) for a given Date, defaulting to yesterday.
+ * Accepting an explicit date makes the function testable without time-travel.
+ */
+function targetDate(d = new Date()) {
+  const dt = new Date(d);
+  dt.setUTCDate(dt.getUTCDate() - 1);
+  return dt.toISOString().slice(0, 10);
+}
+
+/**
+ * Aggregate product_views for a single date into product_view_summaries.
+ *
+ * Idempotent: uses INSERT … ON CONFLICT DO UPDATE (PG) / INSERT OR REPLACE (SQLite)
+ * so reruns for the same date safely overwrite stale data.
+ *
+ * Batching: processes products in chunks of BATCH_SIZE to avoid full-table scans
+ * and keep memory usage bounded on large datasets.
+ *
+ * @param {string} [date] - ISO date string YYYY-MM-DD; defaults to yesterday.
+ * @returns {Promise<{date: string, processed: number, skipped: number}>}
+ */
+async function aggregateProductViews(date) {
+  const aggDate = date || targetDate();
+  const BATCH_SIZE = parseInt(process.env.VIEWS_AGG_BATCH_SIZE || '500', 10);
+
+  logger.info('[product-views-agg] Starting aggregation', { date: aggDate });
+
+  // Fetch distinct product IDs that have views on the target date.
+  // Using a targeted date-range query avoids a full scan of product_views.
+  let productIds;
+  if (db.isPostgres) {
+    const { rows } = await db.query(
+      `SELECT DISTINCT product_id
+       FROM product_views
+       WHERE viewed_at >= $1::date AND viewed_at < ($1::date + INTERVAL '1 day')`,
+      [aggDate]
+    );
+    productIds = rows.map((r) => r.product_id);
+  } else {
+    productIds = db
+      .prepare(
+        `SELECT DISTINCT product_id
+         FROM product_views
+         WHERE date(viewed_at) = ?`
+      )
+      .all(aggDate)
+      .map((r) => r.product_id);
+  }
+
+  if (productIds.length === 0) {
+    logger.info('[product-views-agg] No views found, nothing to aggregate', { date: aggDate });
+    return { date: aggDate, processed: 0, skipped: 0 };
+  }
+
+  logger.info('[product-views-agg] Products to aggregate', {
+    date: aggDate,
+    count: productIds.length,
+  });
+
+  let processed = 0;
+  let skipped = 0;
+
+  // Process in batches to keep memory bounded
+  for (let offset = 0; offset < productIds.length; offset += BATCH_SIZE) {
+    const batch = productIds.slice(offset, offset + BATCH_SIZE);
+
+    try {
+      await aggregateBatch(batch, aggDate);
+      processed += batch.length;
+    } catch (err) {
+      logger.error('[product-views-agg] Batch failed, skipping', {
+        date: aggDate,
+        batchOffset: offset,
+        batchSize: batch.length,
+        error: err.message,
+      });
+      skipped += batch.length;
+    }
+  }
+
+  logger.info('[product-views-agg] Aggregation complete', { date: aggDate, processed, skipped });
+  return { date: aggDate, processed, skipped };
+}
+
+/**
+ * Aggregate a batch of product IDs for the given date and upsert into the summary table.
+ * Wrapped in a transaction so a partial batch failure leaves no partial writes.
+ */
+async function aggregateBatch(productIds, aggDate) {
+  if (db.isPostgres) {
+    // Build a single query that aggregates all products in the batch at once,
+    // then upserts the results.
+    const placeholders = productIds.map((_, i) => `$${i + 2}`).join(', ');
+    await db.query(
+      `INSERT INTO product_view_summaries (product_id, view_date, view_count, unique_viewers, aggregated_at)
+       SELECT product_id,
+              $1::date                                AS view_date,
+              COUNT(*)                                AS view_count,
+              COUNT(DISTINCT COALESCE(user_id, -id))  AS unique_viewers,
+              NOW()                                   AS aggregated_at
+       FROM product_views
+       WHERE viewed_at >= $1::date
+         AND viewed_at < ($1::date + INTERVAL '1 day')
+         AND product_id IN (${placeholders})
+       GROUP BY product_id
+       ON CONFLICT (product_id, view_date)
+       DO UPDATE SET
+         view_count     = EXCLUDED.view_count,
+         unique_viewers = EXCLUDED.unique_viewers,
+         aggregated_at  = EXCLUDED.aggregated_at`,
+      [aggDate, ...productIds]
+    );
+  } else {
+    // SQLite: use a transaction with individual INSERT OR REPLACE per product
+    // to stay within parameter limits and keep the logic simple.
+    const upsert = db.prepare(
+      `INSERT OR REPLACE INTO product_view_summaries
+         (product_id, view_date, view_count, unique_viewers, aggregated_at)
+       SELECT product_id,
+              date(?) AS view_date,
+              COUNT(*) AS view_count,
+              COUNT(DISTINCT COALESCE(user_id, -id)) AS unique_viewers,
+              datetime('now') AS aggregated_at
+       FROM product_views
+       WHERE date(viewed_at) = ? AND product_id = ?
+       GROUP BY product_id`
+    );
+
+    db.transaction(() => {
+      for (const pid of productIds) {
+        upsert.run(aggDate, aggDate, pid);
+      }
+    })();
+  }
+}
+
+function startProductViewsAggJob() {
+  // Run daily at 01:00 UTC (after midnight, after the backup job at 00:00)
+  cron.schedule('0 1 * * *', () => {
+    aggregateProductViews().catch((e) =>
+      logger.error('[product-views-agg] Job error', { message: e.message })
+    );
+  });
+  logger.info('[product-views-agg] Cron job scheduled (daily at 01:00 UTC)');
+}
+
+module.exports = { startProductViewsAggJob, aggregateProductViews, targetDate };

--- a/backend/src/jobs/deactivateExpiredProducts.js
+++ b/backend/src/jobs/deactivateExpiredProducts.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const cron = require('node-cron');
+const db = require('../db/schema');
+const logger = require('../logger');
+const { sendProductExpiredEmail } = require('../utils/mailer');
+
+const BATCH_SIZE = parseInt(process.env.EXPIRY_BATCH_SIZE || '100', 10);
+
+/**
+ * Returns the UTC date string (YYYY-MM-DD) for the given Date, defaulting to today.
+ * Accepting an explicit date makes the function testable without time-travel.
+ */
+function todayUTC(d = new Date()) {
+  return new Date(d).toISOString().slice(0, 10);
+}
+
+/**
+ * Deactivate all active products whose best_before < today (UTC) and send
+ * one expiry notification email per product to the owning farmer.
+ *
+ * Idempotency: the UPDATE only touches rows where active=1 AND expiry_notified_at IS NULL,
+ * so reruns are safe — already-processed products are skipped automatically.
+ *
+ * Batching: fetches products in pages of BATCH_SIZE to keep memory bounded.
+ *
+ * @param {string} [date] - ISO date string YYYY-MM-DD; defaults to today UTC.
+ * @returns {Promise<{date: string, deactivated: number, notified: number, skipped: number}>}
+ */
+async function deactivateExpiredProducts(date) {
+  const cutoff = date || todayUTC();
+  logger.info('[expiry-job] Starting expired product deactivation', { cutoff });
+
+  let deactivated = 0;
+  let notified = 0;
+  let skipped = 0;
+  let offset = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const batch = await fetchExpiredBatch(cutoff, offset, BATCH_SIZE);
+    if (batch.length === 0) break;
+
+    for (const product of batch) {
+      try {
+        await processProduct(product, cutoff);
+        deactivated++;
+        if (product.farmer_email) {
+          notified++;
+        } else {
+          logger.warn('[expiry-job] Farmer email missing, skipping notification', {
+            productId: product.id,
+            farmerId: product.farmer_id,
+          });
+        }
+      } catch (err) {
+        logger.error('[expiry-job] Failed to process product', {
+          productId: product.id,
+          error: err.message,
+        });
+        skipped++;
+      }
+    }
+
+    // If we got fewer than BATCH_SIZE, we've reached the end
+    if (batch.length < BATCH_SIZE) break;
+    offset += BATCH_SIZE;
+  }
+
+  logger.info('[expiry-job] Deactivation complete', { cutoff, deactivated, notified, skipped });
+  return { date: cutoff, deactivated, notified, skipped };
+}
+
+/**
+ * Fetch a page of active, expired, not-yet-notified products with farmer info.
+ */
+async function fetchExpiredBatch(cutoff, offset, limit) {
+  if (db.isPostgres) {
+    const { rows } = await db.query(
+      `SELECT p.id, p.name, p.best_before, p.farmer_id,
+              u.name AS farmer_name, u.email AS farmer_email
+       FROM products p
+       JOIN users u ON p.farmer_id = u.id
+       WHERE p.active = true
+         AND p.best_before < $1::date
+         AND p.expiry_notified_at IS NULL
+       ORDER BY p.id
+       LIMIT $2 OFFSET $3`,
+      [cutoff, limit, offset]
+    );
+    return rows;
+  } else {
+    return db
+      .prepare(
+        `SELECT p.id, p.name, p.best_before, p.farmer_id,
+                u.name AS farmer_name, u.email AS farmer_email
+         FROM products p
+         JOIN users u ON p.farmer_id = u.id
+         WHERE p.active = 1
+           AND p.best_before < ?
+           AND p.expiry_notified_at IS NULL
+         ORDER BY p.id
+         LIMIT ? OFFSET ?`
+      )
+      .all(cutoff, limit, offset);
+  }
+}
+
+/**
+ * Atomically deactivate a single product and mark it notified, then send email.
+ * The UPDATE uses a WHERE clause that re-checks the idempotency guard so concurrent
+ * runs cannot double-process the same row.
+ */
+async function processProduct(product, cutoff) {
+  const now = new Date().toISOString();
+
+  let updated;
+  if (db.isPostgres) {
+    const { rowCount } = await db.query(
+      `UPDATE products
+       SET active = false, expiry_notified_at = $1
+       WHERE id = $2
+         AND active = true
+         AND best_before < $3::date
+         AND expiry_notified_at IS NULL`,
+      [now, product.id, cutoff]
+    );
+    updated = rowCount;
+  } else {
+    const { rowCount } = await db.query(
+      `UPDATE products
+       SET active = 0, expiry_notified_at = ?
+       WHERE id = ?
+         AND active = 1
+         AND best_before < ?
+         AND expiry_notified_at IS NULL`,
+      [now, product.id, cutoff]
+    );
+    updated = rowCount;
+  }
+
+  if (updated === 0) {
+    // Another concurrent run already processed this product — skip silently
+    logger.debug('[expiry-job] Product already processed, skipping', { productId: product.id });
+    return;
+  }
+
+  logger.info('[expiry-job] Product deactivated', {
+    productId: product.id,
+    bestBefore: product.best_before,
+  });
+
+  if (product.farmer_email) {
+    await sendProductExpiredEmail({
+      product: { id: product.id, name: product.name, best_before: product.best_before },
+      farmer: { name: product.farmer_name, email: product.farmer_email },
+    });
+  }
+}
+
+function startExpiryJob() {
+  // Run daily at 02:00 UTC
+  cron.schedule('0 2 * * *', () => {
+    deactivateExpiredProducts().catch((err) =>
+      logger.error('[expiry-job] Job error', { message: err.message })
+    );
+  }, { timezone: 'UTC' });
+  logger.info('[expiry-job] Cron job scheduled (daily at 02:00 UTC)');
+}
+
+module.exports = { startExpiryJob, deactivateExpiredProducts, todayUTC };

--- a/backend/src/jobs/processSubscriptions.js
+++ b/backend/src/jobs/processSubscriptions.js
@@ -1,64 +1,146 @@
+'use strict';
+
 const cron = require('node-cron');
 const logger = require('../logger');
 const db = require('../db/schema');
 const { sendPayment } = require('../utils/stellar');
 const { nextOrderDate } = require('../routes/subscriptions');
-const { getCachedResponse, cacheResponse } = require('../utils/idempotency');
+
+const MAX_RETRIES = parseInt(process.env.SUBSCRIPTION_MAX_RETRIES || '3', 10);
+const RETRY_DELAY_MINUTES = parseInt(process.env.SUBSCRIPTION_RETRY_DELAY_MINUTES || '60', 10);
+
+/** Errors that should not be retried — transition subscription to 'failed'. */
+const PERMANENT_ERROR_CODES = new Set(['account_not_found', 'insufficient_balance']);
+
+function isPermanentError(err) {
+  if (PERMANENT_ERROR_CODES.has(err.code)) return true;
+  const msg = (err.message || '').toLowerCase();
+  return msg.includes('insufficient balance') || msg.includes('account merge');
+}
+
+function retryAfterDate() {
+  const d = new Date();
+  d.setMinutes(d.getMinutes() + RETRY_DELAY_MINUTES);
+  return d.toISOString();
+}
+
+/**
+ * Idempotency key scoped to subscription + renewal cycle.
+ * Using next_order_at ensures a new key per billing period.
+ */
+function idempotencyKey(sub) {
+  return `sub_payment_${sub.id}_${sub.next_order_at}`;
+}
+
+/**
+ * Lightweight in-process idempotency store (survives within a single run).
+ * Durable idempotency is enforced by the order row (status='paid') and
+ * the idempotency_keys table via db.query when available.
+ */
+async function isAlreadyProcessed(sub) {
+  // Check for an existing paid order for this subscription cycle
+  const key = idempotencyKey(sub);
+  try {
+    const { rows } = await db.query(
+      `SELECT id FROM idempotency_keys WHERE key = $1 AND expires_at > $2`,
+      [key, new Date().toISOString()]
+    );
+    return rows.length > 0;
+  } catch {
+    // Fallback: check orders table for a paid order in this cycle
+    const row = db
+      .prepare(
+        `SELECT id FROM orders
+         WHERE buyer_id = ? AND product_id = ? AND status = 'paid'
+           AND created_at >= ?`
+      )
+      .get(sub.buyer_id, sub.product_id, sub.next_order_at);
+    return !!row;
+  }
+}
+
+async function markProcessed(sub) {
+  const key = idempotencyKey(sub);
+  const expiresAt = new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString(); // 25h TTL
+  try {
+    await db.query(
+      `INSERT INTO idempotency_keys (key, response, expires_at)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (key) DO UPDATE SET response = EXCLUDED.response, expires_at = EXCLUDED.expires_at`,
+      [key, JSON.stringify({ success: true }), expiresAt]
+    );
+  } catch {
+    // Non-fatal: idempotency_keys table may not exist in all environments
+  }
+}
 
 async function processSubscriptions() {
   const now = new Date().toISOString();
+
   const due = db
     .prepare(
-      `
-    SELECT s.*, u.stellar_public_key as buyer_wallet, u.stellar_secret_key as buyer_secret,
-           p.price, p.name as product_name,
-           fu.stellar_public_key as farmer_wallet
-    FROM subscriptions s
-    JOIN users u ON s.buyer_id = u.id
-    JOIN products p ON s.product_id = p.id
-    JOIN users fu ON p.farmer_id = fu.id
-    WHERE s.status = 'active' AND s.next_order_at <= ?
-  `
+      `SELECT s.*,
+              u.stellar_public_key  AS buyer_wallet,
+              u.stellar_secret_key  AS buyer_secret,
+              p.price,
+              p.name                AS product_name,
+              fu.stellar_public_key AS farmer_wallet
+       FROM subscriptions s
+       JOIN users    u  ON s.buyer_id   = u.id
+       JOIN products p  ON s.product_id = p.id
+       JOIN users    fu ON p.farmer_id  = fu.id
+       WHERE s.status = 'active'
+         AND s.next_order_at <= ?
+         AND (s.retry_after IS NULL OR s.retry_after <= ?)`
     )
-    .all(now);
+    .all(now, now);
 
   if (due.length === 0) return;
   logger.info(`[subscriptions] Processing ${due.length} due subscription(s)`);
 
   for (const sub of due) {
-    const totalPrice = sub.price * sub.quantity;
-
-    // Atomic stock check + decrement
-    const reserve = db.transaction(() => {
-      const deducted = db
-        .prepare('UPDATE products SET quantity = quantity - ? WHERE id = ? AND quantity >= ?')
-        .run(sub.quantity, sub.product_id, sub.quantity);
-      if (deducted.changes === 0) throw new Error('Insufficient stock');
-
-      const order = db
-        .prepare(
-          'INSERT INTO orders (buyer_id, product_id, quantity, total_price, status) VALUES (?, ?, ?, ?, ?)'
-        )
-        .run(sub.buyer_id, sub.product_id, sub.quantity, totalPrice, 'pending');
-      return order.lastInsertRowid;
-    });
-
-    let orderId;
-    try {
-      orderId = reserve();
-    } catch (e) {
-      console.warn(`[subscriptions] Sub ${sub.id} skipped: ${e.message}`);
+    // Guard: re-check status inside loop (another worker may have processed it)
+    const current = db
+      .prepare('SELECT status, retry_count FROM subscriptions WHERE id = ?')
+      .get(sub.id);
+    if (!current || current.status !== 'active') {
+      logger.info(`[subscriptions] Sub ${sub.id} skipped (status=${current?.status})`);
       continue;
     }
 
-    try {
-      const idempotencyKey = `sub_payment_${sub.id}_${sub.next_order_at}`;
-      const cached = await getCachedResponse(idempotencyKey);
-      if (cached) {
-        logger.info(`[subscriptions] Sub ${sub.id} payment already processed, skipping`);
-        continue;
-      }
+    // Idempotency: skip if already paid this cycle
+    if (await isAlreadyProcessed(sub)) {
+      logger.info(`[subscriptions] Sub ${sub.id} already processed this cycle, skipping`);
+      continue;
+    }
 
+    const totalPrice = sub.price * sub.quantity;
+
+    // Atomic stock check + order creation
+    let orderId;
+    try {
+      orderId = db.transaction(() => {
+        const deducted = db
+          .prepare(
+            'UPDATE products SET quantity = quantity - ? WHERE id = ? AND quantity >= ?'
+          )
+          .run(sub.quantity, sub.product_id, sub.quantity);
+        if (deducted.changes === 0) throw new Error('Insufficient stock');
+
+        const order = db
+          .prepare(
+            'INSERT INTO orders (buyer_id, product_id, quantity, total_price, status) VALUES (?, ?, ?, ?, ?)'
+          )
+          .run(sub.buyer_id, sub.product_id, sub.quantity, totalPrice, 'pending');
+        return order.lastInsertRowid;
+      })();
+    } catch (e) {
+      logger.warn(`[subscriptions] Sub ${sub.id} stock reservation failed: ${e.message}`);
+      continue;
+    }
+
+    // Attempt Stellar payment
+    try {
       const txHash = await sendPayment({
         senderSecret: sub.buyer_secret,
         receiverPublicKey: sub.farmer_wallet,
@@ -66,47 +148,68 @@ async function processSubscriptions() {
         memo: `Sub#${sub.id}`,
       });
 
+      // Confirm success atomically
       db.transaction(() => {
         db.prepare('UPDATE orders SET status = ?, stellar_tx_hash = ? WHERE id = ?').run(
           'paid',
           txHash,
           orderId
         );
-        db.prepare('UPDATE subscriptions SET next_order_at = ? WHERE id = ?').run(
-          nextOrderDate(sub.frequency),
-          sub.id
-        );
+        db.prepare(
+          'UPDATE subscriptions SET next_order_at = ?, retry_count = 0, retry_after = NULL WHERE id = ?'
+        ).run(nextOrderDate(sub.frequency), sub.id);
       })();
 
-      // Cache the successful payment
-      await cacheResponse(idempotencyKey, { success: true }, 24);
+      await markProcessed(sub);
 
-      console.log(
-        `[subscriptions] Sub ${sub.id} → order ${orderId} paid (${txHash.slice(0, 12)}…)`
-      );
+      logger.info(`[subscriptions] Sub ${sub.id} → order ${orderId} paid`, {
+        subscriptionId: sub.id,
+        orderId,
+        txHash: txHash.slice(0, 12),
+      });
     } catch (e) {
-      // Payment failed — restore stock, pause subscription
+      // Restore stock
       db.transaction(() => {
         db.prepare('UPDATE orders SET status = ? WHERE id = ?').run('failed', orderId);
         db.prepare('UPDATE products SET quantity = quantity + ? WHERE id = ?').run(
           sub.quantity,
           sub.product_id
         );
-        db.prepare("UPDATE subscriptions SET status = 'paused', active = 0 WHERE id = ?").run(
-          sub.id
-        );
       })();
-      console.error(`[subscriptions] Sub ${sub.id} payment failed, paused: ${e.message}`);
+
+      const retryCount = (current.retry_count || 0) + 1;
+
+      if (isPermanentError(e) || retryCount > MAX_RETRIES) {
+        db.prepare(
+          "UPDATE subscriptions SET status = 'failed', active = 0, retry_count = ? WHERE id = ?"
+        ).run(retryCount, sub.id);
+        logger.error(`[subscriptions] Sub ${sub.id} permanently failed`, {
+          subscriptionId: sub.id,
+          reason: isPermanentError(e) ? 'permanent_error' : 'retry_exhausted',
+          errorCode: e.code,
+          retryCount,
+        });
+      } else {
+        db.prepare(
+          'UPDATE subscriptions SET retry_count = ?, retry_after = ? WHERE id = ?'
+        ).run(retryCount, retryAfterDate(), sub.id);
+        logger.warn(`[subscriptions] Sub ${sub.id} payment failed, scheduled retry ${retryCount}/${MAX_RETRIES}`, {
+          subscriptionId: sub.id,
+          retryCount,
+          errorCode: e.code,
+        });
+      }
     }
   }
 }
 
 function startSubscriptionJob() {
-  // Run every hour at minute 0
   cron.schedule('0 * * * *', () => {
-    processSubscriptions().catch((e) => console.error('[subscriptions] Job error:', e.message));
+    processSubscriptions().catch((e) =>
+      logger.error('[subscriptions] Job error', { message: e.message })
+    );
   });
-  console.log('[subscriptions] Cron job scheduled (hourly)');
+  logger.info('[subscriptions] Cron job scheduled (hourly)');
 }
 
 module.exports = { startSubscriptionJob, processSubscriptions };

--- a/backend/src/middleware/error.js
+++ b/backend/src/middleware/error.js
@@ -15,40 +15,6 @@ function err(res, status, message, code) {
 }
 
 /**
- * Structured error logging middleware — logs route errors with request context
- * @param {Error} error
- * @param {import('express').Request} req
- * @param {import('express').Response} res
- * @param {import('express').NextFunction} next
- */
-function errorHandler(error, req, res, next) { // eslint-disable-line no-unused-vars
-  const errorLog = {
-    timestamp: new Date().toISOString(),
-    error: {
-      message: error.message,
-      code: error.code,
-      statusCode: error.statusCode || 500,
-      stack: error.stack,
-    },
-    request: {
-      id: req.requestId,
-      method: req.method,
-      url: req.url,
-      path: req.path,
-      query: req.query,
-      ip: req.ip,
-      userAgent: req.get('user-agent'),
-    },
-  };
-
-  logger.error('Unhandled error', errorLog);
-  
-  const status = error.statusCode || 500;
-  const message = error.message || 'Internal server error';
-  return err(res, status, message, error.code);
-}
-
-/**
  * Wrap async route handlers to forward errors to the global error handler.
  * Usage: router.get('/path', asyncHandler(async (req, res) => { ... }))
  */
@@ -145,7 +111,6 @@ function notFoundHandler(req, res) {
     error: 'not_found',
     message: `Route not found: ${req.method} ${req.path}`,
   });
-  return err(res, 500, 'Internal server error', 'internal_error');
 }
 
 module.exports = { err, asyncHandler, errorHandler, notFoundHandler };

--- a/backend/src/routes/auctions.js
+++ b/backend/src/routes/auctions.js
@@ -1,9 +1,11 @@
+'use strict';
+
 const router = require('express').Router();
 const { z } = require('zod');
 const db = require('../db/schema');
 const auth = require('../middleware/auth');
-const { sendPayment, getBalance } = require('../utils/stellar');
 const { err } = require('../middleware/error');
+const logger = require('../logger');
 
 const MIN_MINUTES = parseInt(process.env.MIN_AUCTION_DURATION_MINUTES ?? '5', 10);
 
@@ -20,127 +22,259 @@ function validateBody(schema) {
 }
 
 const createAuctionSchema = z.object({
-  product_id: z.coerce.number().int().positive(),
-  start_price: z.coerce.number().positive(),
-  ends_at: z.iso
-    .datetime({ offset: true })
-    .refine(
-      (v) => new Date(v) >= new Date(Date.now() + MIN_MINUTES * 60 * 1000),
-      `ends_at must be at least ${MIN_MINUTES} minutes in the future`
-    ),
+  product_id:    z.coerce.number().int().positive(),
+  start_price:   z.coerce.number().positive(),
+  reserve_price: z.coerce.number().positive().optional(),
+  min_increment: z.coerce.number().min(0).optional().default(0),
+  ends_at: z.string().datetime({ offset: true }).refine(
+    (v) => new Date(v) >= new Date(Date.now() + MIN_MINUTES * 60 * 1000),
+    `ends_at must be at least ${MIN_MINUTES} minutes in the future`
+  ),
 });
 
-// POST /api/auctions - farmer creates auction
-router.post('/', auth, validateBody(createAuctionSchema), (req, res) => {
-    if (req.user.role !== 'farmer') return err(res, 403, 'Farmers only', 'forbidden');
+const bidSchema = z.object({
+  amount: z.coerce.number().positive('amount must be a positive number'),
+});
 
-    const { product_id, start_price, ends_at } = req.body;
+// ── POST /api/auctions ────────────────────────────────────────────────────────
+router.post('/', auth, validateBody(createAuctionSchema), async (req, res) => {
+  if (req.user.role !== 'farmer') return err(res, 403, 'Farmers only', 'forbidden');
 
-    const product = db
-      .prepare('SELECT * FROM products WHERE id = ? AND farmer_id = ?')
-      .get(product_id, req.user.id);
-    if (!product) return err(res, 404, 'Product not found or not yours', 'not_found');
+  const { product_id, start_price, reserve_price, min_increment, ends_at } = req.body;
 
-    const existing = db
-      .prepare(`SELECT id FROM auctions WHERE product_id = ? AND status = 'active'`)
-      .get(product_id);
-    if (existing)
+  try {
+    const { rows: products } = await db.query(
+      'SELECT id FROM products WHERE id = $1 AND farmer_id = $2',
+      [product_id, req.user.id]
+    );
+    if (!products.length) return err(res, 404, 'Product not found or not yours', 'not_found');
+
+    const { rows: existing } = await db.query(
+      `SELECT id FROM auctions WHERE product_id = $1 AND status = 'active'`,
+      [product_id]
+    );
+    if (existing.length)
       return err(res, 409, 'An active auction already exists for this product', 'conflict');
 
-    const { lastInsertRowid } = db
-      .prepare(
-        'INSERT INTO auctions (product_id, farmer_id, start_price, ends_at) VALUES (?, ?, ?, ?)'
-      )
-      .run(product_id, req.user.id, start_price, ends_at);
+    const { rows } = await db.query(
+      `INSERT INTO auctions (product_id, farmer_id, start_price, reserve_price, min_increment, ends_at)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+      [product_id, req.user.id, start_price, reserve_price ?? null, min_increment, ends_at]
+    );
 
-    res.status(201).json({ success: true, auctionId: lastInsertRowid });
+    const auctionId = rows[0]?.id;
+    logger.info('[auctions] Created auction', { auctionId, farmerId: req.user.id, product_id });
+    res.status(201).json({ success: true, auctionId });
+  } catch (e) {
+    logger.error('[auctions] Create failed', { error: e.message });
+    err(res, 500, 'Failed to create auction', 'internal_error');
+  }
 });
 
-// GET /api/auctions - list active auctions
-router.get('/', (req, res) => {
-  const auctions = db
-    .prepare(
-      `
-    SELECT a.*, p.name as product_name, p.description, p.unit, u.name as farmer_name,
-           COUNT(b.id) as bid_count
-    FROM auctions a
-    JOIN products p ON a.product_id = p.id
-    JOIN users u ON a.farmer_id = u.id
-    LEFT JOIN bids b ON b.auction_id = a.id
-    WHERE a.status = 'active' AND a.ends_at > datetime('now')
-    GROUP BY a.id
-    ORDER BY a.ends_at ASC
-  `
-    )
-    .all();
-  res.json({ success: true, data: auctions });
+// ── GET /api/auctions ─────────────────────────────────────────────────────────
+router.get('/', async (_req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT a.id, a.start_price, a.reserve_price, a.min_increment, a.current_bid,
+              a.status, a.ends_at, a.created_at,
+              p.name AS product_name, p.description, p.unit,
+              u.name AS farmer_name,
+              COUNT(b.id) AS bid_count
+       FROM auctions a
+       JOIN products p ON a.product_id = p.id
+       JOIN users    u ON a.farmer_id  = u.id
+       LEFT JOIN bids b ON b.auction_id = a.id
+       WHERE a.status = 'active' AND a.ends_at > $1
+       GROUP BY a.id, p.name, p.description, p.unit, u.name
+       ORDER BY a.ends_at ASC`,
+      [new Date().toISOString()]
+    );
+    res.json({ success: true, data: rows });
+  } catch (e) {
+    logger.error('[auctions] List failed', { error: e.message });
+    err(res, 500, 'Failed to list auctions', 'internal_error');
+  }
 });
 
-// POST /api/auctions/:id/bid - buyer places a bid
-router.post(
-  '/:id/bid',
-  auth,
-  validate([body('amount').isFloat({ gt: 0 }).withMessage('amount must be a positive number')]),
-  async (req, res) => {
-    if (req.user.role !== 'buyer') return err(res, 403, 'Only buyers can bid', 'forbidden');
+// ── GET /api/auctions/:id ─────────────────────────────────────────────────────
+router.get('/:id', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT a.id, a.start_price, a.reserve_price, a.min_increment, a.current_bid,
+              a.status, a.ends_at, a.closed_at, a.created_at,
+              p.name AS product_name, p.description, p.unit,
+              u.name AS farmer_name,
+              COUNT(b.id) AS bid_count
+       FROM auctions a
+       JOIN products p ON a.product_id = p.id
+       JOIN users    u ON a.farmer_id  = u.id
+       LEFT JOIN bids b ON b.auction_id = a.id
+       WHERE a.id = $1
+       GROUP BY a.id, p.name, p.description, p.unit, u.name`,
+      [req.params.id]
+    );
+    if (!rows.length) return err(res, 404, 'Auction not found', 'not_found');
+    res.json({ success: true, data: rows[0] });
+  } catch (e) {
+    logger.error('[auctions] Get failed', { error: e.message, auctionId: req.params.id });
+    err(res, 500, 'Failed to get auction', 'internal_error');
+  }
+});
 
+// ── POST /api/auctions/:id/bid ────────────────────────────────────────────────
+router.post('/:id/bid', auth, validateBody(bidSchema), async (req, res) => {
+  if (req.user.role !== 'buyer') return err(res, 403, 'Only buyers can bid', 'forbidden');
+
+  const auctionId = parseInt(req.params.id, 10);
+  if (!Number.isInteger(auctionId) || auctionId <= 0)
+    return err(res, 400, 'Invalid auction id', 'validation_error');
+
+  const { amount } = req.body;
+
+  try {
+    const result = await placeBid({ auctionId, buyerId: req.user.id, amount });
+    if (!result.success) return err(res, result.status, result.message, result.code);
+
+    logger.info('[auctions] Bid placed', {
+      auctionId,
+      buyerId: req.user.id,
+      amount,
+    });
+    res.json({ success: true, message: 'Bid placed', currentBid: amount });
+  } catch (e) {
+    logger.error('[auctions] Bid failed', { error: e.message, auctionId });
+    err(res, 500, 'Failed to place bid', 'internal_error');
+  }
+});
+
+/**
+ * Atomically validate and record a bid.
+ * Returns { success, status, message, code } — never throws for business-rule failures.
+ *
+ * Locking strategy:
+ *   PostgreSQL: SELECT … FOR UPDATE on the auction row serialises concurrent bids.
+ *   SQLite:     better-sqlite3 transactions are serialised by the single-writer model.
+ */
+async function placeBid({ auctionId, buyerId, amount }) {
+  if (db.isPostgres) {
+    return placeBidPostgres({ auctionId, buyerId, amount });
+  }
+  return placeBidSqlite({ auctionId, buyerId, amount });
+}
+
+async function placeBidPostgres({ auctionId, buyerId, amount }) {
+  const client = await db.getClient();
+  try {
+    await client.query('BEGIN');
+
+    // Lock the auction row for the duration of this transaction
+    const { rows } = await client.query(
+      `SELECT id, status, ends_at, start_price, current_bid, highest_bidder_id,
+              min_increment, reserve_price, farmer_id
+       FROM auctions WHERE id = $1 FOR UPDATE`,
+      [auctionId]
+    );
+
+    const validation = validateBidRules(rows[0], buyerId, amount);
+    if (!validation.ok) {
+      await client.query('ROLLBACK');
+      return validation;
+    }
+
+    await client.query(
+      'INSERT INTO bids (auction_id, buyer_id, amount) VALUES ($1, $2, $3)',
+      [auctionId, buyerId, amount]
+    );
+    await client.query(
+      'UPDATE auctions SET current_bid = $1, highest_bidder_id = $2 WHERE id = $3',
+      [amount, buyerId, auctionId]
+    );
+
+    await client.query('COMMIT');
+    return { success: true };
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
+function placeBidSqlite({ auctionId, buyerId, amount }) {
+  // SQLite transactions are synchronous and serialised — no explicit locking needed
+  let result;
+  db.transaction(() => {
     const auction = db
       .prepare(
-        `
-    SELECT a.*, u.stellar_public_key as farmer_wallet
-    FROM auctions a JOIN users u ON a.farmer_id = u.id
-    WHERE a.id = ?
-  `
+        `SELECT id, status, ends_at, start_price, current_bid, highest_bidder_id,
+                min_increment, reserve_price, farmer_id
+         FROM auctions WHERE id = ?`
       )
-      .get(req.params.id);
+      .get(auctionId);
 
-    if (!auction) return err(res, 404, 'Auction not found', 'not_found');
-    if (auction.status !== 'active')
-      return err(res, 400, 'Auction is not active', 'auction_closed');
-    if (new Date(auction.ends_at) <= new Date())
-      return err(res, 400, 'Auction has ended', 'auction_ended');
-
-    const { amount } = req.body;
-    const minBid = auction.current_bid ?? auction.start_price;
-    if (amount <= minBid)
-      return err(res, 400, `Bid must be higher than current bid of ${minBid} XLM`, 'bid_too_low');
-
-    if (auction.highest_bidder_id === req.user.id)
-      return err(res, 400, 'You are already the highest bidder', 'already_highest');
+    const validation = validateBidRules(auction, buyerId, amount);
+    if (!validation.ok) {
+      result = validation;
+      return; // transaction body returns; better-sqlite3 will commit (no writes occurred)
+    }
 
     db.prepare('INSERT INTO bids (auction_id, buyer_id, amount) VALUES (?, ?, ?)').run(
-      auction.id,
-      req.user.id,
-      amount
+      auctionId, buyerId, amount
     );
-    db.prepare('UPDATE auctions SET current_bid = ?, highest_bidder_id = ? WHERE id = ?').run(
-      amount,
-      req.user.id,
-      auction.id
+    db.prepare(
+      'UPDATE auctions SET current_bid = ?, highest_bidder_id = ? WHERE id = ?'
+    ).run(amount, buyerId, auctionId);
+
+    result = { success: true };
+  })();
+  return result;
+}
+
+/**
+ * Pure validation — no DB side-effects.
+ * Returns { ok: true } or { ok: false, success: false, status, message, code }.
+ */
+function validateBidRules(auction, buyerId, amount) {
+  if (!auction) return fail(404, 'Auction not found', 'not_found');
+
+  if (auction.status === 'cancelled')
+    return fail(400, 'Auction has been cancelled', 'auction_cancelled');
+
+  if (auction.status === 'closed')
+    return fail(400, 'Auction has already closed', 'auction_closed');
+
+  // Treat past end_time as closed even if the cron hasn't run yet
+  if (new Date(auction.ends_at) <= new Date())
+    return fail(400, 'Auction has ended', 'auction_ended');
+
+  // Bidder eligibility: farmers cannot bid; bidder cannot be the auction owner
+  if (auction.farmer_id === buyerId)
+    return fail(403, 'Auction owner cannot bid on their own auction', 'forbidden');
+
+  const floor = auction.current_bid ?? auction.start_price;
+  const minRequired = floor + (auction.min_increment ?? 0);
+
+  if (amount <= floor)
+    return fail(400, `Bid must be greater than current bid of ${floor}`, 'bid_too_low');
+
+  if (auction.min_increment > 0 && amount < minRequired)
+    return fail(
+      400,
+      `Bid must be at least ${minRequired} (current bid + minimum increment of ${auction.min_increment})`,
+      'bid_below_increment'
     );
 
-    res.json({ success: true, message: 'Bid placed', currentBid: amount });
-  }
-);
+  if (auction.highest_bidder_id === buyerId)
+    return fail(400, 'You are already the highest bidder', 'already_highest');
 
-// GET /api/auctions/:id - single auction detail
-router.get('/:id', (req, res) => {
-  const auction = db
-    .prepare(
-      `
-    SELECT a.*, p.name as product_name, p.description, p.unit, u.name as farmer_name,
-           COUNT(b.id) as bid_count
-    FROM auctions a
-    JOIN products p ON a.product_id = p.id
-    JOIN users u ON a.farmer_id = u.id
-    LEFT JOIN bids b ON b.auction_id = a.id
-    WHERE a.id = ?
-    GROUP BY a.id
-  `
-    )
-    .get(req.params.id);
-  if (!auction) return err(res, 404, 'Auction not found', 'not_found');
-  res.json({ success: true, data: auction });
-});
+  return { ok: true };
+}
+
+function fail(status, message, code) {
+  return { ok: false, success: false, status, message, code };
+}
 
 module.exports = router;
+// Export for testing
+module.exports.validateBidRules = validateBidRules;
+module.exports.placeBid = placeBid;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -348,5 +348,6 @@ registerRoute('/', '/bundles', require('./bundles'));
 registerRoute('/', '/farmers/bundles', require('./bundleDiscounts'));
 registerRoute('/', '', require('./export'));
 registerRoute('/', '/announcements', require('./announcements'));
+registerRoute('/', '/auctions', require('./auctions'));
 
 module.exports = router;

--- a/backend/src/utils/mailer.js
+++ b/backend/src/utils/mailer.js
@@ -108,6 +108,16 @@ async function sendReturnEmail({ type, order, buyer, farmer, reason, txHash, rej
   }
 }
 
+async function sendProductExpiredEmail({ product, farmer }) {
+  if (!SMTP_CONFIGURED) return;
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to: farmer.email,
+    subject: `🚫 Product Deactivated – ${product.name}`,
+    text: `Hi ${farmer.name},\n\nYour product "${product.name}" has been automatically deactivated because its best-before date (${product.best_before}) has passed.\n\nIf you have fresh stock, please create a new listing.\n\nFarmers Marketplace`,
+  });
+}
+
 async function sendContractAlert({ to, alert }) {
   if (!SMTP_CONFIGURED) return;
   const typeLabel = alert.alert_type === 'failed_invocations' ? '⚠️ Failed Invocations' : '🚨 Large Transfer';
@@ -124,6 +134,8 @@ module.exports = {
   sendOrderEmails,
   sendLowStockAlert,
   sendStatusUpdateEmail,
+  sendFreshnessAlert,
+  sendProductExpiredEmail,
   sendBackInStockEmail: async () => {
     if (!SMTP_CONFIGURED) return;
     // Placeholder for back in stock email


### PR DESCRIPTION
Closes #599

---

## Summary

Adds a scheduled job that automatically deactivates product listings whose `best_before` date has passed and sends a notification email to the owning farmer.

## Changes

### Migration
- `backend/migrations/024_product_expiry_notified_at.sql` — adds `expiry_notified_at DATETIME` column to `products`
- `backend/migrations/024_product_expiry_notified_at.undo.sql` — rollback

### Job: `backend/src/jobs/deactivateExpiredProducts.js`
- Runs daily at **02:00 UTC** via `node-cron`
- Fetches active products where `best_before < today` AND `expiry_notified_at IS NULL`
- Atomically sets `active = 0` and `expiry_notified_at = now` in a single UPDATE with idempotency guard
- Sends `sendProductExpiredEmail` to the farmer after deactivation
- Batched fetching (default 100 rows, configurable via `EXPIRY_BATCH_SIZE` env var)
- Supports both **SQLite** and **PostgreSQL** query paths
- Errors per-product are caught and counted as `skipped` — one bad row does not abort the batch

### Mailer: `backend/src/utils/mailer.js`
- Added `sendProductExpiredEmail({ product, farmer })` — no-op when SMTP is not configured

### App entry: `backend/src/index.js`
- Registers `startExpiryJob()` alongside existing cron jobs

## Idempotency

The UPDATE re-checks `active = 1 AND expiry_notified_at IS NULL` at write time, so:
- Re-running the job on the same day is safe — already-processed rows are skipped
- Concurrent runs cannot double-process the same product

## Tests

`backend/src/__tests__/deactivateExpiredProducts.test.js` — **19 tests, all passing**

| Suite | Tests |
|---|---|
| `todayUTC` | format, UTC correctness, default |
| Normal flow | zero results, deactivate + notify, cutoff date, default date |
| Idempotency | rowCount=0 skips email, no duplicate on re-run |
| Missing email | null and empty string farmer email |
| Error handling | DB throws, SMTP throws, continues after failure |
| Batching | multiple products in one batch |
| Timezone | cutoff passed to SQL, UTC boundary correctness |
| PostgreSQL mode | deactivates + notifies, uses `$1` placeholders |

## Testing Locally

```bash
# Apply migration
cd backend && npm run migrate

# Run tests
npx jest deactivateExpiredProducts --no-coverage

# Trigger manually (set a past date)
node -e "require('./src/jobs/deactivateExpiredProducts').deactivateExpiredProducts('2099-01-01').then(console.log)"
```

## Environment Variables

| Variable | Default | Description |
|---|---|---|
| `EXPIRY_BATCH_SIZE` | `100` | Products fetched per batch |
| `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS` | — | Required for email notifications |