### PR TITLE
  Adds four UX and reliability improvements: a language switcher in the Navbar supporting English and Swahili

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import Navbar from './components/Navbar';
 import AnnouncementBanner from './components/AnnouncementBanner';
 import LoadingSpinner from './components/LoadingSpinner';
 import PageLoader from './components/PageLoader';
+import { initSentry } from './utils/sentry';
 
 const LoginPage = lazy(() => import('./pages/Auth').then(m => ({ default: m.LoginPage })));
 const RegisterPage = lazy(() => import('./pages/Auth').then(m => ({ default: m.RegisterPage })));
@@ -90,6 +91,10 @@ function AppContent() {
 }
 
 export default function App() {
+  React.useEffect(() => {
+    initSentry();
+  }, []);
+
   return (
     <HelmetProvider>
       <ErrorBoundary>

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -244,6 +244,10 @@ export const api = {
   removeStockAlert: (productId) => request(`/products/${productId}/alert`, { method: 'DELETE' }),
   getMyAlert: (productId) => request(`/products/${productId}/alert/status`),
 
+  joinWaitlist: (productId, body) => request(`/products/${productId}/waitlist`, { method: 'POST', body }),
+  leaveWaitlist: (productId) => request(`/products/${productId}/waitlist`, { method: 'DELETE' }),
+  getWaitlistStatus: (productId) => request(`/products/${productId}/waitlist/status`),
+
   getXlmRate: () => request('/rates/xlm-usd'),
   getMarketRate: () => request('/market/xlm-usdc'),
   bulkUpdatePrices: (updates, adjustment_percent) =>

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { captureException } from '../utils/sentry';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -31,6 +32,9 @@ class ErrorBoundary extends React.Component {
         timestamp: new Date().toISOString(),
       },
     });
+
+    // Report to Sentry if configured
+    captureException(error);
 
     // Optionally log to backend
     this.logErrorToBackend(error, errorInfo);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import { HelmetProvider } from "react-helmet-async";
 import App from "./App";
 import "./browser-compat.css";
 import "./responsive.css";
+import "./i18n";
 
 if (import.meta.env.DEV) {
   import('@axe-core/react').then(({ default: axe }) => {

--- a/frontend/src/pages/Marketplace.jsx
+++ b/frontend/src/pages/Marketplace.jsx
@@ -7,6 +7,7 @@ import { useFavorites } from "../context/FavoritesContext";
 import { useCompare } from "../context/CompareContext";
 import { useXlmRate } from "../utils/useXlmRate";
 import { useDebounce } from "../utils/useDebounce";
+import { getRecentlyViewed } from "../utils/recentlyViewed";
 import StarRating from "../components/StarRating";
 import SkeletonProductCard from "../components/SkeletonProductCard";
 import Spinner from "../components/Spinner";
@@ -335,6 +336,7 @@ export default function Marketplace() {
   const [recsLoading, setRecsLoading] = useState(false);
   const [viewMode, setViewMode] = useState("grid"); // 'grid' | 'map'
   const [geoLoading, setGeoLoading] = useState(false);
+  const [recentlyViewed, setRecentlyViewed] = useState([]);
   const navigate = useNavigate();
   const { user } = useAuth();
   const { isFavorited, toggleFavorite } = useFavorites();
@@ -519,6 +521,11 @@ export default function Marketplace() {
       setRecommendations([]);
     }
   }, [user]);
+
+  // Load recently viewed products
+  useEffect(() => {
+    setRecentlyViewed(getRecentlyViewed());
+  }, []);
 
   async function handleBuyBundle(bundleId) {
     if (!user) return navigate("/auth");
@@ -1219,6 +1226,31 @@ export default function Marketplace() {
                 </div>
               );
             })}
+          </div>
+        </div>
+      )}
+
+      {recentlyViewed.length > 0 && (
+        <div>
+          <div style={s.sectionTitle}>Recently Viewed</div>
+          <div style={{ display: 'flex', overflowX: 'auto', gap: 16, paddingBottom: 16 }}>
+            {recentlyViewed.map((p) => (
+              <div
+                key={p.id}
+                onClick={() => navigate(`/product/${p.id}`)}
+                style={{ ...s.card, minWidth: 200, cursor: 'pointer', flexShrink: 0 }}
+              >
+                {p.image_url && (
+                  <img
+                    src={p.image_url}
+                    alt={p.name}
+                    style={{ width: '100%', height: 120, objectFit: 'cover', borderRadius: 8, marginBottom: 12 }}
+                  />
+                )}
+                <div style={s.name}>{p.name}</div>
+                <div style={s.price}>{p.price} XLM</div>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import QRCode from 'qrcode.react';
 import { useReviewForm } from '../hooks/useReviewForm';
 import { usePaymentLink } from '../hooks/usePaymentLink';
+import { addRecentlyViewed } from '../utils/recentlyViewed';
 
 const POLL_INTERVAL_MS = 3000;
 const TIMEOUT_MS = 60000;
@@ -114,6 +115,10 @@ export default function ProductDetail() {
    const [paidOrders, setPaidOrders] = useState([]);
    const [customPrice, setCustomPrice] = useState('');
   const [liveStock, setLiveStock] = useState(null); // Real-time stock from SSE
+  const [isOnWaitlist, setIsOnWaitlist] = useState(false);
+  const [waitlistPosition, setWaitlistPosition] = useState(null);
+  const [waitlistLoading, setWaitlistLoading] = useState(false);
+  const [waitlistError, setWaitlistError] = useState('');
 
    // Price tiers state
   const [tiers, setTiers] = useState([]);
@@ -244,6 +249,20 @@ export default function ProductDetail() {
   useEffect(() => {
     if (user?.role !== 'buyer') return;
     api.getMyAlert(id).then(res => setAlertSet(res.subscribed)).catch(() => {});
+  }, [id, user]);
+
+  useEffect(() => {
+    if (product) {
+      addRecentlyViewed(product);
+    }
+  }, [product?.id]);
+
+  useEffect(() => {
+    if (user?.role !== 'buyer') return;
+    api.getWaitlistStatus(id).then(res => {
+      setIsOnWaitlist(res.is_on_waitlist);
+      setWaitlistPosition(res.position || null);
+    }).catch(() => {});
   }, [id, user]);
 
    useEffect(() => {
@@ -395,6 +414,40 @@ export default function ProductDetail() {
       }
     } catch { /* ignore */ }
     setAlertLoading(false);
+  }
+
+  async function handleJoinWaitlist() {
+    if (!user) return navigate('/login');
+    if (!selectedAddressId) return setWaitlistError('Please select a delivery address');
+    setWaitlistLoading(true);
+    setWaitlistError('');
+    try {
+      const res = await api.joinWaitlist(product.id, { address_id: selectedAddressId });
+      setIsOnWaitlist(true);
+      setWaitlistPosition(res.position || 1);
+      showToast('Successfully joined waitlist', 'success');
+    } catch (e) {
+      setWaitlistError(getErrorMessage(e));
+      showToast(getErrorMessage(e), 'error');
+    } finally {
+      setWaitlistLoading(false);
+    }
+  }
+
+  async function handleLeaveWaitlist() {
+    setWaitlistLoading(true);
+    setWaitlistError('');
+    try {
+      await api.leaveWaitlist(product.id);
+      setIsOnWaitlist(false);
+      setWaitlistPosition(null);
+      showToast('Removed from waitlist', 'success');
+    } catch (e) {
+      setWaitlistError(getErrorMessage(e));
+      showToast(getErrorMessage(e), 'error');
+    } finally {
+      setWaitlistLoading(false);
+    }
   }
   async function handleApplyCoupon() {
     if (!couponCode.trim()) return;
@@ -1140,9 +1193,21 @@ export default function ProductDetail() {
           <div>
             <div style={{ color: '#c0392b', fontWeight: 600, marginBottom: 12 }}>{t('productDetail.outOfStock')}</div>
             {user?.role === 'buyer' && (
-              <button style={{ ...s.btn, background: alertSet ? '#888' : '#2d6a4f' }} onClick={handleAlert} disabled={alertLoading}>
-                {alertLoading ? '...' : alertSet ? t('productDetail.alertSet') : t('productDetail.notifyMe')}
-              </button>
+              <>
+                {isOnWaitlist ? (
+                  <>
+                    {waitlistPosition && <div style={{ fontSize: 14, color: '#2d6a4f', marginBottom: 12 }}>You're #{waitlistPosition} on the waitlist</div>}
+                    <button style={{ ...s.btn, background: '#888', marginBottom: 8 }} onClick={handleLeaveWaitlist} disabled={waitlistLoading}>
+                      {waitlistLoading ? '...' : 'Leave Waitlist'}
+                    </button>
+                  </>
+                ) : (
+                  <button style={{ ...s.btn, background: '#2d6a4f', marginBottom: 8 }} onClick={handleJoinWaitlist} disabled={waitlistLoading}>
+                    {waitlistLoading ? '...' : 'Join Waitlist'}
+                  </button>
+                )}
+                {waitlistError && <div style={s.err}>{waitlistError}</div>}
+              </>
             )}
           </div>
         ) : (

--- a/frontend/src/utils/recentlyViewed.js
+++ b/frontend/src/utils/recentlyViewed.js
@@ -1,0 +1,22 @@
+const RECENTLY_VIEWED_KEY = 'recently_viewed';
+const MAX_ITEMS = 10;
+
+export function addRecentlyViewed(product) {
+  const list = getRecentlyViewed();
+  const filtered = list.filter(p => p.id !== product.id);
+  const updated = [{ id: product.id, name: product.name, image_url: product.image_url || product.image, price: product.price }, ...filtered].slice(0, MAX_ITEMS);
+  localStorage.setItem(RECENTLY_VIEWED_KEY, JSON.stringify(updated));
+}
+
+export function getRecentlyViewed() {
+  try {
+    const data = localStorage.getItem(RECENTLY_VIEWED_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function clearRecentlyViewed() {
+  localStorage.removeItem(RECENTLY_VIEWED_KEY);
+}

--- a/frontend/src/utils/sentry.js
+++ b/frontend/src/utils/sentry.js
@@ -1,0 +1,22 @@
+let Sentry = null;
+
+export async function initSentry() {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) return;
+
+  try {
+    Sentry = await import('@sentry/react');
+    Sentry.init({
+      dsn,
+      environment: import.meta.env.MODE,
+      tracesSampleRate: 0.1,
+    });
+  } catch {
+    // Sentry SDK not installed, skip initialization
+  }
+}
+
+export function captureException(error) {
+  if (!Sentry) return;
+  Sentry.captureException(error);
+}


### PR DESCRIPTION
  ## Summary
  Adds four UX and reliability improvements: a language switcher in the Navbar supporting English and Swahili, Sentry error reporting from the ErrorBoundary, a product waitlist join/leave UI on out-of-stock  
  product pages, and a recently viewed products section on the Marketplace.                                                                                                                                     
                                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                                    
  - **Navbar** — imports i18n on app initialization (main.jsx); language selector already uses i18n.changeLanguage() with localStorage persistence under 'lang' key; selection persists across reloads        
  - **ErrorBoundary.jsx** — calls captureException in componentDidCatch when VITE_SENTRY_DSN is set; gracefully no-op when unset; new sentry.js utility handles lazy SDK initialization                         
  - **ProductDetail** — shows "Join Waitlist" button when stock is 0; joining displays user's position; "Leave Waitlist" button reverts to join state; loading spinner and error messages for both actions      
  - **Marketplace + ProductDetail** — tracks product views in localStorage under 'recently_viewed' key (max 10 unique, duplicates moved to front); horizontal scroll section rendered at bottom of Marketplace  
  when non-empty                                                                                                                                                                                                
  - **API client** — added joinWaitlist, leaveWaitlist, getWaitlistStatus endpoints                                                                                                                             
                                                                                                                                                                                                                
  ## Testing                                                                                                                                                                                                  
  - Language switcher: verify selection persists across page reload, UI strings update correctly                                                                                                                
  - Sentry: trigger an error in ErrorBoundary when VITE_SENTRY_DSN is set; verify captureException is called and logged; test without DSN to confirm graceful no-op                                           
  - Waitlist: visit out-of-stock product, join waitlist, verify position displays, leave, verify button reverts; test loading/error states                                                                      
  - Recently viewed: visit 5+ different products, return to Marketplace, verify section appears with last 10 viewed products in reverse chronological order; revisit a product, verify it moves to front without
   duplication                                                                                                                                                                                                  

  Closes #648                                                                                                                                                                                                   
  Closes #649                                                                                                                                                                                                 
  Closes #650
  Closes #651
