### PR TITLE
feat: price history chart, flash sale timer, compare UI, map farmer filter

### DIFF
--- a/frontend/src/components/FlashSaleCountdown.jsx
+++ b/frontend/src/components/FlashSaleCountdown.jsx
@@ -25,11 +25,7 @@ export default function FlashSaleCountdown({ endsAt }) {
   }, [endsAt]);
 
   if (remaining.diff <= 0) {
-    return (
-      <div style={{ fontSize: 12, fontWeight: 700, color: "#b42318", marginTop: 6 }}>
-        Sale ended
-      </div>
-    );
+    return null;
   }
 
   const label = `${String(remaining.hours).padStart(2, "0")}:${String(remaining.minutes).padStart(2, "0")}:${String(remaining.seconds).padStart(2, "0")}`;

--- a/frontend/src/components/MapView.jsx
+++ b/frontend/src/components/MapView.jsx
@@ -32,33 +32,29 @@ const s = {
   },
 };
 
-// Group products by farmer to avoid stacking markers
 function groupByFarmer(products) {
   const map = new Map();
   for (const p of products) {
     if (p.farmer_lat == null || p.farmer_lng == null) continue;
     const key = `${p.farmer_lat},${p.farmer_lng}`;
-    if (!map.has(key)) map.set(key, { lat: p.farmer_lat, lng: p.farmer_lng, products: [] });
+    if (!map.has(key)) map.set(key, { lat: p.farmer_lat, lng: p.farmer_lng, farmerName: p.farmer_name, products: [] });
     map.get(key).products.push(p);
   }
   return Array.from(map.values());
 }
 
-export default function MapView({ products = [], lat, lng, farmerName, onBuy }) {
-  const navigate = useNavigate();
-  const hasSingleLocation = lat != null && lng != null;
-  const groups = hasSingleLocation
-    ? [{ lat, lng, farmerName, products: [] }]
-    : groupByFarmer(products);
 function RecenterMap({ center }) {
   const map = useMap();
   useEffect(() => { map.setView(center, map.getZoom()); }, [center, map]);
   return null;
 }
 
-export default function MapView({ products, onBuy }) {
+export default function MapView({ products = [], lat, lng, farmerName, onFarmerClick }) {
   const navigate = useNavigate();
-  const groups = groupByFarmer(products);
+  const hasSingleLocation = lat != null && lng != null;
+  const groups = hasSingleLocation
+    ? [{ lat, lng, farmerName, products: [] }]
+    : groupByFarmer(products);
   const [center, setCenter] = useState(null);
   const [toast, setToast] = useState('');
 
@@ -89,31 +85,15 @@ export default function MapView({ products, onBuy }) {
     );
   }
 
-  // Fall back to average of markers while geolocation is pending
-  const avgLat = groups.reduce((s, g) => s + g.lat, 0) / groups.length;
-  const avgLng = groups.reduce((s, g) => s + g.lng, 0) / groups.length;
+  const avgLat = groups.reduce((sum, g) => sum + g.lat, 0) / groups.length;
+  const avgLng = groups.reduce((sum, g) => sum + g.lng, 0) / groups.length;
   const mapCenter = center ?? [avgLat, avgLng];
 
   return (
-    <MapContainer
-      center={[avgLat, avgLng]}
-      zoom={7}
-      style={{ height: 520, width: '100%', borderRadius: 12, zIndex: 0 }}
-    >
-      <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
-      {groups.map((group, i) => (
-        <Marker key={i} position={[group.lat, group.lng]}>
-          <Popup>
-            <div style={s.popup}>
-              {group.products && group.products.length > 0 ? (
-                group.products.map(p => (
     <div style={{ position: 'relative' }}>
       {toast && <div style={s.toast} role="status">{toast}</div>}
       <MapContainer
-        center={mapCenter}
+        center={[avgLat, avgLng]}
         zoom={7}
         style={{ height: 520, width: '100%', borderRadius: 12, zIndex: 0 }}
       >
@@ -121,32 +101,40 @@ export default function MapView({ products, onBuy }) {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        {center && <RecenterMap center={center} />}
+        {center && <RecenterMap center={mapCenter} />}
         {groups.map((group, i) => (
-          <Marker key={i} position={[group.lat, group.lng]}>
+          <Marker
+            key={i}
+            position={[group.lat, group.lng]}
+            eventHandlers={onFarmerClick ? {
+              click: () => onFarmerClick(group.farmerName ?? group.products[0]?.farmer_name),
+            } : {}}
+          >
             <Popup>
               <div style={s.popup}>
-                {group.products.map(p => (
-                  <div key={p.id} style={{ marginBottom: group.products.length > 1 ? 12 : 0, paddingBottom: group.products.length > 1 ? 12 : 0, borderBottom: group.products.length > 1 ? '1px solid #eee' : 'none' }}>
-                    <div style={s.name}>{p.name}</div>
-                    <div style={s.price}>{p.price} XLM / {p.unit}</div>
-                    <div style={s.farmer}>🌾 {p.farmer_name}</div>
-                    {p.farmer_farm_address && <div style={s.address}>📍 {p.farmer_farm_address}</div>}
-                    <button style={s.btn} onClick={() => navigate(`/products/${p.id}`)}>View &amp; Buy</button>
+                {group.products.length > 0 ? (
+                  group.products.map(p => (
+                    <div
+                      key={p.id}
+                      style={{
+                        marginBottom: group.products.length > 1 ? 12 : 0,
+                        paddingBottom: group.products.length > 1 ? 12 : 0,
+                        borderBottom: group.products.length > 1 ? '1px solid #eee' : 'none',
+                      }}
+                    >
+                      <div style={s.name}>{p.name}</div>
+                      <div style={s.price}>{p.price} XLM / {p.unit}</div>
+                      <div style={s.farmer}>🌾 {p.farmer_name}</div>
+                      {p.farmer_farm_address && <div style={s.address}>📍 {p.farmer_farm_address}</div>}
+                      <button style={s.btn} onClick={() => navigate(`/product/${p.id}`)}>View &amp; Buy</button>
+                    </div>
+                  ))
+                ) : (
+                  <div>
+                    <div style={s.name}>{group.farmerName || 'Farm location'}</div>
+                    <div style={s.farmer}>🌾 {group.farmerName || 'Farmer'}</div>
                   </div>
-                ))
-              ) : (
-                <div>
-                  <div style={s.name}>{group.farmerName || 'Farm location'}</div>
-                  <div style={s.farmer}>🌾 {group.farmerName || 'Farmer'}</div>
-                </div>
-              )}
-            </div>
-          </Popup>
-        </Marker>
-      ))}
-    </MapContainer>
-                ))}
+                )}
               </div>
             </Popup>
           </Marker>

--- a/frontend/src/context/CompareContext.jsx
+++ b/frontend/src/context/CompareContext.jsx
@@ -59,7 +59,7 @@ export function CompareProvider({ children }) {
     setProducts(prev => {
       if (prev.some(p => p.id === product.id)) return prev;
       const next = [...prev, product];
-      return next.length > 3 ? next.slice(1) : next;
+      return next.length > 4 ? next.slice(1) : next;
     });
   }, []);
 
@@ -72,7 +72,7 @@ export function CompareProvider({ children }) {
       const exists = prev.some(p => p.id === product.id);
       if (exists) return prev.filter(p => p.id !== product.id);
       const next = [...prev, product];
-      return next.length > 3 ? next.slice(1) : next;
+      return next.length > 4 ? next.slice(1) : next;
     });
   }, []);
 

--- a/frontend/src/pages/Compare.jsx
+++ b/frontend/src/pages/Compare.jsx
@@ -27,7 +27,7 @@ export default function Compare() {
     <div style={s.page}>
       <div style={s.header}>Compare Products</div>
       <div style={s.description}>
-        Compare selected marketplace products side by side. Select up to three products on the marketplace to view them here.
+        Compare selected marketplace products side by side. Select up to four products on the marketplace to view them here.
       </div>
 
       {!hasEnoughProducts ? (
@@ -90,6 +90,40 @@ export default function Compare() {
                 {products.map(product => (
                   <td key={`${product.id}-category`} style={s.td}>{product?.category ?? '—'}</td>
                 ))}
+              </tr>
+              <tr>
+                <td style={{ ...s.td, ...s.rowLabel }}>Weight</td>
+                {products.map(product => {
+                  let weight = '—';
+                  if (product?.pricing_type === 'weight' && product.min_weight != null && product.max_weight != null) {
+                    weight = `${product.min_weight}–${product.max_weight} ${product.unit ?? ''}`.trim();
+                  } else if (product?.unit) {
+                    weight = product.unit;
+                  }
+                  return <td key={`${product.id}-weight`} style={s.td}>{weight}</td>;
+                })}
+              </tr>
+              <tr>
+                <td style={{ ...s.td, ...s.rowLabel }}>Allergens</td>
+                {products.map(product => {
+                  let allergens = [];
+                  try { allergens = product?.allergens ? JSON.parse(product.allergens) : []; } catch {}
+                  return (
+                    <td key={`${product.id}-allergens`} style={s.td}>
+                      {allergens.length === 0 ? 'None' : allergens.map(a => a.charAt(0).toUpperCase() + a.slice(1)).join(', ')}
+                    </td>
+                  );
+                })}
+              </tr>
+              <tr>
+                <td style={{ ...s.td, ...s.rowLabel }}>Freshness</td>
+                {products.map(product => {
+                  const bestBefore = product?.best_before;
+                  if (!bestBefore) return <td key={`${product.id}-freshness`} style={s.td}>—</td>;
+                  const diffDays = Math.ceil((new Date(bestBefore) - new Date()) / (1000 * 60 * 60 * 24));
+                  const label = diffDays < 0 ? 'Expired' : diffDays === 0 ? 'Expires today' : `${diffDays}d left`;
+                  return <td key={`${product.id}-freshness`} style={s.td}>{new Date(bestBefore).toLocaleDateString()} ({label})</td>;
+                })}
               </tr>
             </tbody>
           </table>

--- a/frontend/src/pages/Marketplace.jsx
+++ b/frontend/src/pages/Marketplace.jsx
@@ -897,7 +897,15 @@ export default function Marketplace() {
         </div>
       ) : viewMode === "map" ? (
         <Suspense fallback={<Spinner />}>
-          <MapView products={products} />
+          <MapView
+            products={products}
+            onFarmerClick={(name) => {
+              if (name) {
+                setFilters(f => ({ ...f, seller: name }));
+              }
+              setViewMode("grid");
+            }}
+          />
         </Suspense>
       ) : products.length === 0 ? (
         <div style={s.empty} role="status">

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -805,17 +805,6 @@ export default function ProductDetail() {
         })()}
 
         <PriceHistoryChart data={priceHistory} />
-        <div style={s.price}>
-          {unitPrice} XLM{" "}
-          <span style={{ fontSize: 14, fontWeight: 400 }}>
-            / {product.unit}
-          </span>
-          {tiers.length > 0 && (
-            <span style={{ fontSize: 12, color: '#666', marginLeft: 8 }}>
-              (bulk pricing available)
-            </span>
-          )}
-        </div>
         {usd(unitPrice) && (
           <div style={{ fontSize: 13, color: '#888', marginBottom: 4 }}>
             {usd(unitPrice)} {t('productDetail.perUnit', { unit: product.unit })} <span style={{ fontSize: 11, color: '#bbb' }}>{t('productDetail.approxRate')}</span>


### PR DESCRIPTION
## Summary of Changes

### #639 — Add price history chart to ProductDetail page
- `PriceHistoryChart` was already imported, state initialized, and API call (`GET /api/products/:id/price-history`) already wired up
- Removed a duplicate price `<div>` that was incorrectly placed right after `<PriceHistoryChart data={priceHistory} />`, leaving the chart cleanly rendered below the allergens section

### #638 — Flash sale countdown timer on product cards
- `FlashSaleCountdown` was already rendered on product cards and ProductDetail when a flash sale is active (conditional on `flash_sale_ends_at > now`)
- Changed `FlashSaleCountdown` to return `null` instead of a "Sale ended" label — the component now auto-hides itself once the countdown hits zero

### #636 — Product comparison feature UI
- Raised the comparison limit from **3 → 4** products in `CompareContext.jsx` (`addProduct` and `toggleProduct`)
- Updated Compare page description to reflect "up to four products"
- Added three new attribute rows to the side-by-side comparison table:
  - **Weight** — shows `min_weight–max_weight unit` for weight-based products, otherwise the unit
  - **Allergens** — parses the `allergens` JSON field and displays as a comma-separated list, or "None"
  - **Freshness** — shows the `best_before` date with a human-readable days-remaining label (e.g. `2025-06-10 (11d left)`)

### #637 — Map view for nearby farmers on Marketplace
- Fixed `MapView.jsx` which had a **corrupted duplicate `export default function MapView`** causing a runtime error — consolidated into a single clean component
- Merged the two partial implementations: single-location mode (`lat`/`lng`/`farmerName` props for ProductDetail) and multi-product mode with geolocation + `RecenterMap`
- Added `onFarmerClick` prop — fires with the farmer's name when a map pin is clicked
- Fixed incorrect route `/products/:id` → `/product/:id` in popup "View & Buy" button
- In `Marketplace.jsx`, wired `onFarmerClick` so clicking a farmer pin sets `filters.seller` to that farmer's name and switches the view back to grid mode

## Closes

Closes #639
Closes #638
Closes #636
Closes #637

## Test plan

- [ ] Product detail page — price history chart renders below allergens; no duplicate price block below it
- [ ] Marketplace product cards — flash sale countdown shows; after expiry the timer disappears entirely (no "Sale ended" text)
- [ ] Marketplace compare — can select up to 4 products; Compare page shows Weight, Allergens, Freshness rows
- [ ] Marketplace map view — clicking a farmer pin switches to grid view filtered to that farmer

🤖 Generated with [Claude Code](https://claude.com/claude-code)