### PR TITLE
feat: Add push notification history tracking and expose GET /api/notifications/history

### DIFF
--- a/backend/migrations/016_push_notification_history.sql
+++ b/backend/migrations/016_push_notification_history.sql
@@ -1,0 +1,12 @@
+-- Migration: 016_push_notification_history
+CREATE TABLE IF NOT EXISTS push_notification_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  endpoint TEXT,
+  title TEXT,
+  body TEXT,
+  payload TEXT,
+  status TEXT NOT NULL CHECK(status IN ('sent','delivered','failed')),
+  error TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/migrations/016_push_notification_history.undo.sql
+++ b/backend/migrations/016_push_notification_history.undo.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS push_notification_history;

--- a/backend/src/__tests__/notifications.test.js
+++ b/backend/src/__tests__/notifications.test.js
@@ -1,0 +1,101 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+process.env.NODE_ENV = 'test';
+
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+
+jest.mock('../db/schema', () => ({
+  query: jest.fn(),
+  isPostgres: false,
+  placeholder: () => '?',
+}));
+
+jest.mock('web-push', () => ({
+  sendNotification: jest.fn(),
+  setVapidDetails: jest.fn(),
+}));
+
+const mockDb = require('../db/schema');
+const webpush = require('web-push');
+const app = require('../app');
+const { sendPushToUser } = require('../utils/pushNotifications');
+
+const SECRET = process.env.JWT_SECRET;
+const userToken = jwt.sign({ id: 1, role: 'buyer' }, SECRET);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('push notification delivery history', () => {
+  it('records delivered status when push send succeeds', async () => {
+    const subscription = { endpoint: 'https://example.com/push', keys: { p256dh: 'p256dh', auth: 'auth' } };
+    mockDb.query.mockImplementation(async (sql) => {
+      if (sql.includes('CREATE TABLE IF NOT EXISTS push_subscriptions')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('CREATE TABLE IF NOT EXISTS push_notification_history')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('SELECT id, subscription FROM push_subscriptions')) {
+        return { rows: [{ id: 1, subscription: JSON.stringify(subscription) }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO push_notification_history')) {
+        return { rows: [{ id: 42 }], rowCount: 1 };
+      }
+      if (sql.includes('SELECT last_insert_rowid() AS id')) {
+        return { rows: [{ id: 42 }], rowCount: 1 };
+      }
+      if (sql.includes('UPDATE push_notification_history')) {
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    webpush.sendNotification.mockResolvedValue();
+
+    await sendPushToUser(1, { title: 'Test', body: 'Hello', url: '/test' });
+
+    expect(webpush.sendNotification).toHaveBeenCalledWith(subscription, JSON.stringify({ title: 'Test', body: 'Hello', url: '/test' }));
+    expect(mockDb.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO push_notification_history'), expect.any(Array));
+    expect(mockDb.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE push_notification_history'), ['delivered', null, 42]);
+  });
+});
+
+describe('GET /api/notifications/history', () => {
+  it('returns the authenticated user notification history', async () => {
+    mockDb.query.mockImplementation(async (sql) => {
+      if (sql.includes('SELECT active FROM users WHERE id')) {
+        return { rows: [{ active: 1 }], rowCount: 1 };
+      }
+      if (sql.includes('SELECT COUNT(*)')) {
+        return { rows: [{ count: '1' }], rowCount: 1 };
+      }
+      if (sql.includes('SELECT id, title, body, status, error, created_at')) {
+        return {
+          rows: [
+            {
+              id: 1,
+              title: 'Test Notification',
+              body: 'Delivery history works',
+              status: 'delivered',
+              error: null,
+              created_at: '2026-06-02T00:00:00Z',
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const res = await request(app)
+      .get('/api/notifications/history')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].status).toBe('delivered');
+  });
+});

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const auth = require('../middleware/auth');
 const { err } = require('../middleware/error');
+const db = require('../db/schema');
 const {
   VAPID_PUBLIC_KEY,
   savePushSubscription,
@@ -13,6 +14,39 @@ router.get('/vapid-public-key', (_req, res) => {
     return err(res, 503, 'Web Push is not configured', 'push_not_configured');
   }
   res.json({ success: true, data: { publicKey: VAPID_PUBLIC_KEY } });
+});
+
+router.get('/history', auth, async (req, res) => {
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 20));
+  const offset = (page - 1) * limit;
+
+  try {
+    const { rows: countRows } = await db.query(
+      'SELECT COUNT(*) as count FROM push_notification_history WHERE user_id = $1',
+      [req.user.id]
+    );
+    const total = parseInt(countRows[0]?.count || 0, 10);
+    const { rows: data } = await db.query(
+      `SELECT id, title, body, status, error, created_at
+       FROM push_notification_history
+       WHERE user_id = $1
+       ORDER BY created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [req.user.id, limit, offset]
+    );
+
+    res.json({
+      success: true,
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    });
+  } catch (e) {
+    res.status(500).json({ success: false, message: e.message, code: 'notification_history_error' });
+  }
 });
 
 router.post('/subscribe', auth, async (req, res) => {

--- a/backend/src/utils/pushNotifications.js
+++ b/backend/src/utils/pushNotifications.js
@@ -27,6 +27,46 @@ async function ensurePushSubscriptionTable() {
   );
 }
 
+async function ensurePushNotificationHistoryTable() {
+  await db.query(
+    `CREATE TABLE IF NOT EXISTS push_notification_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      endpoint TEXT,
+      title TEXT,
+      body TEXT,
+      payload TEXT,
+      status TEXT NOT NULL CHECK(status IN ('sent','delivered','failed')),
+      error TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`
+  );
+}
+
+async function insertPushNotificationHistory({ userId, endpoint, title, body, payload, status, error }) {
+  await ensurePushNotificationHistoryTable();
+  const query = db.isPostgres
+    ? `INSERT INTO push_notification_history (user_id, endpoint, title, body, payload, status, error)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`
+    : `INSERT INTO push_notification_history (user_id, endpoint, title, body, payload, status, error)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`;
+  const params = [userId, endpoint, title, body, JSON.stringify(payload), status, error || null];
+  const result = await db.query(query, params);
+  if (db.isPostgres) {
+    return result.rows[0]?.id;
+  }
+  const lastRow = await db.query('SELECT last_insert_rowid() AS id');
+  return lastRow.rows[0]?.id;
+}
+
+async function updatePushNotificationHistoryStatus(id, status, error) {
+  if (!id) return;
+  const query = db.isPostgres
+    ? 'UPDATE push_notification_history SET status = $1, error = $2 WHERE id = $3'
+    : 'UPDATE push_notification_history SET status = ?, error = ? WHERE id = ?';
+  await db.query(query, [status, error || null, id]);
+}
+
 async function savePushSubscription(userId, subscription) {
   await ensurePushSubscriptionTable();
   const serialized = JSON.stringify(subscription);
@@ -68,9 +108,23 @@ async function sendPushToUser(userId, payload) {
   const { rows } = await db.query(query, [userId]);
   if (!rows[0]) return;
 
+  const subscription = JSON.parse(rows[0].subscription);
+  const endpoint = subscription.endpoint || null;
+  const historyId = await insertPushNotificationHistory({
+    userId,
+    endpoint,
+    title: payload.title,
+    body: payload.body,
+    payload,
+    status: 'sent',
+    error: null,
+  });
+
   try {
-    await webpush.sendNotification(JSON.parse(rows[0].subscription), JSON.stringify(payload));
+    await webpush.sendNotification(subscription, JSON.stringify(payload));
+    await updatePushNotificationHistoryStatus(historyId, 'delivered', null);
   } catch (e) {
+    await updatePushNotificationHistoryStatus(historyId, 'failed', e?.message || String(e));
     if (e?.statusCode === 404 || e?.statusCode === 410) {
       await deletePushSubscription(userId);
       return;
@@ -84,6 +138,9 @@ module.exports = {
   isConfigured,
   configureWebPush,
   ensurePushSubscriptionTable,
+  ensurePushNotificationHistoryTable,
+  insertPushNotificationHistory,
+  updatePushNotificationHistoryStatus,
   savePushSubscription,
   deletePushSubscription,
   sendPushToUser,

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -54,8 +54,10 @@ export function LoginPage() {
   const navigate = useNavigate();
 
   function handleChange(field, value) {
-    setForm(f => ({ ...f, [field]: value }));
-    if (errors[field]) setErrors(e => ({ ...e, [field]: '' }));
+    const updatedForm = { ...form, [field]: value };
+    setForm(updatedForm);
+    const fieldErrors = validateLogin(updatedForm);
+    setErrors((prev) => ({ ...prev, [field]: fieldErrors[field] || '' }));
   }
 
   async function handleSubmit(e) {
@@ -91,6 +93,7 @@ export function LoginPage() {
             <label style={s.label} htmlFor="login-password">{t('auth.password')}</label>
             <input id="login-password" style={errors.password ? s.inputErr : s.input} type="password"
               value={form.password} onChange={e => handleChange('password', e.target.value)} autoComplete="current-password" />
+            <PasswordStrength password={form.password} />
             {errors.password && <div style={s.err} role="alert">{errors.password}</div>}
           </div>
           {formError && <div style={s.formErr} role="alert">{formError}</div>}
@@ -114,8 +117,10 @@ export function RegisterPage() {
   const refCode = searchParams.get('ref');
 
   function handleChange(field, value) {
-    setForm(f => ({ ...f, [field]: value }));
-    if (errors[field]) setErrors(e => ({ ...e, [field]: '' }));
+    const updatedForm = { ...form, [field]: value };
+    setForm(updatedForm);
+    const fieldErrors = validateRegister(updatedForm);
+    setErrors((prev) => ({ ...prev, [field]: fieldErrors[field] || '' }));
   }
 
   async function handleSubmit(e) {


### PR DESCRIPTION
# PR Summary

- Track push notification delivery status in the database and expose GET /api/notifications/history so users can see past push notification events.
- Add inline field-level validation messages on login/register forms with real-time email format and password strength feedback.

## Closes
Closes #619 
Closes #635 