### PR TITLE
feat(contracts): add WASM size optimization profiling for escrow and reward-token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,43 @@ jobs:
 
       - name: Run contract tests
         run: npm run test:contracts
+
+  wasm-size-profile:
+    name: WASM Size Profile (nightly)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contract/target
+          key: ${{ runner.os }}-cargo-contract-${{ hashFiles('contract/Cargo.toml', 'contract/reward-token/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-contract-
+
+      - name: Profile WASM binary sizes
+        run: bash contract/wasm-profile.sh | tee wasm-profile.txt
+
+      - name: Write job summary
+        run: |
+          echo "## WASM Binary Size Profile" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          cat wasm-profile.txt >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload size report
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-size-profile
+          path: wasm-profile.txt
+          retention-days: 30

--- a/contract/wasm-profile.sh
+++ b/contract/wasm-profile.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Profiles compiled WASM binary sizes for the escrow and reward-token contracts.
+#
+# Builds each contract in both debug (unoptimized) and release (optimized) modes,
+# then reports sizes and the reduction achieved by the release profile settings:
+#   opt-level = "z", lto = true, codegen-units = 1, strip = "symbols", panic = "abort"
+#
+# Usage:
+#   ./contract/wasm-profile.sh
+#
+# Requirements:
+#   cargo + wasm32-unknown-unknown target  (rustup target add wasm32-unknown-unknown)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+fmt_bytes() {
+  local b=$1
+  if [ "$b" -ge 1048576 ]; then
+    printf "%.2f MiB (%d bytes)" "$(echo "scale=2; $b / 1048576" | bc)" "$b"
+  elif [ "$b" -ge 1024 ]; then
+    printf "%.2f KiB (%d bytes)" "$(echo "scale=2; $b / 1024" | bc)" "$b"
+  else
+    printf "%d bytes" "$b"
+  fi
+}
+
+pct_reduction() {
+  local before=$1 after=$2
+  echo "scale=1; 100 - ($after * 100 / $before)" | bc
+}
+
+build_wasm() {
+  local dir="$1" profile="$2"
+  local cargo_flag=""
+  [ "$profile" = "release" ] && cargo_flag="--release"
+  cargo build --manifest-path "$dir/Cargo.toml" \
+    --target wasm32-unknown-unknown $cargo_flag \
+    --quiet 2>/dev/null
+}
+
+wasm_size() {
+  local dir="$1" pkg="$2" profile="$3"
+  # Cargo converts hyphens to underscores in output file names
+  local name="${pkg//-/_}"
+  local wasm="$dir/target/wasm32-unknown-unknown/$profile/${name}.wasm"
+  if [ ! -f "$wasm" ]; then
+    echo "ERROR: WASM not found at $wasm" >&2
+    return 1
+  fi
+  wc -c < "$wasm"
+}
+
+profile_contract() {
+  local dir="$1" pkg="$2"
+
+  echo "┌─ $pkg"
+  echo "│  dir: $dir"
+
+  printf "│  Building debug  … "
+  build_wasm "$dir" "debug"
+  local dbg
+  dbg=$(wasm_size "$dir" "$pkg" "debug")
+  printf "done\n"
+
+  printf "│  Building release … "
+  build_wasm "$dir" "release"
+  local rel
+  rel=$(wasm_size "$dir" "$pkg" "release")
+  printf "done\n"
+
+  local pct
+  pct=$(pct_reduction "$dbg" "$rel")
+
+  echo "│"
+  echo "│  debug   : $(fmt_bytes "$dbg")"
+  echo "│  release : $(fmt_bytes "$rel")"
+  echo "│  reduction: ${pct}%"
+  echo "└──────────────────────────────────────────"
+  echo ""
+
+  # Emit structured output for CI job summaries
+  echo "WASM_PROFILE_${pkg//-/_}_DEBUG_BYTES=$dbg"
+  echo "WASM_PROFILE_${pkg//-/_}_RELEASE_BYTES=$rel"
+  echo "WASM_PROFILE_${pkg//-/_}_REDUCTION_PCT=$pct"
+}
+
+# ── preflight ────────────────────────────────────────────────────────────────
+
+if ! command -v cargo &>/dev/null; then
+  echo "ERROR: cargo not found. Install Rust: https://rustup.rs" >&2
+  exit 1
+fi
+
+if ! rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown; then
+  echo "ERROR: wasm32-unknown-unknown target not installed." >&2
+  echo "       Run: rustup target add wasm32-unknown-unknown" >&2
+  exit 1
+fi
+
+# ── profile ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "========================================"
+echo "  WASM Binary Size Profile"
+echo "  Stellar / Soroban Contracts"
+echo "========================================"
+echo ""
+echo "Release profile optimizations:"
+echo "  opt-level      = \"z\"      (optimize for size)"
+echo "  lto            = true     (link-time optimization)"
+echo "  codegen-units  = 1        (single codegen unit for better LTO)"
+echo "  strip          = \"symbols\" (strip debug symbols)"
+echo "  panic          = \"abort\"   (no unwind tables)"
+echo ""
+
+profile_contract "$SCRIPT_DIR"              "escrow"
+profile_contract "$SCRIPT_DIR/reward-token" "reward-token"

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -17,6 +17,11 @@ opt-level = "z"
 overflow-checks = true
 debug = 0
 strip = "symbols"
+debug-assertions = false
 panic = "abort"
 codegen-units = 1
 lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true


### PR DESCRIPTION
closes #702


this PR commits the following changes:

- contracts/escrow/Cargo.toml: complete release profile to match other contracts — add debug-assertions = false and [profile.release-with-logs] (inherits release, enables debug-assertions for tracing builds). The existing opt-level = "z" and lto = true settings are preserved.

- contract/wasm-profile.sh: new script that builds escrow and reward-token in both debug and release modes, measures WASM binary sizes, and reports the byte counts and percentage reduction achieved by the release profile (opt-level = "z", lto, codegen-units = 1, strip = "symbols", panic = "abort").

- .github/workflows/ci.yml: add nightly wasm-size-profile job that runs the profiling script via Rust stable + wasm32-unknown-unknown target, writes results to the GitHub job summary, and uploads a 30-day artifact.
