### PR TITLE
fix: correct storage key usage in transfer_from function

### DIFF
--- a/contract/reward-token/src/lib.rs
+++ b/contract/reward-token/src/lib.rs
@@ -218,8 +218,8 @@ impl RewardToken {
             panic!("insufficient balance");
         }
         let to_balance = Self::balance(env.clone(), to.clone());
-        env.storage().persistent().set(&(BALANCE, from.clone()), &(from_balance - amount));
-        env.storage().persistent().set(&(BALANCE, to.clone()), &(to_balance + amount));
+        env.storage().persistent().set(&DataKey::Balance(from.clone()), &(from_balance - amount));
+        env.storage().persistent().set(&DataKey::Balance(to.clone()), &(to_balance + amount));
 
         env.events().publish(("transfer_from", spender, from, to), amount);
     }


### PR DESCRIPTION
## Issue
Implement approve, allowance, and transfer_from functions in the RewardToken contract following the Soroban token interface standard.

## Changes
- Fix incorrect storage key format in transfer_from function
- Use DataKey::Balance enum instead of tuple (BALANCE, address)
- Ensures consistent storage key serialization across SDK versions
- Maintains compatibility with existing balance storage format

## Implementation Details
The transfer_from function now correctly:
- Validates spender authorization
- Checks allowance expiration
- Verifies sufficient allowance
- Deducts from allowance
- Transfers tokens with proper storage keys
- Emits transfer_from event

## Testing
All existing tests pass, including:
- test_approve_and_allowance
- test_transfer_from_within_allowance
- test_transfer_from_exceeding_allowance_panics
- test_transfer_from_expired_allowance_panics

Closes #678 
