### PR TITLE
feat: subscriptions, address book modal, coupon validation, favorites persistence (#640 #641 #642 #643)

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -379,6 +379,9 @@ export const api = {
   initiateCoopTx: (id, body) => request(`/cooperatives/${id}/transactions`, { method: 'POST', body }),
   signPendingTx: (txId) => request(`/cooperatives/transactions/${txId}/sign`, { method: 'POST' }),
   getPendingTxs: (coopId) => request(`/cooperatives/${coopId}/pending`),
+  // Coupons
+  validateCoupon: (body) => request('/coupons/validate', { method: 'POST', body }),
+
   // Platform fee
   getFeePreview: (amount) => request(`/orders/fee-preview?amount=${amount}`),
   // Account alerts

--- a/frontend/src/context/FavoritesContext.jsx
+++ b/frontend/src/context/FavoritesContext.jsx
@@ -4,25 +4,49 @@ import { useAuth } from './AuthContext';
 
 const FavoritesContext = createContext(null);
 
+const lsKey = (userId) => `fm_favorites_${userId}`;
+
+function readFromStorage(userId) {
+  try {
+    const raw = localStorage.getItem(lsKey(userId));
+    if (!raw) return null;
+    const ids = JSON.parse(raw);
+    if (Array.isArray(ids)) return new Set(ids);
+  } catch { /* ignore */ }
+  return null;
+}
+
+function writeToStorage(userId, favorites) {
+  try {
+    localStorage.setItem(lsKey(userId), JSON.stringify([...favorites]));
+  } catch { /* ignore */ }
+}
+
 export function FavoritesProvider({ children }) {
   const { user } = useAuth();
   const [favorites, setFavorites] = useState(new Set());
   const [loading, setLoading] = useState(false);
 
-  // Load favorites on mount or when user changes
   useEffect(() => {
     if (!user || user.role !== 'buyer') {
       setFavorites(new Set());
       return;
     }
 
+    // Initialize immediately from localStorage so UI is responsive before API
+    const cached = readFromStorage(user.id);
+    if (cached) setFavorites(cached);
+
     setLoading(true);
     api.getFavorites({ limit: 1000 })
       .then(res => {
         const ids = new Set((res.data || []).map(p => p.id));
         setFavorites(ids);
+        writeToStorage(user.id, ids);
       })
-      .catch(() => setFavorites(new Set()))
+      .catch(() => {
+        if (!cached) setFavorites(new Set());
+      })
       .finally(() => setLoading(false));
   }, [user]);
 
@@ -36,15 +60,18 @@ export function FavoritesProvider({ children }) {
       if (isFavorited) {
         newFavorites.delete(productId);
         setFavorites(newFavorites);
+        writeToStorage(user.id, newFavorites);
         await api.removeFavorite(productId);
       } else {
         newFavorites.add(productId);
         setFavorites(newFavorites);
+        writeToStorage(user.id, newFavorites);
         await api.addFavorite(productId);
       }
     } catch (err) {
       // Revert on error
       setFavorites(favorites);
+      writeToStorage(user.id, favorites);
       throw err;
     }
   }, [user, favorites]);

--- a/frontend/src/pages/AddressBook.jsx
+++ b/frontend/src/pages/AddressBook.jsx
@@ -16,9 +16,98 @@ const s = {
   addressCard: { border: '1px solid #e0e0e0', borderRadius: 10, padding: 16, marginBottom: 12, position: 'relative' },
   defaultBadge: { position: 'absolute', top: 12, right: 12, background: '#2d6a4f', color: '#fff', padding: '2px 8px', borderRadius: 4, fontSize: 11, fontWeight: 600 },
   empty: { color: '#888', fontSize: 14, textAlign: 'center', padding: 24 },
+  overlay: { position: 'fixed', inset: 0, background: '#0005', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 },
+  modal: { background: '#fff', borderRadius: 12, padding: 28, maxWidth: 480, width: '90%', boxShadow: '0 4px 24px #0003', maxHeight: '90vh', overflowY: 'auto' },
+  modalTitle: { fontWeight: 700, fontSize: 17, marginBottom: 16, color: '#2d6a4f' },
 };
 
 const EMPTY_FORM = { label: '', street: '', city: '', country: '', postal_code: '', is_default: false };
+
+function AddressFormModal({ initial, onSave, onCancel, loading }) {
+  const [form, setForm] = useState(initial || EMPTY_FORM);
+  const isEdit = Boolean(initial);
+
+  React.useEffect(() => {
+    function onKey(e) { if (e.key === 'Escape') onCancel(); }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    onSave(form);
+  }
+
+  return (
+    <div role="dialog" aria-modal="true" aria-labelledby="addr-modal-title" style={s.overlay}>
+      <div style={s.modal}>
+        <div id="addr-modal-title" style={s.modalTitle}>{isEdit ? 'Edit Address' : 'Add New Address'}</div>
+        <form onSubmit={handleSubmit}>
+          <label style={s.label}>Label (e.g., Home, Work)</label>
+          <input
+            style={s.input}
+            value={form.label}
+            onChange={e => setForm({ ...form, label: e.target.value })}
+            required
+            maxLength={50}
+            autoFocus
+          />
+
+          <label style={s.label}>Street Address</label>
+          <input
+            style={s.input}
+            value={form.street}
+            onChange={e => setForm({ ...form, street: e.target.value })}
+            required
+            maxLength={200}
+          />
+
+          <label style={s.label}>City</label>
+          <input
+            style={s.input}
+            value={form.city}
+            onChange={e => setForm({ ...form, city: e.target.value })}
+            required
+            maxLength={100}
+          />
+
+          <label style={s.label}>Country</label>
+          <input
+            style={s.input}
+            value={form.country}
+            onChange={e => setForm({ ...form, country: e.target.value })}
+            required
+            maxLength={100}
+          />
+
+          <label style={s.label}>Postal Code (optional)</label>
+          <input
+            style={s.input}
+            value={form.postal_code}
+            onChange={e => setForm({ ...form, postal_code: e.target.value })}
+            maxLength={20}
+          />
+
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 20, cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={form.is_default}
+              onChange={e => setForm({ ...form, is_default: e.target.checked })}
+            />
+            <span style={{ fontSize: 14, color: '#555' }}>Set as default address</span>
+          </label>
+
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <button type="button" style={s.btnSecondary} onClick={onCancel}>Cancel</button>
+            <button type="submit" style={s.btn} disabled={loading}>
+              {loading ? 'Saving...' : (isEdit ? 'Update Address' : 'Add Address')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
 
 function DeleteConfirmDialog({ onConfirm, onCancel }) {
   const cancelRef = React.useRef(null);
@@ -35,7 +124,7 @@ function DeleteConfirmDialog({ onConfirm, onCancel }) {
       role="dialog"
       aria-modal="true"
       aria-labelledby="del-dialog-title"
-      style={{ position: 'fixed', inset: 0, background: '#0005', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
+      style={s.overlay}
     >
       <div style={{ background: '#fff', borderRadius: 12, padding: 28, maxWidth: 380, width: '90%', boxShadow: '0 4px 24px #0003' }}>
         <div id="del-dialog-title" style={{ fontWeight: 700, fontSize: 16, marginBottom: 10 }}>Delete Address</div>
@@ -54,11 +143,11 @@ function DeleteConfirmDialog({ onConfirm, onCancel }) {
 export default function AddressBook() {
   const { user } = useAuth();
   const [addresses, setAddresses] = useState([]);
-  const [form, setForm] = useState(EMPTY_FORM);
-  const [editingId, setEditingId] = useState(null);
   const [msg, setMsg] = useState(null);
   const [loading, setLoading] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingAddress, setEditingAddress] = useState(null); // null = adding new
 
   async function load() {
     try {
@@ -69,37 +158,33 @@ export default function AddressBook() {
 
   useEffect(() => { load(); }, []);
 
-  function startEdit(address) {
-    setEditingId(address.id);
-    setForm({
-      label: address.label,
-      street: address.street,
-      city: address.city,
-      country: address.country,
-      postal_code: address.postal_code || '',
-      is_default: !!address.is_default,
-    });
+  function openAdd() {
+    setEditingAddress(null);
+    setModalOpen(true);
   }
 
-  function cancelEdit() {
-    setEditingId(null);
-    setForm(EMPTY_FORM);
+  function openEdit(address) {
+    setEditingAddress(address);
+    setModalOpen(true);
   }
 
-  async function handleSubmit(e) {
-    e.preventDefault();
+  function closeModal() {
+    setModalOpen(false);
+    setEditingAddress(null);
+  }
+
+  async function handleSave(form) {
     setMsg(null);
     setLoading(true);
     try {
-      if (editingId) {
-        await api.updateAddress(editingId, form);
+      if (editingAddress) {
+        await api.updateAddress(editingAddress.id, form);
         setMsg({ type: 'ok', text: 'Address updated' });
       } else {
         await api.createAddress(form);
         setMsg({ type: 'ok', text: 'Address added' });
       }
-      setForm(EMPTY_FORM);
-      setEditingId(null);
+      closeModal();
       load();
     } catch (err) {
       setMsg({ type: 'err', text: err.message });
@@ -142,7 +227,10 @@ export default function AddressBook() {
 
   return (
     <div style={s.page}>
-      <div style={s.title}>📍 Address Book</div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
+        <div style={s.title}>📍 Address Book</div>
+        <button style={s.btn} onClick={openAdd}>+ Add Address</button>
+      </div>
 
       {msg && (
         <div style={{ ...s.msg, background: msg.type === 'ok' ? '#d8f3dc' : '#fee', color: msg.type === 'ok' ? '#2d6a4f' : '#c0392b' }}>
@@ -150,79 +238,10 @@ export default function AddressBook() {
         </div>
       )}
 
-      {/* Add/Edit Form */}
-      <div style={s.card}>
-        <h3 style={{ marginBottom: 16, color: '#333' }}>{editingId ? 'Edit Address' : 'Add New Address'}</h3>
-        <form onSubmit={handleSubmit}>
-          <label style={s.label}>Label (e.g., Home, Work)</label>
-          <input
-            style={s.input}
-            value={form.label}
-            onChange={e => setForm({ ...form, label: e.target.value })}
-            required
-            maxLength={50}
-          />
-
-          <label style={s.label}>Street Address</label>
-          <input
-            style={s.input}
-            value={form.street}
-            onChange={e => setForm({ ...form, street: e.target.value })}
-            required
-            maxLength={200}
-          />
-
-          <label style={s.label}>City</label>
-          <input
-            style={s.input}
-            value={form.city}
-            onChange={e => setForm({ ...form, city: e.target.value })}
-            required
-            maxLength={100}
-          />
-
-          <label style={s.label}>Country</label>
-          <input
-            style={s.input}
-            value={form.country}
-            onChange={e => setForm({ ...form, country: e.target.value })}
-            required
-            maxLength={100}
-          />
-
-          <label style={s.label}>Postal Code (optional)</label>
-          <input
-            style={s.input}
-            value={form.postal_code}
-            onChange={e => setForm({ ...form, postal_code: e.target.value })}
-            maxLength={20}
-          />
-
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16, cursor: 'pointer' }}>
-            <input
-              type="checkbox"
-              checked={form.is_default}
-              onChange={e => setForm({ ...form, is_default: e.target.checked })}
-            />
-            <span style={{ fontSize: 14, color: '#555' }}>Set as default address</span>
-          </label>
-
-          <div style={{ display: 'flex', gap: 8 }}>
-            <button type="submit" style={s.btn} disabled={loading}>
-              {loading ? 'Saving...' : (editingId ? 'Update Address' : 'Add Address')}
-            </button>
-            {editingId && (
-              <button type="button" style={s.btnSecondary} onClick={cancelEdit}>Cancel</button>
-            )}
-          </div>
-        </form>
-      </div>
-
-      {/* Address List */}
       <div style={s.card}>
         <h3 style={{ marginBottom: 16, color: '#333' }}>My Addresses ({addresses.length})</h3>
         {addresses.length === 0 ? (
-          <div style={s.empty}>No addresses yet. Add your first delivery address above.</div>
+          <div style={s.empty}>No addresses yet. Add your first delivery address.</div>
         ) : (
           addresses.map(addr => (
             <div key={addr.id} style={s.addressCard}>
@@ -233,7 +252,7 @@ export default function AddressBook() {
                 {addr.postal_code ? ` ${addr.postal_code}` : ''}
               </div>
               <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
-                <button style={s.btnSm} onClick={() => startEdit(addr)}>Edit</button>
+                <button style={s.btnSm} onClick={() => openEdit(addr)}>Edit</button>
                 {!addr.is_default && (
                   <button style={s.btnSecondary} onClick={() => handleSetDefault(addr.id)}>Set Default</button>
                 )}
@@ -243,6 +262,22 @@ export default function AddressBook() {
           ))
         )}
       </div>
+
+      {modalOpen && (
+        <AddressFormModal
+          initial={editingAddress ? {
+            label: editingAddress.label,
+            street: editingAddress.street,
+            city: editingAddress.city,
+            country: editingAddress.country,
+            postal_code: editingAddress.postal_code || '',
+            is_default: !!editingAddress.is_default,
+          } : null}
+          onSave={handleSave}
+          onCancel={closeModal}
+          loading={loading}
+        />
+      )}
 
       {confirmDeleteId && (
         <DeleteConfirmDialog

--- a/frontend/src/pages/Subscriptions.jsx
+++ b/frontend/src/pages/Subscriptions.jsx
@@ -20,6 +20,7 @@ const s = {
   badge:   { display: 'inline-block', fontSize: 11, padding: '3px 10px', borderRadius: 20, fontWeight: 600 },
   actions: { display: 'flex', gap: 8, flexShrink: 0 },
   smBtn:   { fontSize: 12, padding: '5px 12px', borderRadius: 6, border: 'none', cursor: 'pointer', fontWeight: 600 },
+  overlay: { position: 'fixed', inset: 0, background: '#0005', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 },
 };
 
 const STATUS_STYLE = {
@@ -28,11 +29,54 @@ const STATUS_STYLE = {
   cancelled: { background: '#fee',    color: '#c0392b' },
 };
 
+function CancelConfirmDialog({ sub, onConfirm, onCancel }) {
+  const cancelRef = React.useRef(null);
+
+  React.useEffect(() => {
+    cancelRef.current?.focus();
+    function onKey(e) { if (e.key === 'Escape') onCancel(); }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  const nextAmount = sub.product_price && sub.quantity
+    ? `${(sub.product_price * sub.quantity).toFixed(2)} XLM`
+    : null;
+
+  return (
+    <div role="dialog" aria-modal="true" aria-labelledby="cancel-dialog-title" style={s.overlay}>
+      <div style={{ background: '#fff', borderRadius: 12, padding: 28, maxWidth: 400, width: '90%', boxShadow: '0 4px 24px #0003' }}>
+        <div id="cancel-dialog-title" style={{ fontWeight: 700, fontSize: 16, marginBottom: 10 }}>Cancel Subscription</div>
+        <p style={{ fontSize: 14, color: '#555', marginBottom: 8 }}>
+          Are you sure you want to cancel your subscription for <strong>{sub.product_name}</strong>?
+        </p>
+        <div style={{ background: '#f8fdf9', border: '1px solid #b7e4c7', borderRadius: 8, padding: '10px 14px', marginBottom: 16, fontSize: 13 }}>
+          <div><span style={{ color: '#888' }}>Frequency:</span> {FREQ_LABEL[sub.frequency]}</div>
+          <div><span style={{ color: '#888' }}>Quantity:</span> {sub.quantity} {sub.unit}</div>
+          {nextAmount && <div><span style={{ color: '#888' }}>Next renewal amount:</span> {nextAmount}</div>}
+          {sub.next_order_at && (
+            <div>
+              <span style={{ color: '#888' }}>Next renewal date:</span>{' '}
+              {new Date(sub.next_order_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
+            </div>
+          )}
+        </div>
+        <p style={{ fontSize: 13, color: '#888', marginBottom: 20 }}>This action cannot be undone.</p>
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+          <button ref={cancelRef} style={{ ...s.smBtn, background: '#f0f0f0', color: '#333', padding: '8px 16px' }} onClick={onCancel}>Keep Subscription</button>
+          <button style={{ ...s.smBtn, background: '#fee', color: '#c0392b', padding: '8px 16px' }} onClick={onConfirm}>Cancel Subscription</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function Subscriptions() {
   const [subs, setSubs]       = useState([]);
   const [loading, setLoading] = useState(true);
   const [form, setForm]       = useState({ product_id: '', quantity: 1, frequency: 'weekly' });
   const [msg, setMsg]         = useState(null);
+  const [cancelTarget, setCancelTarget] = useState(null); // sub object pending cancellation
 
   async function load() {
     setLoading(true);
@@ -58,11 +102,20 @@ export default function Subscriptions() {
 
   async function handleAction(id, action) {
     try {
-      if (action === 'cancel')  await api.cancelSubscription(id);
       if (action === 'pause')   await api.pauseSubscription(id);
       if (action === 'resume')  await api.resumeSubscription(id);
       load();
-    } catch (err) { alert(err.message); }
+    } catch (err) { setMsg({ type: 'err', text: err.message }); }
+  }
+
+  async function confirmCancel() {
+    const id = cancelTarget.id;
+    setCancelTarget(null);
+    try {
+      await api.cancelSubscription(id);
+      setMsg({ type: 'ok', text: 'Subscription cancelled.' });
+      load();
+    } catch (err) { setMsg({ type: 'err', text: err.message }); }
   }
 
   return (
@@ -103,27 +156,45 @@ export default function Subscriptions() {
         <h3 style={{ marginBottom: 16, color: '#333' }}>My Subscriptions ({subs.length})</h3>
         {loading ? <Spinner /> : subs.length === 0 ? (
           <p style={{ color: '#888', fontSize: 14 }}>No active subscriptions.</p>
-        ) : subs.map(sub => (
-          <div key={sub.id} style={s.row}>
-            <div>
-              <div style={s.name}>{sub.product_name}</div>
-              <div style={s.meta}>{sub.quantity} {sub.unit} · {FREQ_LABEL[sub.frequency]} · {sub.product_price} XLM/unit</div>
-              <div style={s.meta}>Next order: {new Date(sub.next_order_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}</div>
-              <div style={s.meta}>Next billing: {sub.next_billing_at ? new Date(sub.next_billing_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : 'Billing date not set'}</div>
+        ) : subs.map(sub => {
+          const nextAmount = sub.product_price && sub.quantity
+            ? `${(sub.product_price * sub.quantity).toFixed(2)} XLM`
+            : null;
+          return (
+            <div key={sub.id} style={s.row}>
+              <div>
+                <div style={s.name}>{sub.product_name}</div>
+                <div style={s.meta}>{sub.quantity} {sub.unit} · {FREQ_LABEL[sub.frequency]}</div>
+                {nextAmount && <div style={s.meta}>Next renewal amount: <strong>{nextAmount}</strong></div>}
+                <div style={s.meta}>Next renewal date: {new Date(sub.next_order_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}</div>
+                {sub.next_billing_at && (
+                  <div style={s.meta}>Next billing: {new Date(sub.next_billing_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}</div>
+                )}
+              </div>
+              <div style={s.actions}>
+                <span style={{ ...s.badge, ...STATUS_STYLE[sub.status] }}>{sub.status}</span>
+                {sub.status === 'active' && (
+                  <button style={{ ...s.smBtn, background: '#fff3cd', color: '#856404' }} onClick={() => handleAction(sub.id, 'pause')}>Pause</button>
+                )}
+                {sub.status === 'paused' && (
+                  <button style={{ ...s.smBtn, background: '#d8f3dc', color: '#2d6a4f' }} onClick={() => handleAction(sub.id, 'resume')}>Resume</button>
+                )}
+                {sub.status !== 'cancelled' && (
+                  <button style={{ ...s.smBtn, background: '#fee', color: '#c0392b' }} onClick={() => setCancelTarget(sub)}>Cancel</button>
+                )}
+              </div>
             </div>
-            <div style={s.actions}>
-              <span style={{ ...s.badge, ...STATUS_STYLE[sub.status] }}>{sub.status}</span>
-              {sub.status === 'active' && (
-                <button style={{ ...s.smBtn, background: '#fff3cd', color: '#856404' }} onClick={() => handleAction(sub.id, 'pause')}>Pause</button>
-              )}
-              {sub.status === 'paused' && (
-                <button style={{ ...s.smBtn, background: '#d8f3dc', color: '#2d6a4f' }} onClick={() => handleAction(sub.id, 'resume')}>Resume</button>
-              )}
-              <button style={{ ...s.smBtn, background: '#fee', color: '#c0392b' }} onClick={() => { if (confirm('Cancel this subscription?')) handleAction(sub.id, 'cancel'); }}>Cancel</button>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
+
+      {cancelTarget && (
+        <CancelConfirmDialog
+          sub={cancelTarget}
+          onConfirm={confirmCancel}
+          onCancel={() => setCancelTarget(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR implements four buyer-facing features across the FarmersMarketplace frontend.

---

### #640 — Favorites (wishlist) persistence across sessions

**File:** `frontend/src/context/FavoritesContext.jsx`

- Added `localStorage` persistence keyed per user (`fm_favorites_<userId>`) to avoid cross-user leaks
- On login, favorites are loaded immediately from `localStorage` so the UI is responsive before the API responds
- After the `GET /api/favorites` sync completes, `localStorage` is updated with the authoritative server state
- Every `toggleFavorite` call (add/remove) writes the new set to `localStorage` immediately, and reverts both state and storage on API failure

Closes #640

---

### #641 — Address book management UI with form modal

**File:** `frontend/src/pages/AddressBook.jsx`

- Replaced the inline add/edit form with a `AddressFormModal` component rendered as a fixed overlay dialog
- Modal opens for both "Add New Address" (top-right button) and "Edit" (per-address button)
- Modal supports Escape key to dismiss and auto-focuses the first field on open
- Delete confirmation dialog (`DeleteConfirmDialog`) retained with keyboard/Escape support
- Delivery address pre-fill in the order flow (`ProductDetail`) was already wired to the address book and remains unchanged

Closes #641

---

### #642 — Coupon code input on checkout

**File:** `frontend/src/api/client.js`

- Added the missing `validateCoupon` method: `POST /api/coupons/validate`
- The ProductDetail buy flow already had the full coupon UI (input field, Apply button, discount display, line-through original price) and called `api.validateCoupon` — the API client method was the only missing piece
- Backend endpoint `POST /api/coupons/validate` already existed and returns `{ discount_type, discount_value, discount, final_total }`

Closes #642

---

### #643 — Subscription management page with cancellation dialog

**File:** `frontend/src/pages/Subscriptions.jsx`

- Replaced browser-native `confirm()` with a `CancelConfirmDialog` React component
- Dialog shows the subscription details before confirming: product name, frequency, quantity, next renewal date, and next renewal amount (calculated as `price × quantity`)
- Cancel button is now hidden for already-cancelled subscriptions
- Error messages from pause/resume/cancel are surfaced in the page message area instead of `alert()`

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)