### PR TITLE
feat: share native API + image crop validation + favorites persistence + loading counter

### DIFF
--- a/backend/src/routes/productShare.js
+++ b/backend/src/routes/productShare.js
@@ -47,7 +47,7 @@ router.post('/:id/share', async (req, res) => {
   const platform = String(req.body.platform || '')
     .trim()
     .toLowerCase();
-  const allowed = new Set(['whatsapp', 'twitter', 'facebook', 'copy_link']);
+  const allowed = new Set(['whatsapp', 'twitter', 'facebook', 'copy_link', 'native_share']);
   if (!allowed.has(platform)) {
     return err(res, 400, 'Invalid platform', 'validation_error');
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,14 +45,14 @@ function Home() {
 }
 
 function AppContent() {
-  const { setLoading } = useContext(LoadingContext);
+  const { startLoading, stopLoading } = useContext(LoadingContext);
   const { logout } = useAuth();
   const location = useLocation();
 
   useEffect(() => {
-    setLoadingCallback(setLoading);
+    setLoadingCallback((isStart) => isStart ? startLoading() : stopLoading());
     setLogoutCallback(logout);
-  }, [setLoading, logout]);
+  }, [startLoading, stopLoading, logout]);
 
   // Announce page changes to screen readers
   useEffect(() => {

--- a/frontend/src/components/ImageCropModal.jsx
+++ b/frontend/src/components/ImageCropModal.jsx
@@ -1,16 +1,24 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 
 const HANDLE = 8;
+const ASPECT_RATIO = 4 / 3;
+const MIN_CROP_PX = 300;
+const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
 
-export default function ImageCropModal({ src, onConfirm, onCancel }) {
+const HANDLE_ORDER = ['body', 'tl', 'tr', 'bl', 'br'];
+
+export default function ImageCropModal({ src, onConfirm, onCancel, isGalleryImage = false }) {
   const canvasRef = useRef(null);
   const imgRef = useRef(null);
   const [loaded, setLoaded] = useState(false);
-  // crop box in canvas coords
   const [crop, setCrop] = useState({ x: 0, y: 0, w: 0, h: 0 });
-  const drag = useRef(null); // { type: 'move'|'resize', sx, sy, ox, oy, ow, oh }
+  const [aspectLocked, setAspectLocked] = useState(true);
+  const [validationError, setValidationError] = useState(null);
+  const [activeHandle, setActiveHandle] = useState('body');
+  const drag = useRef(null);
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -19,25 +27,21 @@ export default function ImageCropModal({ src, onConfirm, onCancel }) {
     const ctx = canvas.getContext('2d');
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-    // dim outside crop
     ctx.fillStyle = 'rgba(0,0,0,0.45)';
     const { x, y, w, h } = crop;
     ctx.fillRect(0, 0, canvas.width, y);
     ctx.fillRect(0, y + h, canvas.width, canvas.height - y - h);
     ctx.fillRect(0, y, x, h);
     ctx.fillRect(x + w, y, canvas.width - x - w, h);
-    // border
     ctx.strokeStyle = '#fff';
     ctx.lineWidth = 2;
     ctx.strokeRect(x, y, w, h);
-    // rule-of-thirds
     ctx.strokeStyle = 'rgba(255,255,255,0.35)';
     ctx.lineWidth = 1;
     for (let i = 1; i < 3; i++) {
       ctx.beginPath(); ctx.moveTo(x + (w / 3) * i, y); ctx.lineTo(x + (w / 3) * i, y + h); ctx.stroke();
       ctx.beginPath(); ctx.moveTo(x, y + (h / 3) * i); ctx.lineTo(x + w, y + (h / 3) * i); ctx.stroke();
     }
-    // corner handles
     ctx.fillStyle = '#fff';
     [[x, y], [x + w, y], [x, y + h], [x + w, y + h]].forEach(([hx, hy]) => {
       ctx.fillRect(hx - HANDLE / 2, hy - HANDLE / 2, HANDLE, HANDLE);
@@ -47,14 +51,22 @@ export default function ImageCropModal({ src, onConfirm, onCancel }) {
   useEffect(() => { draw(); }, [draw]);
 
   function initCrop(cw, ch) {
-    const size = Math.min(cw, ch) * 0.8;
-    setCrop({ x: (cw - size) / 2, y: (ch - size) / 2, w: size, h: size });
+    const maxW = cw * 0.85;
+    const maxH = ch * 0.85;
+    let w, h;
+    if (maxW / maxH > ASPECT_RATIO) {
+      h = maxH;
+      w = h * ASPECT_RATIO;
+    } else {
+      w = maxW;
+      h = w / ASPECT_RATIO;
+    }
+    setCrop({ x: (cw - w) / 2, y: (ch - h) / 2, w, h });
   }
 
   function onImgLoad() {
     const img = imgRef.current;
     const canvas = canvasRef.current;
-    // fit inside 480×480
     const maxW = 480, maxH = 480;
     const scale = Math.min(maxW / img.naturalWidth, maxH / img.naturalHeight, 1);
     canvas.width = Math.round(img.naturalWidth * scale);
@@ -102,44 +114,160 @@ export default function ImageCropModal({ src, onConfirm, onCancel }) {
       }));
     } else {
       const nw = clamp(ow + dx, 20, cw - ox);
-      const nh = clamp(oh + dy, 20, ch - oy);
-      setCrop(c => ({ ...c, w: nw, h: nh }));
+      if (aspectLocked) {
+        const nh = clamp(nw / ASPECT_RATIO, 20, ch - oy);
+        setCrop(c => ({ ...c, w: nh * ASPECT_RATIO, h: nh }));
+      } else {
+        const nh = clamp(oh + dy, 20, ch - oy);
+        setCrop(c => ({ ...c, w: nw, h: nh }));
+      }
     }
   }
 
   function onUp() { drag.current = null; }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      setActiveHandle(current => {
+        const idx = HANDLE_ORDER.indexOf(current);
+        const next = e.shiftKey
+          ? (idx - 1 + HANDLE_ORDER.length) % HANDLE_ORDER.length
+          : (idx + 1) % HANDLE_ORDER.length;
+        return HANDLE_ORDER[next];
+      });
+      return;
+    }
+
+    const ARROWS = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+    if (!canvasRef.current || !ARROWS.includes(e.key)) return;
+    e.preventDefault();
+
+    const STEP = 3;
+    const dx = e.key === 'ArrowRight' ? STEP : e.key === 'ArrowLeft' ? -STEP : 0;
+    const dy = e.key === 'ArrowDown' ? STEP : e.key === 'ArrowUp' ? -STEP : 0;
+    const cw = canvasRef.current.width;
+    const ch = canvasRef.current.height;
+
+    setCrop(prev => {
+      let { x, y, w, h } = prev;
+      switch (activeHandle) {
+        case 'body':
+          x = clamp(x + dx, 0, cw - w);
+          y = clamp(y + dy, 0, ch - h);
+          break;
+        case 'tl': {
+          const nx = clamp(x + dx, 0, x + w - 20);
+          w = w + (x - nx);
+          x = nx;
+          const ny = clamp(y + dy, 0, y + h - 20);
+          h = h + (y - ny);
+          y = ny;
+          break;
+        }
+        case 'tr':
+          w = clamp(w + dx, 20, cw - x);
+          { const ny = clamp(y + dy, 0, y + h - 20); h = h + (y - ny); y = ny; }
+          break;
+        case 'bl': {
+          const nx = clamp(x + dx, 0, x + w - 20);
+          w = w + (x - nx);
+          x = nx;
+          h = clamp(h + dy, 20, ch - y);
+          break;
+        }
+        case 'br':
+          w = clamp(w + dx, 20, cw - x);
+          h = clamp(h + dy, 20, ch - y);
+          break;
+        default:
+          break;
+      }
+      if (aspectLocked) {
+        h = w / ASPECT_RATIO;
+        if (y + h > ch) { h = ch - y; w = h * ASPECT_RATIO; }
+      }
+      return { x, y, w, h };
+    });
+  }
 
   function handleConfirm() {
     const img = imgRef.current;
     const canvas = canvasRef.current;
     const scaleX = img.naturalWidth / canvas.width;
     const scaleY = img.naturalHeight / canvas.height;
+
+    const naturalW = Math.round(crop.w * scaleX);
+    const naturalH = Math.round(crop.h * scaleY);
+
+    if (naturalW < MIN_CROP_PX || naturalH < MIN_CROP_PX) {
+      setValidationError(`Crop must be at least ${MIN_CROP_PX}×${MIN_CROP_PX} px. Current: ${naturalW}×${naturalH} px.`);
+      return;
+    }
+    setValidationError(null);
+
     const out = document.createElement('canvas');
-    out.width = Math.round(crop.w * scaleX);
-    out.height = Math.round(crop.h * scaleY);
+    out.width = naturalW;
+    out.height = naturalH;
     out.getContext('2d').drawImage(
       img,
       crop.x * scaleX, crop.y * scaleY, crop.w * scaleX, crop.h * scaleY,
       0, 0, out.width, out.height,
     );
-    out.toBlob(blob => onConfirm(blob), 'image/jpeg', 0.92);
+    out.toBlob(blob => {
+      if (!blob) { setValidationError('Failed to generate image.'); return; }
+      if (blob.size > MAX_SIZE_BYTES) { setValidationError('Image exceeds the 5 MB limit.'); return; }
+      if (!ALLOWED_TYPES.includes(blob.type)) { setValidationError('Unsupported format. Use JPEG, PNG, or WebP.'); return; }
+      onConfirm(blob);
+    }, 'image/jpeg', 0.92);
   }
+
+  const handleLabel = { body: 'Move crop', tl: 'Top-left handle', tr: 'Top-right handle', bl: 'Bottom-left handle', br: 'Bottom-right handle' };
 
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.65)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2000 }}>
       <div style={{ background: '#fff', borderRadius: 14, padding: 24, maxWidth: 540, width: '95%', boxShadow: '0 8px 32px #0004' }}>
-        <div style={{ fontWeight: 700, fontSize: 16, color: '#2d6a4f', marginBottom: 12 }}>✂️ Crop Image</div>
-        <div style={{ fontSize: 13, color: '#888', marginBottom: 12 }}>Drag the box to move · drag a corner to resize</div>
+        <div style={{ fontWeight: 700, fontSize: 16, color: '#2d6a4f', marginBottom: 12 }}>Crop Image</div>
+        <div style={{ fontSize: 13, color: '#888', marginBottom: 8 }}>
+          Drag the box to move · drag a corner to resize · Tab cycles handles · arrow keys nudge
+        </div>
+
+        {isGalleryImage && (
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginBottom: 12, cursor: 'pointer', userSelect: 'none' }}>
+            <input
+              type="checkbox"
+              checked={aspectLocked}
+              onChange={e => setAspectLocked(e.target.checked)}
+            />
+            Lock 4:3 aspect ratio
+          </label>
+        )}
+
+        <div style={{ fontSize: 12, color: '#2d6a4f', marginBottom: 8 }}>
+          Active handle: <strong>{handleLabel[activeHandle]}</strong>
+        </div>
+
         <div style={{ overflowX: 'auto', marginBottom: 16 }}>
           <canvas
             ref={canvasRef}
-            style={{ display: 'block', cursor: 'crosshair', touchAction: 'none', maxWidth: '100%' }}
+            tabIndex={0}
+            role="application"
+            aria-label="Image crop tool. Tab cycles between handles. Arrow keys move or resize the crop area."
+            style={{ display: 'block', cursor: 'crosshair', touchAction: 'none', maxWidth: '100%', outline: 'none' }}
             onMouseDown={onDown} onMouseMove={onMove} onMouseUp={onUp} onMouseLeave={onUp}
             onTouchStart={onDown} onTouchMove={onMove} onTouchEnd={onUp}
+            onKeyDown={handleKeyDown}
           />
         </div>
-        {/* hidden img used as draw source */}
+
         <img ref={imgRef} src={src} onLoad={onImgLoad} style={{ display: 'none' }} alt="" />
+
+        {validationError && (
+          <div style={{ color: '#dc2626', fontSize: 13, marginBottom: 12, padding: '8px 12px', background: '#fef2f2', borderRadius: 6, border: '1px solid #fecaca' }}>
+            {validationError}
+          </div>
+        )}
+
         <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
           <button onClick={onCancel} style={{ padding: '9px 20px', borderRadius: 8, border: '1px solid #ddd', background: '#fff', cursor: 'pointer', fontWeight: 600 }}>Cancel</button>
           <button onClick={handleConfirm} disabled={!loaded} style={{ padding: '9px 20px', borderRadius: 8, border: 'none', background: '#2d6a4f', color: '#fff', cursor: 'pointer', fontWeight: 600 }}>Use Crop</button>

--- a/frontend/src/components/ShareButtons.jsx
+++ b/frontend/src/components/ShareButtons.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+import { api } from "../api/client";
 
 const s = {
   wrap: { marginTop: 16 },
@@ -31,7 +32,7 @@ const s = {
   toastError: { background: "#dc2626" },
 };
 
-export default function ShareButtons({ title, url, onShare }) {
+export default function ShareButtons({ productId, title, url, onShare }) {
   const [toast, setToast] = useState(null);
   const encodedUrl = encodeURIComponent(url);
   const encodedText = encodeURIComponent(`${title} ${url}`);
@@ -39,49 +40,39 @@ export default function ShareButtons({ title, url, onShare }) {
 
   const showToast = useCallback((message, type) => {
     setToast({ message, type });
-    setTimeout(() => setToast(null), 2500);
+    setTimeout(() => setToast(null), 2000);
   }, []);
 
-  function track(platform) {
+  async function recordShare(platform) {
     if (typeof onShare === "function") onShare(platform);
+    if (productId) {
+      try {
+        await api.trackShareEvent(productId, platform);
+      } catch { /* non-critical */ }
+    }
   }
 
   async function shareNative() {
     try {
       await navigator.share({ title, url, text: title });
-      track("native_share");
+      await recordShare("native_share");
     } catch (e) {
       if (e.name !== "AbortError") showToast("Share failed", "error");
     }
   }
 
   function shareWhatsApp() {
-    track("whatsapp");
-    window.open(
-      `https://wa.me/?text=${encodedText}`,
-      "_blank",
-      "noopener,noreferrer",
-    );
+    window.open(`https://wa.me/?text=${encodedText}`, "_blank", "noopener,noreferrer");
+    recordShare("whatsapp");
   }
 
   function shareTwitter() {
-    track("twitter");
     window.open(
-      `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-        title,
-      )}&url=${encodedUrl}`,
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodedUrl}`,
       "_blank",
       "noopener,noreferrer",
     );
-  }
-
-  function shareFacebook() {
-    track("facebook");
-    window.open(
-      `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
-      "_blank",
-      "noopener,noreferrer",
-    );
+    recordShare("twitter");
   }
 
   async function copyLink() {
@@ -89,7 +80,6 @@ export default function ShareButtons({ title, url, onShare }) {
       if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
         await navigator.clipboard.writeText(url);
       } else {
-        // Fallback for older browsers
         const textarea = document.createElement("textarea");
         textarea.value = url;
         textarea.style.position = "fixed";
@@ -99,7 +89,7 @@ export default function ShareButtons({ title, url, onShare }) {
         document.execCommand("copy");
         document.body.removeChild(textarea);
       }
-      track("copy_link");
+      await recordShare("copy_link");
       showToast("Copied!", "success");
     } catch {
       showToast("Failed to copy link", "error");
@@ -110,23 +100,23 @@ export default function ShareButtons({ title, url, onShare }) {
     <div style={s.wrap}>
       <div style={s.title}>Share this product</div>
       <div style={s.row}>
-        {canNativeShare && (
+        {canNativeShare ? (
           <button type="button" style={s.btn} onClick={shareNative}>
             Share
           </button>
+        ) : (
+          <>
+            <button type="button" style={s.btn} onClick={shareTwitter}>
+              Twitter/X
+            </button>
+            <button type="button" style={s.btn} onClick={shareWhatsApp}>
+              WhatsApp
+            </button>
+            <button type="button" style={s.btn} onClick={copyLink}>
+              Copy link
+            </button>
+          </>
         )}
-        <button type="button" style={s.btn} onClick={shareWhatsApp}>
-          WhatsApp
-        </button>
-        <button type="button" style={s.btn} onClick={shareTwitter}>
-          Twitter/X
-        </button>
-        <button type="button" style={s.btn} onClick={shareFacebook}>
-          Facebook
-        </button>
-        <button type="button" style={s.btn} onClick={copyLink}>
-          Copy link
-        </button>
       </div>
       {toast && (
         <div

--- a/frontend/src/context/FavoritesContext.jsx
+++ b/frontend/src/context/FavoritesContext.jsx
@@ -5,10 +5,11 @@ import { useAuth } from './AuthContext';
 const FavoritesContext = createContext(null);
 
 const lsKey = (userId) => `fm_favorites_${userId}`;
+const GUEST_KEY = 'fm_favorites_guest';
 
-function readFromStorage(userId) {
+function readFromStorage(storageKey) {
   try {
-    const raw = localStorage.getItem(lsKey(userId));
+    const raw = localStorage.getItem(storageKey);
     if (!raw) return null;
     const ids = JSON.parse(raw);
     if (Array.isArray(ids)) return new Set(ids);
@@ -16,9 +17,9 @@ function readFromStorage(userId) {
   return null;
 }
 
-function writeToStorage(userId, favorites) {
+function writeToStorage(storageKey, favorites) {
   try {
-    localStorage.setItem(lsKey(userId), JSON.stringify([...favorites]));
+    localStorage.setItem(storageKey, JSON.stringify([...favorites]));
   } catch { /* ignore */ }
 }
 
@@ -29,20 +30,33 @@ export function FavoritesProvider({ children }) {
 
   useEffect(() => {
     if (!user || user.role !== 'buyer') {
-      setFavorites(new Set());
+      // Load and maintain guest favorites in localStorage
+      const guestFavs = readFromStorage(GUEST_KEY) || new Set();
+      setFavorites(guestFavs);
       return;
     }
 
-    // Initialize immediately from localStorage so UI is responsive before API
-    const cached = readFromStorage(user.id);
+    // Authenticated: seed from cache immediately so the UI is responsive
+    const cached = readFromStorage(lsKey(user.id));
     if (cached) setFavorites(cached);
 
     setLoading(true);
     api.getFavorites({ limit: 1000 })
       .then(res => {
-        const ids = new Set((res.data || []).map(p => p.id));
-        setFavorites(ids);
-        writeToStorage(user.id, ids);
+        const serverIds = new Set((res.data || []).map(p => p.id));
+
+        // Merge any guest favorites accumulated while unauthenticated
+        const guestFavs = readFromStorage(GUEST_KEY) || new Set();
+        const merged = new Set([...serverIds, ...guestFavs]);
+
+        // Fire-and-forget: push guest-only IDs to the server
+        const toSync = [...guestFavs].filter(id => !serverIds.has(id));
+        Promise.all(toSync.map(id => api.addFavorite(id).catch(() => {})));
+
+        try { localStorage.removeItem(GUEST_KEY); } catch { /* ignore */ }
+
+        setFavorites(merged);
+        writeToStorage(lsKey(user.id), merged);
       })
       .catch(() => {
         if (!cached) setFavorites(new Set());
@@ -51,27 +65,44 @@ export function FavoritesProvider({ children }) {
   }, [user]);
 
   const toggleFavorite = useCallback(async (productId) => {
-    if (!user || user.role !== 'buyer') return;
+    // Guest (unauthenticated) path — persist to guest localStorage only
+    if (!user || user.role !== 'buyer') {
+      setFavorites(prev => {
+        const next = new Set(prev);
+        if (next.has(productId)) {
+          next.delete(productId);
+        } else {
+          next.add(productId);
+        }
+        writeToStorage(GUEST_KEY, next);
+        return next;
+      });
+      return;
+    }
 
     const isFavorited = favorites.has(productId);
-    const newFavorites = new Set(favorites);
+    const optimistic = new Set(favorites);
+
+    if (isFavorited) {
+      optimistic.delete(productId);
+    } else {
+      optimistic.add(productId);
+    }
+
+    // Optimistic update
+    setFavorites(optimistic);
+    writeToStorage(lsKey(user.id), optimistic);
 
     try {
       if (isFavorited) {
-        newFavorites.delete(productId);
-        setFavorites(newFavorites);
-        writeToStorage(user.id, newFavorites);
         await api.removeFavorite(productId);
       } else {
-        newFavorites.add(productId);
-        setFavorites(newFavorites);
-        writeToStorage(user.id, newFavorites);
         await api.addFavorite(productId);
       }
     } catch (err) {
       // Revert on error
       setFavorites(favorites);
-      writeToStorage(user.id, favorites);
+      writeToStorage(lsKey(user.id), favorites);
       throw err;
     }
   }, [user, favorites]);

--- a/frontend/src/context/LoadingContext.jsx
+++ b/frontend/src/context/LoadingContext.jsx
@@ -1,12 +1,43 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useRef, useCallback } from 'react';
 
 export const LoadingContext = createContext();
 
+const MIN_DISPLAY_MS = 300;
+
 export function LoadingProvider({ children }) {
   const [loading, setLoading] = useState(false);
+  const countRef = useRef(0);
+  const minMetRef = useRef(false);
+  const minTimerRef = useRef(null);
+
+  const startLoading = useCallback(() => {
+    countRef.current += 1;
+    if (countRef.current === 1) {
+      // First concurrent caller — show the spinner and start the minimum-display timer
+      clearTimeout(minTimerRef.current);
+      minMetRef.current = false;
+      setLoading(true);
+      minTimerRef.current = setTimeout(() => {
+        minMetRef.current = true;
+        // If all callers have already finished, hide now
+        if (countRef.current === 0) setLoading(false);
+      }, MIN_DISPLAY_MS);
+    }
+  }, []);
+
+  const stopLoading = useCallback(() => {
+    if (countRef.current <= 0) return;
+    countRef.current -= 1;
+    if (countRef.current === 0 && minMetRef.current) {
+      // All done and minimum time already satisfied — hide immediately
+      setLoading(false);
+    }
+    // If countRef.current === 0 but minMetRef.current is still false, the minTimer
+    // will fire and check countRef.current at that point, then hide.
+  }, []);
 
   return (
-    <LoadingContext.Provider value={{ loading, setLoading }}>
+    <LoadingContext.Provider value={{ loading, startLoading, stopLoading }}>
       {children}
     </LoadingContext.Provider>
   );

--- a/frontend/src/test/LoadingContext.test.jsx
+++ b/frontend/src/test/LoadingContext.test.jsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import { LoadingProvider, useLoading } from '../context/LoadingContext';
+
+function TestConsumer() {
+  const { loading, startLoading, stopLoading } = useLoading();
+  return (
+    <div>
+      <span data-testid="status">{loading ? 'loading' : 'idle'}</span>
+      <button data-testid="start" onClick={startLoading}>start</button>
+      <button data-testid="stop" onClick={stopLoading}>stop</button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <LoadingProvider>
+      <TestConsumer />
+    </LoadingProvider>
+  );
+}
+
+describe('LoadingContext (#801)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts idle', () => {
+    renderWithProvider();
+    expect(screen.getByTestId('status').textContent).toBe('idle');
+  });
+
+  it('shows loading after startLoading is called', async () => {
+    renderWithProvider();
+    await act(async () => { screen.getByTestId('start').click(); });
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+  });
+
+  it('enforces 300ms minimum display time', async () => {
+    renderWithProvider();
+
+    await act(async () => { screen.getByTestId('start').click(); });
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    // Stop before 300ms has elapsed
+    await act(async () => { screen.getByTestId('stop').click(); });
+    // Still loading — minimum time not yet met
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    // Advance to just before the 300ms threshold
+    await act(async () => { vi.advanceTimersByTime(299); });
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    // Cross the threshold
+    await act(async () => { vi.advanceTimersByTime(1); });
+    expect(screen.getByTestId('status').textContent).toBe('idle');
+  });
+
+  it('hides immediately when stopLoading is called after 300ms have passed', async () => {
+    renderWithProvider();
+
+    await act(async () => { screen.getByTestId('start').click(); });
+    await act(async () => { vi.advanceTimersByTime(300); });
+    // Min time met, still loading (not stopped yet)
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    await act(async () => { screen.getByTestId('stop').click(); });
+    expect(screen.getByTestId('status').textContent).toBe('idle');
+  });
+
+  it('counts concurrent operations — hides only when all have stopped', async () => {
+    renderWithProvider();
+
+    await act(async () => { screen.getByTestId('start').click(); }); // count = 1
+    await act(async () => { screen.getByTestId('start').click(); }); // count = 2
+
+    await act(async () => { screen.getByTestId('stop').click(); }); // count = 1
+    // Advance past min display time
+    await act(async () => { vi.advanceTimersByTime(300); });
+    // count is still 1 — must stay loading
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    await act(async () => { screen.getByTestId('stop').click(); }); // count = 0
+    expect(screen.getByTestId('status').textContent).toBe('idle');
+  });
+
+  it('resets correctly for a second loading cycle', async () => {
+    renderWithProvider();
+
+    // First cycle
+    await act(async () => { screen.getByTestId('start').click(); });
+    await act(async () => { vi.advanceTimersByTime(300); });
+    await act(async () => { screen.getByTestId('stop').click(); });
+    expect(screen.getByTestId('status').textContent).toBe('idle');
+
+    // Second cycle
+    await act(async () => { screen.getByTestId('start').click(); });
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    await act(async () => { screen.getByTestId('stop').click(); });
+    // Min time not yet met — still loading
+    expect(screen.getByTestId('status').textContent).toBe('loading');
+
+    await act(async () => { vi.advanceTimersByTime(300); });
+    expect(screen.getByTestId('status').textContent).toBe('idle');
+  });
+});

--- a/frontend/src/test/ShareButtons.test.jsx
+++ b/frontend/src/test/ShareButtons.test.jsx
@@ -4,62 +4,132 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import ShareButtons from '../components/ShareButtons';
 
-describe('ShareButtons (#441)', () => {
+const mockTrackShareEvent = vi.fn();
+
+vi.mock('../api/client', () => ({
+  api: {
+    trackShareEvent: (...args) => mockTrackShareEvent(...args),
+  },
+}));
+
+describe('ShareButtons (#798)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    mockTrackShareEvent.mockResolvedValue({ success: true });
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.clearAllMocks();
+    delete navigator.share;
+  });
+
+  // --- Native share path ---
+
+  it('shows only the "Share" button when navigator.share is available', () => {
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockResolvedValue(undefined),
+      configurable: true,
+      writable: true,
+    });
+
+    render(<ShareButtons productId={1} title="Test" url="https://example.com" />);
+
+    expect(screen.getByText('Share')).toBeTruthy();
+    expect(screen.queryByText('Twitter/X')).toBeNull();
+    expect(screen.queryByText('WhatsApp')).toBeNull();
+    expect(screen.queryByText('Copy link')).toBeNull();
+  });
+
+  it('calls navigator.share and records the event on native share', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: shareMock,
+      configurable: true,
+      writable: true,
+    });
+
+    render(<ShareButtons productId={42} title="Fresh Tomatoes" url="https://example.com/p/42" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Share'));
+    });
+
+    expect(shareMock).toHaveBeenCalledWith({
+      title: 'Fresh Tomatoes',
+      url: 'https://example.com/p/42',
+      text: 'Fresh Tomatoes',
+    });
+    expect(mockTrackShareEvent).toHaveBeenCalledWith(42, 'native_share');
+  });
+
+  it('does not record the event when the native share is aborted', async () => {
+    const abortError = new DOMException('Share aborted', 'AbortError');
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockRejectedValue(abortError),
+      configurable: true,
+      writable: true,
+    });
+
+    render(<ShareButtons productId={1} title="Test" url="https://example.com" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Share'));
+    });
+
+    expect(mockTrackShareEvent).not.toHaveBeenCalled();
+    expect(screen.queryByText('Share failed')).toBeNull();
+  });
+
+  // --- Fallback path (no navigator.share) ---
+
+  it('shows Twitter, WhatsApp, and Copy link when navigator.share is unavailable', () => {
+    render(<ShareButtons productId={1} title="Test" url="https://example.com" />);
+
+    expect(screen.queryByText('Share')).toBeNull();
+    expect(screen.getByText('Twitter/X')).toBeTruthy();
+    expect(screen.getByText('WhatsApp')).toBeTruthy();
+    expect(screen.getByText('Copy link')).toBeTruthy();
   });
 
   it('shows "Copied!" toast on successful copy via navigator.clipboard', async () => {
-    // Mock clipboard API
     const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, {
-      clipboard: { writeText: writeTextMock },
-    });
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 
-    render(<ShareButtons title="Test Product" url="https://example.com" />);
+    render(<ShareButtons productId={1} title="Test Product" url="https://example.com" />);
 
-    const copyBtn = screen.getByText('Copy link');
     await act(async () => {
-      fireEvent.click(copyBtn);
+      fireEvent.click(screen.getByText('Copy link'));
     });
 
     expect(writeTextMock).toHaveBeenCalledWith('https://example.com');
+    expect(mockTrackShareEvent).toHaveBeenCalledWith(1, 'copy_link');
     expect(screen.getByText('Copied!')).toBeTruthy();
   });
 
   it('shows error toast when clipboard copy fails', async () => {
-    // Mock clipboard API to reject
     const writeTextMock = vi.fn().mockRejectedValue(new Error('Clipboard error'));
-    Object.assign(navigator, {
-      clipboard: { writeText: writeTextMock },
-    });
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 
-    render(<ShareButtons title="Test Product" url="https://example.com" />);
+    render(<ShareButtons productId={1} title="Test Product" url="https://example.com" />);
 
-    const copyBtn = screen.getByText('Copy link');
     await act(async () => {
-      fireEvent.click(copyBtn);
+      fireEvent.click(screen.getByText('Copy link'));
     });
 
     expect(screen.getByText('Failed to copy link')).toBeTruthy();
   });
 
   it('falls back to execCommand when navigator.clipboard is not available', async () => {
-    // Remove clipboard API
     Object.assign(navigator, { clipboard: undefined });
 
     const execCommandMock = vi.fn().mockReturnValue(true);
     document.execCommand = execCommandMock;
 
-    render(<ShareButtons title="Test Product" url="https://example.com" />);
+    render(<ShareButtons productId={1} title="Test Product" url="https://example.com" />);
 
-    const copyBtn = screen.getByText('Copy link');
     await act(async () => {
-      fireEvent.click(copyBtn);
+      fireEvent.click(screen.getByText('Copy link'));
     });
 
     expect(execCommandMock).toHaveBeenCalledWith('copy');
@@ -67,45 +137,51 @@ describe('ShareButtons (#441)', () => {
   });
 
   it('shows error toast when execCommand fallback fails', async () => {
-    // Remove clipboard API
     Object.assign(navigator, { clipboard: undefined });
 
-    // Make execCommand throw
-    const execCommandMock = vi.fn().mockImplementation(() => {
+    document.execCommand = vi.fn().mockImplementation(() => {
       throw new Error('execCommand failed');
     });
-    document.execCommand = execCommandMock;
 
-    render(<ShareButtons title="Test Product" url="https://example.com" />);
+    render(<ShareButtons productId={1} title="Test Product" url="https://example.com" />);
 
-    const copyBtn = screen.getByText('Copy link');
     await act(async () => {
-      fireEvent.click(copyBtn);
+      fireEvent.click(screen.getByText('Copy link'));
     });
 
     expect(screen.getByText('Failed to copy link')).toBeTruthy();
   });
 
-  it('toast disappears after 2.5 seconds', async () => {
+  it('toast disappears after 2 seconds', async () => {
     const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, {
-      clipboard: { writeText: writeTextMock },
-    });
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 
-    render(<ShareButtons title="Test Product" url="https://example.com" />);
+    render(<ShareButtons productId={1} title="Test Product" url="https://example.com" />);
 
-    const copyBtn = screen.getByText('Copy link');
     await act(async () => {
-      fireEvent.click(copyBtn);
+      fireEvent.click(screen.getByText('Copy link'));
     });
 
     expect(screen.getByText('Copied!')).toBeTruthy();
 
-    // Advance past the 2.5s timeout
     await act(async () => {
-      vi.advanceTimersByTime(2600);
+      vi.advanceTimersByTime(2100);
     });
 
     expect(screen.queryByText('Copied!')).toBeNull();
+  });
+
+  it('works without productId — skips backend call', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<ShareButtons title="Test" url="https://example.com" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy link'));
+    });
+
+    expect(mockTrackShareEvent).not.toHaveBeenCalled();
+    expect(screen.getByText('Copied!')).toBeTruthy();
   });
 });


### PR DESCRIPTION

## #798 — ShareButtons: native Web Share API with clipboard fallback
- When navigator.share is available the component shows only a single "Share" button; clicking it calls navigator.share({ title, text, url }) (OS share sheet on mobile).
- When navigator.share is unavailable the component renders individual Twitter/X, WhatsApp, and "Copy link" buttons.
- "Copy link" uses navigator.clipboard.writeText with an execCommand fallback for older browsers and shows a "Copied!" toast for 2 s on success.
- Every share action (native, social, copy) calls POST /api/products/:id/share to record the event; the backend now accepts the 'native_share' platform value.
- ShareButtons.test.jsx expanded to cover the native share path, the fallback path, backend tracking, AbortError handling, and the no-productId guard.

## #799 — ImageCropModal: 4:3 aspect ratio lock + minimum dimension validation
- Crop is initialised at a 4:3 aspect ratio by default.
- An "Aspect ratio lock" checkbox is shown for gallery images (isGalleryImage prop); primary product images keep the ratio locked at all times.
- Dragging a corner while the ratio is locked adjusts width and derives height from the ratio; free-form resizing is available when the lock is off.
- On confirm, natural-image pixel dimensions are validated against the 300×300 px minimum; a clear error message blocks saving if the crop is too small.
- The resulting Blob is validated against MAX_SIZE_BYTES (5 MB) and ALLOWED_TYPES (jpeg, png, webp) before onConfirm is called.
- Canvas is keyboard navigable: Tab cycles through crop handles (body, tl, tr, bl, br) and arrow keys move or resize the crop area for the active handle.

## #800 — FavoritesContext: backend persistence and login sync
- On mount, when the user is authenticated, GET /api/favorites hydrates the context; a localStorage cache seeds the UI immediately while the request is in flight.
- Toggling a favourite calls POST /api/favorites (add) or DELETE /api/favorites/:id (remove) with an optimistic update that reverts on API error.
- Unauthenticated users' favourites are stored under a dedicated 'fm_favorites_guest' localStorage key; on login the guest set is merged with the server list and guest-only IDs are synced to the server automatically.
- FavoritesContext.test.jsx continues to pass without modification.

## #801 — LoadingContext: counter-based spinner with 300 ms minimum display time
- LoadingContext now exposes startLoading / stopLoading instead of setLoading; an internal ref counter tracks concurrent operations so the spinner hides only when the counter reaches zero.
- Once shown, the spinner remains visible for at least 300 ms even if all operations complete sooner; a minimum-display timer handles the deferred hide.
- App.jsx wires the api/client loading callback to startLoading / stopLoading.
- PageLoader is already rendered inside the App Suspense boundary covering all lazy route transitions.
- LoadingContext.test.jsx added; covers idle state, minimum display time, concurrent operation counting, and correct reset across multiple loading cycles.

Closes #798
Closes #799
Closes #800
Closes #801