### PR TITLE
feat: resolve issues #644 #645 #646 #647 — farmer profile, order filters, share buttons, announcement persistence

### DIFF
--- a/frontend/src/components/ShareButtons.jsx
+++ b/frontend/src/components/ShareButtons.jsx
@@ -35,6 +35,7 @@ export default function ShareButtons({ title, url, onShare }) {
   const [toast, setToast] = useState(null);
   const encodedUrl = encodeURIComponent(url);
   const encodedText = encodeURIComponent(`${title} ${url}`);
+  const canNativeShare = typeof navigator !== "undefined" && typeof navigator.share === "function";
 
   const showToast = useCallback((message, type) => {
     setToast({ message, type });
@@ -43,6 +44,15 @@ export default function ShareButtons({ title, url, onShare }) {
 
   function track(platform) {
     if (typeof onShare === "function") onShare(platform);
+  }
+
+  async function shareNative() {
+    try {
+      await navigator.share({ title, url, text: title });
+      track("native_share");
+    } catch (e) {
+      if (e.name !== "AbortError") showToast("Share failed", "error");
+    }
   }
 
   function shareWhatsApp() {
@@ -100,6 +110,11 @@ export default function ShareButtons({ title, url, onShare }) {
     <div style={s.wrap}>
       <div style={s.title}>Share this product</div>
       <div style={s.row}>
+        {canNativeShare && (
+          <button type="button" style={s.btn} onClick={shareNative}>
+            Share
+          </button>
+        )}
         <button type="button" style={s.btn} onClick={shareWhatsApp}>
           WhatsApp
         </button>

--- a/frontend/src/pages/FarmerProfile.jsx
+++ b/frontend/src/pages/FarmerProfile.jsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
+
+const PAGE_SIZE = 9;
 
 const s = {
   page:       { maxWidth: 900, margin: '0 auto', padding: 24 },
@@ -18,8 +20,13 @@ const s = {
   cardPrice:  { fontWeight: 700, color: '#2d6a4f', fontSize: 16 },
   cardQty:    { fontSize: 12, color: '#888', marginTop: 3 },
   badge:      { display: 'inline-block', fontSize: 11, background: '#d8f3dc', color: '#2d6a4f', borderRadius: 4, padding: '2px 7px', marginBottom: 6 },
+  verifiedBadge: { display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, fontWeight: 600, background: '#dbeafe', color: '#1e40af', borderRadius: 20, padding: '3px 10px', marginTop: 8 },
   empty:      { color: '#aaa', fontSize: 14, padding: '32px 0', textAlign: 'center' },
   back:       { fontSize: 13, color: '#2d6a4f', cursor: 'pointer', marginBottom: 16, display: 'inline-block' },
+  pagination: { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, marginTop: 24 },
+  pageBtn:    { padding: '7px 14px', borderRadius: 8, border: '1px solid #ddd', cursor: 'pointer', fontSize: 13, fontWeight: 600, background: '#fff', color: '#2d6a4f' },
+  pageBtnActive: { background: '#2d6a4f', color: '#fff', border: '1px solid #2d6a4f' },
+  pageBtnDisabled: { opacity: 0.4, cursor: 'not-allowed' },
 };
 
 const shimmer = `
@@ -76,14 +83,23 @@ export default function FarmerProfile() {
   const [farmer, setFarmer] = useState(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     setLoading(true);
+    setPage(1);
     api.getFarmer(id)
       .then(res => setFarmer(res.data))
       .catch(() => setNotFound(true))
       .finally(() => setLoading(false));
   }, [id]);
+
+  const totalPages = farmer ? Math.ceil(farmer.listings.length / PAGE_SIZE) : 1;
+  const pagedListings = useMemo(() => {
+    if (!farmer) return [];
+    const start = (page - 1) * PAGE_SIZE;
+    return farmer.listings.slice(start, start + PAGE_SIZE);
+  }, [farmer, page]);
 
   if (loading) return <ProfileSkeleton />;
 
@@ -119,6 +135,9 @@ export default function FarmerProfile() {
           <div style={s.since}>
             Member since {new Date(farmer.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long' })}
           </div>
+          {farmer.verified && (
+            <div style={s.verifiedBadge}>✔ Verified Farmer</div>
+          )}
         </div>
       </div>
 
@@ -130,27 +149,56 @@ export default function FarmerProfile() {
       {farmer.listings.length === 0 ? (
         <div style={s.empty}>This farmer has no active listings right now.</div>
       ) : (
-        <div style={s.grid}>
-          {farmer.listings.map(p => (
-            <div
-              key={p.id}
-              style={s.card}
-              onClick={() => navigate(`/product/${p.id}`)}
-              onMouseEnter={e => e.currentTarget.style.transform = 'translateY(-2px)'}
-              onMouseLeave={e => e.currentTarget.style.transform = ''}
-            >
-              {p.image_url
-                ? <img src={p.image_url} alt={p.name} style={{ width: '100%', height: 120, objectFit: 'cover', borderRadius: 8, marginBottom: 10 }} />
-                : <div style={{ fontSize: 28, marginBottom: 8 }}>🥬</div>
-              }
-              {p.category && p.category !== 'other' && <div style={s.badge}>{p.category}</div>}
-              <div style={s.cardName}>{p.name}</div>
-              <div style={s.cardDesc}>{p.description || 'Fresh from the farm'}</div>
-              <div style={s.cardPrice}>{p.price} XLM <span style={{ fontSize: 12, fontWeight: 400 }}>/ {p.unit}</span></div>
-              <div style={s.cardQty}>{p.quantity} {p.unit} available</div>
+        <>
+          <div style={s.grid}>
+            {pagedListings.map(p => (
+              <div
+                key={p.id}
+                style={s.card}
+                onClick={() => navigate(`/product/${p.id}`)}
+                onMouseEnter={e => e.currentTarget.style.transform = 'translateY(-2px)'}
+                onMouseLeave={e => e.currentTarget.style.transform = ''}
+              >
+                {p.image_url
+                  ? <img src={p.image_url} alt={p.name} style={{ width: '100%', height: 120, objectFit: 'cover', borderRadius: 8, marginBottom: 10 }} />
+                  : <div style={{ fontSize: 28, marginBottom: 8 }}>🥬</div>
+                }
+                {p.category && p.category !== 'other' && <div style={s.badge}>{p.category}</div>}
+                <div style={s.cardName}>{p.name}</div>
+                <div style={s.cardDesc}>{p.description || 'Fresh from the farm'}</div>
+                <div style={s.cardPrice}>{p.price} XLM <span style={{ fontSize: 12, fontWeight: 400 }}>/ {p.unit}</span></div>
+                <div style={s.cardQty}>{p.quantity} {p.unit} available</div>
+              </div>
+            ))}
+          </div>
+          {totalPages > 1 && (
+            <div style={s.pagination}>
+              <button
+                style={{ ...s.pageBtn, ...(page === 1 ? s.pageBtnDisabled : {}) }}
+                disabled={page === 1}
+                onClick={() => setPage(p => p - 1)}
+              >
+                ← Prev
+              </button>
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map(n => (
+                <button
+                  key={n}
+                  style={{ ...s.pageBtn, ...(n === page ? s.pageBtnActive : {}) }}
+                  onClick={() => setPage(n)}
+                >
+                  {n}
+                </button>
+              ))}
+              <button
+                style={{ ...s.pageBtn, ...(page === totalPages ? s.pageBtnDisabled : {}) }}
+                disabled={page === totalPages}
+                onClick={() => setPage(p => p + 1)}
+              >
+                Next →
+              </button>
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/Orders.jsx
+++ b/frontend/src/pages/Orders.jsx
@@ -53,6 +53,11 @@ const s = {
   step:      { display: 'flex', flexDirection: 'column', alignItems: 'center', fontSize: 10, color: '#bbb', minWidth: 60 },
   stepDot:   { width: 10, height: 10, borderRadius: '50%', background: '#ddd', marginBottom: 3 },
   stepLine:  { flex: 1, height: 2, background: '#eee', minWidth: 20 },
+  filters:   { display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap', alignItems: 'center' },
+  filterLabel: { fontSize: 13, color: '#555', whiteSpace: 'nowrap' },
+  dateInput: { padding: '6px 10px', border: '1px solid #ddd', borderRadius: 8, fontSize: 13, color: '#333' },
+  sortSelect: { padding: '6px 10px', border: '1px solid #ddd', borderRadius: 8, fontSize: 13, color: '#333', background: '#fff', cursor: 'pointer' },
+  clearBtn:  { fontSize: 12, padding: '5px 12px', borderRadius: 8, border: '1px solid #ddd', cursor: 'pointer', background: '#f5f5f5', color: '#555', fontWeight: 600 },
 };
 
 function StatusTimeline({ status }) {
@@ -84,7 +89,29 @@ export default function Orders() {
   const [allOrders, setAllOrders] = useState([]);
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = FILTER_TABS.includes(searchParams.get('status')) ? searchParams.get('status') : 'all';
-  const setActiveTab = (tab) => setSearchParams(tab === 'all' ? {} : { status: tab }, { replace: true });
+  const dateFrom = searchParams.get('date_from') || '';
+  const dateTo = searchParams.get('date_to') || '';
+  const sortBy = searchParams.get('sort') || 'newest';
+
+  const setActiveTab = (tab) => {
+    const p = {};
+    if (tab !== 'all') p.status = tab;
+    if (dateFrom) p.date_from = dateFrom;
+    if (dateTo) p.date_to = dateTo;
+    if (sortBy !== 'newest') p.sort = sortBy;
+    setSearchParams(p, { replace: true });
+  };
+
+  function setFilterParam(key, value) {
+    const p = {};
+    if (activeTab !== 'all') p.status = activeTab;
+    if (dateFrom) p.date_from = dateFrom;
+    if (dateTo) p.date_to = dateTo;
+    if (sortBy !== 'newest') p.sort = sortBy;
+    if (value) p[key] = value;
+    else delete p[key];
+    setSearchParams(p, { replace: true });
+  }
   const [loading, setLoading]      = useState(true);
   const [error, setError]          = useState(null);
   const [hovered, setHovered]      = useState(null);
@@ -189,7 +216,24 @@ export default function Orders() {
     spent:   allOrders.filter(o => o.status === 'paid').reduce((sum, o) => sum + parseFloat(o.total_price || 0), 0),
   };
 
-  const visible = activeTab === 'all' ? allOrders : allOrders.filter(o => o.status === activeTab);
+  let visible = activeTab === 'all' ? allOrders : allOrders.filter(o => o.status === activeTab);
+  if (dateFrom) {
+    const from = new Date(dateFrom);
+    visible = visible.filter(o => new Date(o.created_at) >= from);
+  }
+  if (dateTo) {
+    const to = new Date(dateTo + 'T23:59:59');
+    visible = visible.filter(o => new Date(o.created_at) <= to);
+  }
+  if (sortBy === 'oldest') {
+    visible = [...visible].sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  } else if (sortBy === 'total_asc') {
+    visible = [...visible].sort((a, b) => parseFloat(a.total_price) - parseFloat(b.total_price));
+  } else if (sortBy === 'total_desc') {
+    visible = [...visible].sort((a, b) => parseFloat(b.total_price) - parseFloat(a.total_price));
+  } else {
+    visible = [...visible].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+  }
 
   return (
     <div style={s.page}>
@@ -228,6 +272,49 @@ export default function Orders() {
             <div style={s.statCard}><div style={{ ...s.statNum, color: '#856404' }}>{stats.pending}</div><div style={s.statLabel}>Pending</div></div>
             <div style={s.statCard}><div style={{ ...s.statNum, color: '#c0392b' }}>{stats.failed}</div><div style={s.statLabel}>Failed</div></div>
             <div style={s.statCard}><div style={s.statNum}>{stats.spent.toFixed(2)}</div><div style={s.statLabel}>XLM Spent</div></div>
+          </div>
+
+          <div style={s.filters}>
+            <span style={s.filterLabel}>From:</span>
+            <input
+              type="date"
+              style={s.dateInput}
+              value={dateFrom}
+              max={dateTo || undefined}
+              onChange={e => setFilterParam('date_from', e.target.value)}
+            />
+            <span style={s.filterLabel}>To:</span>
+            <input
+              type="date"
+              style={s.dateInput}
+              value={dateTo}
+              min={dateFrom || undefined}
+              onChange={e => setFilterParam('date_to', e.target.value)}
+            />
+            <span style={s.filterLabel}>Sort:</span>
+            <select
+              style={s.sortSelect}
+              value={sortBy}
+              onChange={e => setFilterParam('sort', e.target.value === 'newest' ? '' : e.target.value)}
+            >
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="total_desc">Total ↓</option>
+              <option value="total_asc">Total ↑</option>
+            </select>
+            {(dateFrom || dateTo) && (
+              <button
+                style={s.clearBtn}
+                onClick={() => {
+                  const p = {};
+                  if (activeTab !== 'all') p.status = activeTab;
+                  if (sortBy !== 'newest') p.sort = sortBy;
+                  setSearchParams(p, { replace: true });
+                }}
+              >
+                Clear dates
+              </button>
+            )}
           </div>
 
           <div style={s.tabs}>


### PR DESCRIPTION
## Summary

Resolves four issues across the frontend: farmer profile enhancements, order filtering/sorting, product share buttons with Web Share API, and announcement banner dismissal persistence.

---

## Changes

### #647 — Announcement Banner Dismissal Persistence
- Already fully implemented in `AnnouncementBanner.jsx` prior to this PR.
- Dismissed announcement IDs are stored in `localStorage` under the key `dismissed_announcements`.
- On mount, the component reads dismissed IDs and filters them out so they never reappear after a page reload.
- Clicking × persists the ID to localStorage and removes the banner from the UI immediately.

### #646 — Product Share Buttons (Web Share API)
**File:** `frontend/src/components/ShareButtons.jsx`
- Detect `navigator.share` availability at render time via `canNativeShare`.
- Added `shareNative()` function that calls `navigator.share({ title, url, text })` and tracks the event via `onShare('native_share')`.
- When the Web Share API is supported (most mobile browsers), a native **"Share"** button appears before the platform-specific buttons, opening the OS-level share sheet.
- Twitter/X, WhatsApp, Facebook, and Copy Link buttons remain for all environments.
- `ShareButtons` was already imported and rendered on `ProductDetail.jsx` — no changes needed there.

### #645 — Order Filtering and Sorting
**File:** `frontend/src/pages/Orders.jsx`
- Added `date_from`, `date_to`, and `sort` URL query params (persisted via `useSearchParams`).
- All filter state is preserved when switching status tabs — `setActiveTab` now merges existing date/sort params instead of resetting them.
- Added `setFilterParam()` helper that updates a single param while preserving all others.
- Filter controls rendered between the stats cards and the status tabs:
  - **Date range:** From / To date pickers with min/max constraints to prevent invalid ranges.
  - **Sort:** dropdown with Newest first, Oldest first, Total ↓, Total ↑.
  - **Clear dates** button appears only when a date filter is active.
- `visible` orders are now filtered by date range then sorted client-side before rendering.

### #644 — Farmer Profile Page
**File:** `frontend/src/pages/FarmerProfile.jsx`
- **Verification badge:** A blue "✔ Verified Farmer" pill renders below the member-since line when `farmer.verified` is truthy (field already returned by the backend).
- **Paginated product grid:** Listings are sliced into pages of 9 (`PAGE_SIZE = 9`). A pagination bar with Prev / numbered page buttons / Next appears only when there are more than 9 listings.
- Page resets to 1 whenever the farmer `id` param changes.
- Used `useMemo` for the sliced page to avoid unnecessary recomputation.

---

Closes #644
Closes #645
Closes #646
Closes #647