### PR TITLE
feat: extend freshness alerts to buyers with configurable window and expiry reset

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -79,6 +79,9 @@ const EnvSchema = z.object({
 
   // Geo API
   GEO_API_TIMEOUT_MS: z.coerce.number().int().positive().default(2000),
+
+  // Freshness alerts
+  FRESHNESS_ALERT_DAYS: z.coerce.number().int().positive().default(3),
 });
 
 let env;
@@ -127,6 +130,7 @@ const config = {
   databaseUrl: env.DATABASE_URL || null,
   redisUrl: env.REDIS_URL || null,
   GEO_API_TIMEOUT_MS: env.GEO_API_TIMEOUT_MS,
+  freshnessAlertDays: env.FRESHNESS_ALERT_DAYS,
 };
 
 module.exports = config;

--- a/backend/src/jobs/processFreshnessAlerts.js
+++ b/backend/src/jobs/processFreshnessAlerts.js
@@ -1,53 +1,145 @@
 const cron = require('node-cron');
 const db = require('../db/schema');
 const { sendFreshnessAlert } = require('../utils/mailer');
+const { sendPushToUser } = require('../utils/pushNotifications');
 
-async function processFreshnessAlerts() {
-  // Run daily at 9 AM
-  cron.schedule('0 9 * * *', async () => {
-    console.log('[freshness] Checking for products expiring soon...');
+function getAlertDays() {
+  const val = parseInt(process.env.FRESHNESS_ALERT_DAYS, 10);
+  return Number.isFinite(val) && val > 0 ? val : 3;
+}
 
-    const twoDaysFromNow = new Date();
-    twoDaysFromNow.setDate(twoDaysFromNow.getDate() + 2);
-    const dateStr = twoDaysFromNow.toISOString().split('T')[0]; // YYYY-MM-DD
+function groupByProduct(rows) {
+  const map = new Map();
+  for (const { product_id, buyer_id } of rows) {
+    const pid = Number(product_id);
+    if (!map.has(pid)) map.set(pid, new Set());
+    map.get(pid).add(buyer_id);
+  }
+  return map;
+}
 
-    let expiringProducts;
-    if (db.isPostgres) {
-      const { rows } = await db.query(
-        `SELECT p.*, u.name as farmer_name, u.email as farmer_email
-         FROM products p
-         JOIN users u ON p.farmer_id = u.id
-         WHERE p.best_before = $1`,
-        [dateStr]
-      );
-      expiringProducts = rows;
-    } else {
-      expiringProducts = db.prepare(
-        `SELECT p.*, u.name as farmer_name, u.email as farmer_email
-         FROM products p
-         JOIN users u ON p.farmer_id = u.id
-         WHERE p.best_before = ?`
-      ).all(dateStr);
-    }
+async function runFreshnessAlerts() {
+  const alertDays = getAlertDays();
+  console.log(`[freshness] Checking for products expiring within ${alertDays} day(s)...`);
 
-    if (expiringProducts.length === 0) {
-      console.log('[freshness] No products expiring in 2 days');
-      return;
-    }
+  let expiringProducts;
+  if (db.isPostgres) {
+    const { rows } = await db.query(
+      `SELECT p.id, p.name, p.best_before, p.farmer_id,
+              u.name AS farmer_name, u.email AS farmer_email
+       FROM products p
+       JOIN users u ON p.farmer_id = u.id
+       WHERE p.best_before >= CURRENT_DATE
+         AND p.best_before <= CURRENT_DATE + ($1 * INTERVAL '1 day')
+         AND p.expiry_notified_at IS NULL`,
+      [alertDays]
+    );
+    expiringProducts = rows;
+  } else {
+    const { rows } = await db.query(
+      `SELECT p.id, p.name, p.best_before, p.farmer_id,
+              u.name AS farmer_name, u.email AS farmer_email
+       FROM products p
+       JOIN users u ON p.farmer_id = u.id
+       WHERE p.best_before >= date('now')
+         AND p.best_before <= date('now', '+' || $1 || ' days')
+         AND p.expiry_notified_at IS NULL`,
+      [alertDays]
+    );
+    expiringProducts = rows;
+  }
 
-    console.log(`[freshness] Alerting farmers about ${expiringProducts.length} expiring product(s)`);
+  if (expiringProducts.length === 0) {
+    console.log(`[freshness] No products expiring within ${alertDays} day(s)`);
+    return;
+  }
 
-    for (const product of expiringProducts) {
+  console.log(`[freshness] Processing ${expiringProducts.length} expiring product(s)`);
+
+  const productIds = expiringProducts.map((p) => p.id);
+
+  // Fetch all interested buyers for qualifying products in one query — avoids N+1
+  let buyersByProduct = new Map();
+  if (db.isPostgres) {
+    const { rows: buyerRows } = await db.query(
+      `SELECT DISTINCT buyer_id, product_id FROM (
+         SELECT buyer_id, product_id FROM favorites WHERE product_id = ANY($1)
+         UNION
+         SELECT buyer_id, product_id FROM subscriptions
+         WHERE product_id = ANY($1) AND active = true AND status = 'active'
+       ) interested`,
+      [productIds]
+    );
+    buyersByProduct = groupByProduct(buyerRows);
+  } else {
+    const ph1 = productIds.map((_, i) => `$${i + 1}`).join(', ');
+    const offset = productIds.length;
+    const ph2 = productIds.map((_, i) => `$${offset + i + 1}`).join(', ');
+    const { rows: buyerRows } = await db.query(
+      `SELECT DISTINCT buyer_id, product_id FROM (
+         SELECT buyer_id, product_id FROM favorites WHERE product_id IN (${ph1})
+         UNION
+         SELECT buyer_id, product_id FROM subscriptions
+         WHERE product_id IN (${ph2}) AND active = 1 AND status = 'active'
+       ) interested`,
+      [...productIds, ...productIds]
+    );
+    buyersByProduct = groupByProduct(buyerRows);
+  }
+
+  for (const product of expiringProducts) {
+    try {
+      const bestBefore = new Date(product.best_before);
+      const now = new Date();
+      const daysLeft = Math.max(0, Math.floor((bestBefore - now) / (24 * 60 * 60 * 1000)));
+
+      // Notify farmer via email
       try {
         await sendFreshnessAlert({
           product,
           farmer: { name: product.farmer_name, email: product.farmer_email },
-          daysLeft: 2,
+          daysLeft,
         });
       } catch (e) {
-        console.error(`[freshness] Failed to alert farmer ${product.farmer_email} for product ${product.id}:`, e.message);
+        console.error(
+          `[freshness] Failed to alert farmer ${product.farmer_email} for product ${product.id}:`,
+          e.message
+        );
       }
+
+      // Notify interested buyers via push (deduplication guaranteed by the Set)
+      const buyers = buyersByProduct.get(product.id) || new Set();
+      for (const buyerId of buyers) {
+        try {
+          await sendPushToUser(buyerId, {
+            title: 'Freshness Alert',
+            body: `${product.name} expires in ${daysLeft} day${daysLeft !== 1 ? 's' : ''} — order now!`,
+          });
+        } catch (e) {
+          console.error(
+            `[freshness] Failed to notify buyer ${buyerId} for product ${product.id}:`,
+            e.message
+          );
+        }
+      }
+
+      // Advance the timestamp after all notifications have been attempted.
+      // If the DB update itself throws, the outer catch prevents the stamp from being set,
+      // so the job will retry this product on the next execution.
+      const nowExpr = db.isPostgres ? 'NOW()' : "datetime('now')";
+      await db.query(
+        `UPDATE products SET expiry_notified_at = ${nowExpr} WHERE id = $1`,
+        [product.id]
+      );
+    } catch (e) {
+      console.error(`[freshness] Unexpected error processing product ${product.id}:`, e.message);
     }
+  }
+}
+
+async function processFreshnessAlerts() {
+  cron.schedule('0 9 * * *', async () => {
+    await runFreshnessAlerts();
   });
 }
 
@@ -56,4 +148,4 @@ function startFreshnessJob() {
   console.log('[freshness] Cron job scheduled (daily at 9 AM)');
 }
 
-module.exports = { startFreshnessJob, processFreshnessAlerts };
+module.exports = { startFreshnessJob, processFreshnessAlerts, runFreshnessAlerts };

--- a/backend/src/routes/products.js
+++ b/backend/src/routes/products.js
@@ -344,7 +344,7 @@ router.patch('/:id', auth, async (req, res) => {
     'name', 'description', 'price', 'quantity', 'unit', 'category',
     'low_stock_threshold', 'nutrition', 'pricing_type', 'min_weight', 'max_weight',
     'batch_id', 'is_preorder', 'preorder_delivery_date', 'allergens', 'allowed_regions',
-    'grade', 'carbon_kg_per_unit', 'available_from', 'available_until',
+    'grade', 'carbon_kg_per_unit', 'available_from', 'available_until', 'best_before',
   ];
   const updates = {};
   for (const key of allowed) {
@@ -384,6 +384,16 @@ router.patch('/:id', auth, async (req, res) => {
   if (updates.grade !== undefined) {
     const VALID_GRADES = ['A', 'B', 'C', 'Ungraded'];
     if (!VALID_GRADES.includes(updates.grade)) return err(res, 400, 'grade must be A, B, C, or Ungraded', 'validation_error');
+  }
+  if (updates.best_before !== undefined) {
+    if (updates.best_before !== null && !/^\d{4}-\d{2}-\d{2}$/.test(updates.best_before)) {
+      return err(res, 400, 'best_before must be YYYY-MM-DD or null', 'validation_error');
+    }
+    const currentBestBefore = product.best_before ? String(product.best_before).split('T')[0] : null;
+    const today = new Date().toISOString().split('T')[0];
+    if (updates.best_before !== currentBestBefore && updates.best_before && updates.best_before > today) {
+      updates.expiry_notified_at = null;
+    }
   }
   if (updates.batch_id !== undefined) {
     if (updates.batch_id === null || updates.batch_id === '') {


### PR DESCRIPTION
Closes #828

---

## Summary

Freshness notifications previously only emailed the farmer when a product was approaching its `best_before` date. This PR extends the job to also push-notify every buyer who has **favourited or actively subscribed** to that product, makes the alert window configurable, adds `best_before` as a farmer-editable field, and gates everything behind `expiry_notified_at` to prevent duplicate sends across job runs.

---

## Changes

### `backend/src/jobs/processFreshnessAlerts.js`

**Configurable alert window**
- `FRESHNESS_ALERT_DAYS` env var (positive integer, default `3`) replaces the hardcoded 2-day look-ahead.  Read at runtime via `getAlertDays()` so no restart is required when the value is changed.

**Revised product query**
- Replaces the old single-day exact-date match with a range filter:  
  `best_before >= CURRENT_DATE AND best_before <= CURRENT_DATE + N days`  
  and adds `expiry_notified_at IS NULL` so already-notified products are skipped.
- Dual-mode SQL: Postgres uses `INTERVAL '1 day'` arithmetic; SQLite uses `date('now', '+N days')` concatenation.

**Buyer notifications — no N+1**
- A single `favorites UNION active subscriptions` query retrieves all interested buyers for all qualifying products in one round-trip (keyed via `ANY($1)` for Postgres, expanded `IN (...)` for SQLite).
- Results are grouped into `Map<productId, Set<buyerId>>`.  The `Set` guarantees each buyer receives **at most one push** per alert cycle regardless of whether they reach the product through a favourite, a subscription, or both.
- Push body format: `"{product name} expires in N days — order now!"` (singular form applied when N = 1).

**Transactional integrity on `expiry_notified_at`**
- The timestamp is stamped only after all notification attempts for a product complete.
- Individual delivery failures (farmer email bounce, push endpoint gone) are caught and logged but do not block the stamp — the product will not be re-queued for the same cycle.
- If the `UPDATE` itself throws (DB error, connection loss), the outer `catch` intercepts it and leaves `expiry_notified_at` as `NULL`, so the job retries this product on its next scheduled run.

**Backward compatibility**
- Farmer email path is unchanged (same `sendFreshnessAlert` call, same error handling).
- `processFreshnessAlerts()` and `startFreshnessJob()` retain their existing signatures.
- `runFreshnessAlerts()` is now exported as a standalone `async` function to allow direct invocation in tests without touching the cron scheduler.

---

### `backend/src/routes/products.js` — PATCH handler

- Added `best_before` to the farmer-updatable field allow-list.
- Validates value as `YYYY-MM-DD` string or `null`; rejects anything else with a `400`.
- Resets `expiry_notified_at = null` when `best_before` changes to a value that is **both different from the current one and strictly in the future** — enabling the freshness job to re-notify users based on the revised expiry schedule.  No reset occurs when the date is cleared, set to the past, or unchanged.

---

### `backend/src/config.js`

- Added `FRESHNESS_ALERT_DAYS` to the Zod env schema (`z.coerce.number().int().positive().default(3)`).
- Exposed as `config.freshnessAlertDays` in the exported config object.

---

## Database

No new migration required. `expiry_notified_at` was added to `products` in migration `024_product_expiry_notified_at.sql` and `best_before` in `003_freshness_dates.sql`.

---

## Test plan

- [ ] Set `FRESHNESS_ALERT_DAYS=1` and confirm only products expiring within 1 day are queued
- [ ] Confirm a product with `expiry_notified_at` already set is skipped on the next run
- [ ] Favourite a product as a buyer, run `runFreshnessAlerts()`, confirm push notification arrives with correct body
- [ ] Subscribe (active) to a product as a buyer — same as above
- [ ] Favourite **and** subscribe to the same product — confirm buyer receives only one push
- [ ] Patch `best_before` to a future date via `PATCH /api/products/:id` and confirm `expiry_notified_at` is reset to `NULL`
- [ ] Patch `best_before` to a past date — confirm `expiry_notified_at` is **not** reset
- [ ] Patch `best_before` to the same value it already has — confirm `expiry_notified_at` is **not** reset
- [ ] Simulate a push delivery failure for one buyer — confirm `expiry_notified_at` is still stamped and other buyers are not affected
- [ ] Simulate a DB failure on the `UPDATE expiry_notified_at` — confirm the timestamp is not advanced and the product is retried on the next run
- [ ] Run existing test suite and confirm no regressions
