### PR TITLE
feat: dynamic XML sitemap with farmer profiles, exclusion rules, and ETag caching

### DIFF
--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -266,9 +266,10 @@ function addDeprecationHeaders(req, res, next) {
 // ============================================================================
 
 router.get('/sitemap.xml', require('./sitemap'));
-router.get('/robots.txt', (_, res) => {
+router.get('/robots.txt', (req, res) => {
+  const host = process.env.BACKEND_URL || `${req.protocol}://${req.get('host')}`;
   res.type('text/plain').send(
-    `User-agent: *\nAllow: /\nDisallow: /api/\nSitemap: ${process.env.FRONTEND_URL || 'http://localhost:3000'}/sitemap.xml`
+    `User-agent: *\nAllow: /\nDisallow: /api/\nSitemap: ${host}/sitemap.xml`
   );
 });
 

--- a/backend/src/routes/sitemap.js
+++ b/backend/src/routes/sitemap.js
@@ -1,39 +1,132 @@
+const crypto = require('crypto');
 const router = require('express').Router();
 const db = require('../db/schema');
 const cache = require('../cache');
 
 const BASE_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+const CACHE_TTL = 3600; // 1 hour in seconds
 
-const STATIC_URLS = ['/', '/marketplace'];
+// In-memory fallback used when Redis is unavailable
+let memCache = null; // { xml, etag, expires }
 
-router.get('/', async (req, res) => {
-  const cacheKey = 'sitemap';
-  let xml = await cache.get(cacheKey);
-  if (xml) {
-    return res.type('application/xml').send(xml);
-  }
+const STATIC_PAGES = [
+  { path: '/', changefreq: 'daily', priority: '1.0' },
+  { path: '/marketplace', changefreq: 'daily', priority: '0.9' },
+];
 
-  const { rows } = await db.query(
-    `SELECT id, updated_at FROM products WHERE quantity > 0 ORDER BY id`
+function toDateStr(ts) {
+  if (!ts) return new Date().toISOString().split('T')[0];
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? new Date().toISOString().split('T')[0] : d.toISOString().split('T')[0];
+}
+
+function escapeXml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function urlEntry({ loc, lastmod, changefreq, priority }) {
+  const lines = [`  <url>`, `    <loc>${escapeXml(loc)}</loc>`];
+  if (lastmod) lines.push(`    <lastmod>${lastmod}</lastmod>`);
+  if (changefreq) lines.push(`    <changefreq>${changefreq}</changefreq>`);
+  if (priority) lines.push(`    <priority>${priority}</priority>`);
+  lines.push(`  </url>`);
+  return lines.join('\n');
+}
+
+async function generateSitemapXml() {
+  const activeVal = db.isPostgres ? 'true' : '1';
+
+  // Active, in-stock products only — excludes quantity=0 and deactivated (active=false/0)
+  const { rows: products } = await db.query(
+    `SELECT id, created_at FROM products
+     WHERE quantity > 0 AND active = ${activeVal}
+     ORDER BY id ASC`
   );
 
-  const staticEntries = STATIC_URLS.map(
-    (path) => `  <url><loc>${BASE_URL}${path}</loc><changefreq>daily</changefreq><priority>0.8</priority></url>`
-  ).join('\n');
+  // Public farmer profiles — excludes deactivated accounts
+  const { rows: farmers } = await db.query(
+    `SELECT id, created_at FROM users
+     WHERE role = 'farmer' AND deactivated_at IS NULL AND active = ${activeVal}
+     ORDER BY id ASC`
+  );
 
-  const productEntries = rows.map(
-    (p) =>
-      `  <url><loc>${BASE_URL}/products/${p.id}</loc><lastmod>${new Date(p.updated_at || Date.now()).toISOString().split('T')[0]}</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>`
-  ).join('\n');
+  const entries = [
+    ...STATIC_PAGES.map(({ path, changefreq, priority }) =>
+      urlEntry({ loc: `${BASE_URL}${path}`, changefreq, priority })
+    ),
+    ...products.map((p) =>
+      urlEntry({
+        loc: `${BASE_URL}/products/${p.id}`,
+        lastmod: toDateStr(p.created_at),
+        changefreq: 'weekly',
+        priority: '0.6',
+      })
+    ),
+    ...farmers.map((f) =>
+      urlEntry({
+        loc: `${BASE_URL}/farmers/${f.id}`,
+        lastmod: toDateStr(f.created_at),
+        changefreq: 'weekly',
+        priority: '0.7',
+      })
+    ),
+  ];
 
-  xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${staticEntries}
-${productEntries}
-</urlset>`;
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    entries.join('\n'),
+    '</urlset>',
+  ].join('\n');
+}
 
-  await cache.set(cacheKey, xml, 3600); // Cache for 1 hour
+router.get('/', async (req, res) => {
+  let xml;
+  let etag;
+
+  // 1. Redis cache (shared across instances)
+  const redisHit = await cache.get('sitemap');
+  if (redisHit) {
+    if (typeof redisHit === 'string') {
+      // Tolerate legacy cache format that stored raw XML
+      xml = redisHit;
+      etag = crypto.createHash('sha1').update(xml).digest('hex');
+    } else if (redisHit.xml) {
+      xml = redisHit.xml;
+      etag = redisHit.etag;
+    }
+  }
+
+  // 2. In-memory fallback (single-instance, no Redis)
+  if (!xml && memCache && Date.now() < memCache.expires) {
+    xml = memCache.xml;
+    etag = memCache.etag;
+  }
+
+  // 3. Generate fresh, then populate both cache tiers
+  if (!xml) {
+    xml = await generateSitemapXml();
+    etag = crypto.createHash('sha1').update(xml).digest('hex');
+    await cache.set('sitemap', { xml, etag }, CACHE_TTL);
+    memCache = { xml, etag, expires: Date.now() + CACHE_TTL * 1000 };
+  }
+
+  res.setHeader('Cache-Control', `public, max-age=${CACHE_TTL}`);
+  res.setHeader('ETag', `"${etag}"`);
+
+  // Honour conditional GET — avoids redundant XML transmission on re-crawl
+  if (req.headers['if-none-match'] === `"${etag}"`) {
+    return res.status(304).end();
+  }
+
   res.type('application/xml').send(xml);
 });
 
 module.exports = router;
+module.exports.generateSitemapXml = generateSitemapXml;
+module.exports._resetMemCache = () => { memCache = null; };


### PR DESCRIPTION
Closes #830

---

## Summary

- **`sitemap.js`** rewritten to generate a fully dynamic sitemap covering static pages, active product pages, and public farmer profile pages — with exclusion rules keeping unavailable listings out of crawl indexes.
- **Two-tier caching**: Redis (shared across instances) with an in-memory ETag/304 fallback when Redis is unavailable, both with a 1-hour TTL.
- **`robots.txt`** `Sitemap:` directive corrected to use `BACKEND_URL` (where the sitemap endpoint actually lives) rather than the old `FRONTEND_URL`.

---

## Changes

### `backend/src/routes/sitemap.js`

#### URLs included

| Page type | Path pattern | Priority | Changefreq |
|---|---|---|---|
| Homepage | `/` | 1.0 | daily |
| Marketplace | `/marketplace` | 0.9 | daily |
| Product detail | `/products/:id` | 0.6 | weekly |
| Farmer profile | `/farmers/:id` | 0.7 | weekly |

#### Exclusion rules

- **Products**: `quantity = 0` → excluded; `active = false/0` (set by the deactivation job when `best_before` expires) → excluded.
- **Farmers**: `deactivated_at IS NOT NULL` → excluded; `active = 0` → excluded.
- Dual-mode SQL (`active = true` for Postgres, `active = 1` for SQLite) matches the rest of the codebase.

#### `<lastmod>` derivation

`created_at` is used as the lastmod source — it is the only reliably-present timestamp on both `products` and `users`. All values pass through `toDateStr()` which produces `YYYY-MM-DD` and handles `null`/invalid dates gracefully.

#### XML standards compliance

- `<?xml version="1.0" encoding="UTF-8"?>` declaration
- `xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"` namespace
- All `<loc>` values escaped via `escapeXml()` (handles `&`, `<`, `>`, `"`, `'`)

#### Two-tier caching

```
Request
  │
  ├─ Redis hit? → serve cached { xml, etag }
  │
  ├─ memCache hit (not expired)? → serve cached { xml, etag }
  │
  └─ Generate fresh XML
       → SHA-1 ETag
       → store in Redis (TTL 3600s)
       → store in memCache (expires = now + 3600s)
       → serve with Cache-Control: public, max-age=3600
```

Every response sets `ETag` and `Cache-Control`. A `If-None-Match` match returns `304 Not Modified` without re-transmitting the XML body.

Legacy string-format Redis values (from the previous code) are detected by `typeof === 'string'` and handled gracefully during zero-downtime deploys.

`generateSitemapXml()` and `_resetMemCache()` are exported for test isolation.

---

### `backend/src/routes/index.js`

**Before:**
```
Sitemap: ${process.env.FRONTEND_URL || 'http://localhost:3000'}/sitemap.xml
```

**After:**
```
Sitemap: ${process.env.BACKEND_URL || `${req.protocol}://${req.get('host')}`}/sitemap.xml
```

The sitemap is served by the backend at `/sitemap.xml` — the `FRONTEND_URL` reference was incorrect. The fallback derives the host from the actual incoming request, so local dev works without any env var configuration.

---

## No migration required

No schema changes. Both queries use columns already present: `products.active`, `products.quantity`, `users.role`, `users.deactivated_at`, `users.active`.

---

## Test plan

- [ ] `GET /sitemap.xml` returns `Content-Type: application/xml` with a valid `<?xml …?>` declaration and correct `<urlset>` namespace
- [ ] Static pages `/` and `/marketplace` appear in every sitemap
- [ ] Active product (`quantity > 0`, `active = 1`) → included in sitemap
- [ ] Product with `quantity = 0` → excluded from sitemap
- [ ] Product with `active = 0` (deactivated) → excluded from sitemap
- [ ] Active farmer (role = 'farmer', `deactivated_at IS NULL`, `active = 1`) → included under `/farmers/:id`
- [ ] Farmer with `deactivated_at` set → excluded from sitemap
- [ ] `<lastmod>` values present and formatted as `YYYY-MM-DD`
- [ ] Second `GET /sitemap.xml` returns same `ETag` header; `If-None-Match: "<etag>"` gets `304`
- [ ] `Cache-Control: public, max-age=3600` present on all responses
- [ ] `GET /robots.txt` contains `Sitemap: http://…/sitemap.xml` (pointing to backend, not frontend)
- [ ] Run full test suite — no regressions
