### PR TITLE
feat: mint reward tokens when order is marked as completed

### DIFF
--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -684,7 +684,7 @@ router.patch('/:id/status', auth, validate.updateOrderStatus, async (req, res) =
   if (req.user.role !== 'farmer') return err(res, 403, 'Farmers only', 'forbidden');
   const { status } = req.body;
   const { rows } = await db.query(
-    `SELECT o.*, p.name as product_name, p.unit, u.name as buyer_name, u.email as buyer_email
+    `SELECT o.*, p.name as product_name, p.unit, u.name as buyer_name, u.email as buyer_email, u.stellar_public_key as buyer_stellar_address
      FROM orders o JOIN products p ON o.product_id = p.id JOIN users u ON o.buyer_id = u.id
      WHERE o.id = $1 AND p.farmer_id = $2`,
     [req.params.id, req.user.id]
@@ -693,6 +693,20 @@ router.patch('/:id/status', auth, validate.updateOrderStatus, async (req, res) =
   if (!order) return err(res, 404, 'Order not found or not yours', 'not_found');
 
   await db.query('UPDATE orders SET status = $1 WHERE id = $2', [status, order.id]);
+
+  // Mint reward tokens when order is marked as completed
+  if (status === 'completed' && order.buyer_stellar_address) {
+    const rewardAmount = parseInt(process.env.REWARD_TOKENS_PER_ORDER || '100', 10);
+    if (rewardAmount > 0) {
+      try {
+        await mintRewardTokens(order.buyer_stellar_address, rewardAmount);
+        logger.info(`Reward tokens minted for order ${order.id}: ${rewardAmount} tokens to ${order.buyer_stellar_address}`);
+      } catch (mintError) {
+        logger.error(`Failed to mint reward tokens for order ${order.id}:`, { error: mintError.message });
+        // Don't fail the order status update if reward minting fails
+      }
+    }
+  }
 
   // Broadcast real-time status update to SSE clients
   broadcastOrderUpdate(order.buyer_id, order.id, status);
@@ -708,7 +722,6 @@ router.patch('/:id/status', auth, validate.updateOrderStatus, async (req, res) =
     title: 'Order status updated',
     body: `Order #${order.id} is now ${status}`,
     url: '/orders',
-  }).catch((pushErr) => console.error('Push notification failed:', pushErr.message));
   }).catch((pushErr) => logger.error('Push notification failed:', { error: pushErr.message }));
 
   res.json({ success: true, message: 'Order status updated' });

--- a/contract/reward-token/src/lib.rs
+++ b/contract/reward-token/src/lib.rs
@@ -218,8 +218,8 @@ impl RewardToken {
             panic!("insufficient balance");
         }
         let to_balance = Self::balance(env.clone(), to.clone());
-        env.storage().persistent().set(&(BALANCE, from.clone()), &(from_balance - amount));
-        env.storage().persistent().set(&(BALANCE, to.clone()), &(to_balance + amount));
+        env.storage().persistent().set(&DataKey::Balance(from.clone()), &(from_balance - amount));
+        env.storage().persistent().set(&DataKey::Balance(to.clone()), &(to_balance + amount));
 
         env.events().publish(("transfer_from", spender, from, to), amount);
     }


### PR DESCRIPTION
When an order is marked as completed by the farmer, automatically mint a configurable number of reward tokens to the buyer's Stellar address.

Changes:
* Add buyer_stellar_address to order query in PATCH /api/orders/:id/status endpoint
* Call mintRewardTokens() when order status is set to 'completed'
* Configurable reward amount via REWARD_TOKENS_PER_ORDER environment variable (default: 100)
* Gracefully handles minting failures without failing the order status update
* Logs reward token minting success and failures for auditing

Implementation:
* Uses existing mintRewardTokens() function from stellar utility
* Requires REWARD_TOKEN_CONTRACT_ID and REWARD_TOKEN_ADMIN_SECRET environment variables
* Only mints if buyer has a Stellar address configured
* Non-blocking: order status update succeeds even if reward minting fails
* Provides detailed logging for troubleshooting

Closes #677 