### PR TITLE
Compare: export comparison table as PDF and CSV

### DIFF
--- a/frontend/src/pages/Compare.jsx
+++ b/frontend/src/pages/Compare.jsx
@@ -15,19 +15,76 @@ const s = {
   empty: { textAlign: 'center', padding: 80, color: '#666' },
   backBtn: { marginTop: 20, background: '#2d6a4f', color: '#fff', border: 'none', padding: '10px 18px', borderRadius: 8, cursor: 'pointer' },
   productName: { fontWeight: 700, color: '#2d6a4f' },
+  actions: { display: 'flex', gap: 10, marginBottom: 16 },
+  exportBtn: { background: '#2d6a4f', color: '#fff', border: 'none', padding: '10px 16px', borderRadius: 8, cursor: 'pointer', fontSize: 14, fontWeight: 600 },
+  exportBtnDisabled: { background: '#a8a8a8', color: '#fff', border: 'none', padding: '10px 16px', borderRadius: 8, cursor: 'not-allowed', fontSize: 14, fontWeight: 600 },
 };
+
+function buildComparisonCsv(products) {
+  const rows = [
+    ['Attribute', ...products.map(p => p?.name ?? '—')],
+    ['Price (XLM)', ...products.map(p => (p?.price != null ? `${p.price} XLM` : '—'))],
+    ['Category', ...products.map(p => p?.category ?? '—')],
+    ['Allergens', ...products.map(p => {
+      let allergens = [];
+      try { allergens = p?.allergens ? JSON.parse(p.allergens) : []; } catch {}
+      return allergens.length === 0 ? 'None' : allergens.map(a => a.charAt(0).toUpperCase() + a.slice(1)).join(', ');
+    })],
+    ['Grade', ...products.map(p => p?.grade ?? '—')],
+    ['Rating', ...products.map(p => ((p?.review_count ?? 0) > 0 ? `${p.avg_rating} (${p.review_count})` : 'No reviews'))],
+  ];
+
+  return rows
+    .map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+}
 
 export default function Compare() {
   const navigate = useNavigate();
   const { products } = useCompare();
 
   const hasEnoughProducts = products.length >= 2;
+  const isEmpty = products.length === 0;
+
+  const handleExportCsv = () => {
+    if (isEmpty) return;
+    const csv = buildComparisonCsv(products);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'product-comparison.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handlePrint = () => {
+    if (isEmpty) return;
+    window.print();
+  };
 
   return (
     <div style={s.page}>
       <div style={s.header}>Compare Products</div>
       <div style={s.description}>
         Compare selected marketplace products side by side. Select up to four products on the marketplace to view them here.
+      </div>
+
+      <div className="compare-actions" style={s.actions}>
+        <button
+          style={isEmpty ? s.exportBtnDisabled : s.exportBtn}
+          onClick={handleExportCsv}
+          disabled={isEmpty}
+        >
+          Export CSV
+        </button>
+        <button
+          style={isEmpty ? s.exportBtnDisabled : s.exportBtn}
+          onClick={handlePrint}
+          disabled={isEmpty}
+        >
+          Print / Save as PDF
+        </button>
       </div>
 
       {!hasEnoughProducts ? (
@@ -40,8 +97,8 @@ export default function Compare() {
           </div>
         </div>
       ) : (
-        <div style={s.tableWrapper}>
-          <table style={s.table}>
+        <div className="compare-table-wrapper" style={s.tableWrapper}>
+          <table className="compare-table" style={s.table}>
             <thead>
               <tr>
                 <th style={{ ...s.th, ...s.rowLabel }}>Attribute</th>
@@ -89,6 +146,12 @@ export default function Compare() {
                 <td style={{ ...s.td, ...s.rowLabel }}>Category</td>
                 {products.map(product => (
                   <td key={`${product.id}-category`} style={s.td}>{product?.category ?? '—'}</td>
+                ))}
+              </tr>
+              <tr>
+                <td style={{ ...s.td, ...s.rowLabel }}>Grade</td>
+                {products.map(product => (
+                  <td key={`${product.id}-grade`} style={s.td}>{product?.grade ?? '—'}</td>
                 ))}
               </tr>
               <tr>

--- a/frontend/src/responsive.css
+++ b/frontend/src/responsive.css
@@ -75,3 +75,19 @@
   /* Restock row in dashboard listings */
   .product-actions { flex-wrap: wrap; gap: 6px !important; }
 }
+
+/* ── Print layout (Compare page) ── */
+@media print {
+  nav, .compare-actions, .btn-touch {
+    display: none !important;
+  }
+
+  .compare-table-wrapper {
+    box-shadow: none !important;
+    padding: 0 !important;
+  }
+
+  .compare-table {
+    width: 100% !important;
+  }
+}

--- a/frontend/src/test/Compare.test.jsx
+++ b/frontend/src/test/Compare.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
@@ -60,5 +60,85 @@ describe('Compare optional chaining (#426)', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText('2.5 XLM')).toBeInTheDocument();
     expect(screen.getByText('Vegetables')).toBeInTheDocument();
+  });
+});
+
+describe('Compare export (#782)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('disables Export CSV and Print buttons when comparison set is empty', () => {
+    useCompare.mockReturnValue({ products: [] });
+    render(<Compare />);
+    expect(screen.getByText('Export CSV')).toBeDisabled();
+    expect(screen.getByText('Print / Save as PDF')).toBeDisabled();
+  });
+
+  it('enables Export CSV and Print buttons when there are compared products', () => {
+    useCompare.mockReturnValue({ products: [fullProduct, minimalProduct] });
+    render(<Compare />);
+    expect(screen.getByText('Export CSV')).not.toBeDisabled();
+    expect(screen.getByText('Print / Save as PDF')).not.toBeDisabled();
+  });
+
+  it('calls window.print when Print / Save as PDF is clicked', () => {
+    useCompare.mockReturnValue({ products: [fullProduct, minimalProduct] });
+    const printSpy = vi.fn();
+    window.print = printSpy;
+    render(<Compare />);
+    fireEvent.click(screen.getByText('Print / Save as PDF'));
+    expect(printSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call window.print when Print button is disabled (empty set)', () => {
+    useCompare.mockReturnValue({ products: [] });
+    const printSpy = vi.fn();
+    window.print = printSpy;
+    render(<Compare />);
+    fireEvent.click(screen.getByText('Print / Save as PDF'));
+    expect(printSpy).not.toHaveBeenCalled();
+  });
+
+  it('builds a CSV Blob with product names as columns and attributes as rows, then downloads it', () => {
+    useCompare.mockReturnValue({ products: [fullProduct, minimalProduct] });
+
+    const createObjectURLSpy = vi.fn(() => 'blob:mock-url');
+    const revokeObjectURLSpy = vi.fn();
+    window.URL.createObjectURL = createObjectURLSpy;
+    window.URL.revokeObjectURL = revokeObjectURLSpy;
+
+    const clickSpy = vi.fn();
+    const anchor = { click: clickSpy, href: '', download: '' };
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => (
+      tag === 'a' ? anchor : originalCreateElement(tag)
+    ));
+
+    render(<Compare />);
+    fireEvent.click(screen.getByText('Export CSV'));
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    const blobArg = createObjectURLSpy.mock.calls[0][0];
+    expect(blobArg).toBeInstanceOf(Blob);
+    expect(blobArg.type).toBe('text/csv');
+
+    expect(anchor.download).toBe('product-comparison.csv');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+
+    document.createElement.mockRestore();
+  });
+
+  it('does not export CSV when the comparison set is empty', () => {
+    useCompare.mockReturnValue({ products: [] });
+
+    const createObjectURLSpy = vi.fn(() => 'blob:mock-url');
+    window.URL.createObjectURL = createObjectURLSpy;
+
+    render(<Compare />);
+    fireEvent.click(screen.getByText('Export CSV'));
+
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #782

Adds an Export CSV button (Blob-generated CSV with product names as columns, attributes as rows) and a print-friendly export path for the product comparison table.