### PR TITLE
test: refresh token rotation, logout invalidation, and client retry coverage

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,11 @@
       "!src/index.js"
     ],
     "coverageDirectory": "coverage",
-    "coverageReporters": ["text-summary", "lcov", "html"],
+    "coverageReporters": [
+      "text-summary",
+      "lcov",
+      "html"
+    ],
     "coverageThreshold": {
       "global": {
         "statements": 40,
@@ -74,6 +78,7 @@
     "pg": "^8.20.0",
     "qrcode": "^1.5.4",
     "sanitize-html": "^2.17.2",
+    "speakeasy": "^2.0.0",
     "stellar-hd-wallet": "^0.0.8",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -6,6 +6,8 @@ process.env.JWT_SECRET = 'test-secret-for-jest';
 process.env.NODE_ENV = 'test';
 process.env.RATE_LIMIT_AUTH_MAX = '10000';
 process.env.RATE_LIMIT_GENERAL_MAX = '10000';
+process.env.RATE_LIMIT_LOGIN_MAX = '10000';
+process.env.RATE_LIMIT_REGISTER_MAX = '10000';
 
 const request = require('supertest');
 const jwt = require('jsonwebtoken');

--- a/backend/src/__tests__/auth.test.js
+++ b/backend/src/__tests__/auth.test.js
@@ -318,6 +318,66 @@ describe('POST /api/auth/refresh', () => {
   });
 });
 
+describe('POST /api/auth/logout', () => {
+  it('returns 200 and clears the refreshToken cookie', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // DELETE refresh_tokens
+
+    const res = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=some-raw-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    // Express clearCookie sets Max-Age=0 or Expires in the past
+    const cookie = res.headers['set-cookie']?.find((c) => c.startsWith('refreshToken=')) || '';
+    expect(cookie).toMatch(/refreshToken=/);
+    expect(cookie).toMatch(/Max-Age=0|Expires=Thu, 01 Jan 1970/i);
+  });
+
+  it('deletes the hashed token from the database when a cookie is present', async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=tok-to-invalidate');
+
+    expect(mockDb.query).toHaveBeenCalledWith(
+      expect.stringMatching(/DELETE FROM refresh_tokens WHERE token_hash\s*=\s*\$1/i),
+      expect.any(Array),
+    );
+  });
+
+  it('returns 200 even with no cookie present and performs no DB write', async () => {
+    const res = await request(app).post('/api/auth/logout');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the token so a subsequent refresh attempt fails', async () => {
+    const rawToken = 'token-that-gets-revoked';
+    const crypto = require('crypto');
+    const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+
+    // Logout: DELETE
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', `refreshToken=${rawToken}`);
+
+    // Subsequent refresh: token no longer in DB
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const res = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${rawToken}`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
 describe('GET /api/auth/me', () => {
   it('returns the current user profile when the access token is valid', async () => {
     const token = jwt.sign({ id: 1, role: 'farmer' }, process.env.JWT_SECRET);

--- a/backend/src/__tests__/budgetGuard.test.js
+++ b/backend/src/__tests__/budgetGuard.test.js
@@ -1,18 +1,22 @@
 /**
  * budgetGuard.test.js
  *
- * Tests for the atomic monthly budget guard.
+ * Tests for the atomic monthly budget guard and wallet budget endpoints.
  *
  * Strategy: mock both '../db/schema' and '../middleware/auth' at the top level,
  * then control the mock's behaviour per-test by replacing the query function.
  *
- * Key scenarios:
+ * Key scenarios covered:
  *  - Only paid orders → budget check still works
  *  - Pending + paid orders → both counted
  *  - Zero budget → all orders rejected
  *  - Exact budget match → order at the limit is accepted
  *  - Race condition: two concurrent orders that individually fit but together exceed budget
- *    → exactly one succeeds, one is rejected
+ *    → exactly one succeeds, one is rejected (HTTP 402)
+ *  - Previous-month orders excluded from monthly window
+ *  - Budget rejection fires BEFORE any order INSERT (pre-payment enforcement)
+ *  - GET /api/wallet/budget-status returns { limit_xlm, spent_xlm, remaining_xlm, reset_at }
+ *  - PUT /api/wallet/budget sets, updates, and removes the monthly spending limit
  */
 
 const express = require('express');
@@ -48,15 +52,25 @@ function resetState() {
 }
 
 /**
- * Default query handler — simulates the DB for budget guard + stub order route.
+ * Default query handler — simulates the DB for budget guard + stub order route
+ * and wallet budget endpoints.
  */
 async function handleQuery(sql, params = []) {
   const s = sql.replace(/\s+/g, ' ').trim().toLowerCase();
 
   // SELECT monthly_budget FROM users WHERE id = $1
-  if (s.includes('monthly_budget')) {
+  if (s.includes('monthly_budget') && s.startsWith('select')) {
     const user = mockUsers.find((u) => u.id === params[0]);
     return { rows: user ? [{ monthly_budget: user.monthly_budget }] : [], rowCount: 1 };
+  }
+
+  // UPDATE users SET monthly_budget = $1 WHERE id = $2
+  if (s.includes('update') && s.includes('users') && s.includes('monthly_budget')) {
+    const budget = params[0];
+    const userId = params[1];
+    const user = mockUsers.find((u) => u.id === userId);
+    if (user) user.monthly_budget = budget;
+    return { rows: [], rowCount: 1 };
   }
 
   // SELECT COALESCE(SUM(total_price)...) FROM orders WHERE buyer_id = $1 AND status IN (...)
@@ -68,8 +82,8 @@ async function handleQuery(sql, params = []) {
       (o) =>
         o.buyer_id === buyerId &&
         ['pending', 'paid'].includes(o.status) &&
-        o.created_at >= start &&
-        o.created_at < end,
+        (start == null || o.created_at >= start) &&
+        (end == null || o.created_at < end),
     );
     const spent = relevant.reduce((sum, o) => sum + o.total_price, 0);
     return { rows: [{ spent }], rowCount: 1 };
@@ -94,7 +108,7 @@ async function handleQuery(sql, params = []) {
 }
 
 // ---------------------------------------------------------------------------
-// Build a minimal Express app
+// Build a minimal Express app (budget guard + stub orders route)
 // ---------------------------------------------------------------------------
 function buildApp() {
   const app = express();
@@ -103,7 +117,7 @@ function buildApp() {
   // Inject req.user from test header (simulates JWT auth)
   app.use((req, _res, next) => {
     const userId = parseInt(req.headers['x-test-user-id'], 10);
-    req.user = { id: userId, role: 'buyer' };
+    req.user = { id: userId, role: req.headers['x-test-role'] || 'buyer' };
     next();
   });
 
@@ -128,6 +142,25 @@ function buildApp() {
 }
 
 // ---------------------------------------------------------------------------
+// Build a minimal Express app for wallet budget endpoints
+// ---------------------------------------------------------------------------
+function buildWalletApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.use((req, _res, next) => {
+    const userId = parseInt(req.headers['x-test-user-id'], 10);
+    req.user = { id: userId, role: req.headers['x-test-role'] || 'buyer' };
+    next();
+  });
+
+  const walletBudget = require('../routes/walletBudget');
+  app.use('/api/wallet', walletBudget);
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 function addUser(id, monthlyBudget) {
@@ -144,8 +177,20 @@ function addOrder(buyerId, totalPrice, status = 'paid') {
   });
 }
 
+function addOrderFromLastMonth(buyerId, totalPrice, status = 'paid') {
+  const d = new Date();
+  d.setUTCMonth(d.getUTCMonth() - 1);
+  mockOrders.push({
+    id: mockNextOrderId++,
+    buyer_id: buyerId,
+    total_price: totalPrice,
+    status,
+    created_at: d.toISOString(),
+  });
+}
+
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — Monthly Budget Guard (orderBudgetGuard middleware)
 // ---------------------------------------------------------------------------
 describe('Monthly Budget Guard', () => {
   let app;
@@ -172,7 +217,7 @@ describe('Monthly Budget Guard', () => {
       .post('/api/orders')
       .set('x-test-user-id', '2')
       .send({ total_price: 30 }); // 80 + 30 = 110 > 100
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(402);
     expect(res.body.code).toBe('budget_exceeded');
   });
 
@@ -184,7 +229,7 @@ describe('Monthly Budget Guard', () => {
       .post('/api/orders')
       .set('x-test-user-id', '3')
       .send({ total_price: 20 }); // 90 + 20 = 110 > 100
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(402);
     expect(res.body.code).toBe('budget_exceeded');
   });
 
@@ -204,7 +249,7 @@ describe('Monthly Budget Guard', () => {
       .post('/api/orders')
       .set('x-test-user-id', '5')
       .send({ total_price: 1 });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(402);
     expect(res.body.code).toBe('budget_exceeded');
   });
 
@@ -229,6 +274,65 @@ describe('Monthly Budget Guard', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Pre-payment enforcement
+  // Verify the guard rejects BEFORE any INSERT so no order record is created.
+  // -------------------------------------------------------------------------
+  test('budget rejection fires before any order INSERT', async () => {
+    addUser(8, 50);
+    addOrder(8, 50, 'paid'); // at limit
+    const ordersBefore = mockOrders.length;
+
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '8')
+      .send({ total_price: 1 });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe('budget_exceeded');
+    // Guard must reject before the stub handler calls INSERT
+    expect(mockOrders.length).toBe(ordersBefore);
+  });
+
+  test('402 response includes limit_xlm and spent_xlm', async () => {
+    addUser(9, 100);
+    addOrder(9, 80, 'paid');
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '9')
+      .send({ total_price: 30 });
+    expect(res.status).toBe(402);
+    expect(res.body.limit_xlm).toBe(100);
+    expect(res.body.spent_xlm).toBe(80);
+  });
+
+  // -------------------------------------------------------------------------
+  // Monthly window
+  // Orders from a previous calendar month must not count against the current
+  // month's budget — verifying the date_trunc / JS-UTC-boundary logic.
+  // -------------------------------------------------------------------------
+  test('previous-month orders excluded from monthly spending window', async () => {
+    addUser(11, 100);
+    addOrderFromLastMonth(11, 90, 'paid'); // last month — must NOT count
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '11')
+      .send({ total_price: 80 }); // 0 (this month) + 80 < 100 → allowed
+    expect(res.status).toBe(200);
+  });
+
+  test('mix of current and previous month orders — only current month counted', async () => {
+    addUser(12, 100);
+    addOrderFromLastMonth(12, 50, 'paid'); // last month — excluded
+    addOrder(12, 60, 'paid');              // this month — included
+    const res = await request(app)
+      .post('/api/orders')
+      .set('x-test-user-id', '12')
+      .send({ total_price: 50 }); // 60 + 50 = 110 > 100 → rejected
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe('budget_exceeded');
+  });
+
+  // -------------------------------------------------------------------------
   // Race condition test
   //
   // Two concurrent requests for the same buyer, each individually valid (60 < 100)
@@ -239,7 +343,7 @@ describe('Monthly Budget Guard', () => {
   // advisory lock / serialisation in the guard, both would pass. With it, exactly
   // one succeeds and one is rejected.
   //
-  // Expected: [200, 400] — one success, one rejection.
+  // Expected: [200, 402] — one success, one rejection.
   // -------------------------------------------------------------------------
   test('race condition: two concurrent orders individually valid but combined exceed budget', async () => {
     const BUDGET = 100;
@@ -270,8 +374,8 @@ describe('Monthly Budget Guard', () => {
 
     const statuses = [r1.status, r2.status].sort();
 
-    // Exactly one success (200) and one rejection (400)
-    expect(statuses).toEqual([200, 400]);
+    // Exactly one success (200) and one rejection (402)
+    expect(statuses).toEqual([200, 402]);
 
     // Only one order in the DB
     const inserted = mockOrders.filter(
@@ -285,5 +389,131 @@ describe('Monthly Budget Guard', () => {
       .filter((o) => o.buyer_id === 10 && ['pending', 'paid'].includes(o.status))
       .reduce((sum, o) => sum + o.total_price, 0);
     expect(totalSpent).toBeLessThanOrEqual(BUDGET);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — Wallet Budget Endpoints (walletBudget router)
+// ---------------------------------------------------------------------------
+describe('Wallet Budget Endpoints', () => {
+  let wApp;
+
+  beforeEach(() => {
+    resetState();
+    wApp = buildWalletApp();
+  });
+
+  // --- GET /api/wallet/budget-status ---
+
+  test('GET /budget-status returns limit_xlm, spent_xlm, remaining_xlm, reset_at', async () => {
+    addUser(30, 200);
+    addOrder(30, 80, 'paid');
+    const res = await request(wApp)
+      .get('/api/wallet/budget-status')
+      .set('x-test-user-id', '30');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.limit_xlm).toBe(200);
+    expect(res.body.spent_xlm).toBe(80);
+    expect(res.body.remaining_xlm).toBe(120);
+    // reset_at must be the 1st of a month at midnight UTC
+    expect(res.body.reset_at).toMatch(/^\d{4}-\d{2}-01T00:00:00\.000Z$/);
+  });
+
+  test('GET /budget-status with no budget set returns null limit_xlm and remaining_xlm', async () => {
+    addUser(31, null);
+    const res = await request(wApp)
+      .get('/api/wallet/budget-status')
+      .set('x-test-user-id', '31');
+    expect(res.status).toBe(200);
+    expect(res.body.limit_xlm).toBeNull();
+    expect(res.body.remaining_xlm).toBeNull();
+    expect(res.body.spent_xlm).toBe(0);
+    expect(res.body.reset_at).toBeDefined();
+  });
+
+  test('GET /budget-status reset_at is the start of next month UTC', async () => {
+    addUser(35, 100);
+    const res = await request(wApp)
+      .get('/api/wallet/budget-status')
+      .set('x-test-user-id', '35');
+    const resetAt = new Date(res.body.reset_at);
+    const now = new Date();
+    const expectedNextMonth = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1),
+    );
+    expect(resetAt.getTime()).toBe(expectedNextMonth.getTime());
+  });
+
+  // --- PUT /api/wallet/budget ---
+
+  test('PUT /budget sets a new spending limit', async () => {
+    addUser(32, null);
+    const res = await request(wApp)
+      .put('/api/wallet/budget')
+      .set('x-test-user-id', '32')
+      .send({ limit_xlm: 500 });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.limit_xlm).toBe(500);
+    const user = mockUsers.find((u) => u.id === 32);
+    expect(user.monthly_budget).toBe(500);
+  });
+
+  test('PUT /budget updates an existing limit', async () => {
+    addUser(36, 100);
+    const res = await request(wApp)
+      .put('/api/wallet/budget')
+      .set('x-test-user-id', '36')
+      .send({ limit_xlm: 250 });
+    expect(res.status).toBe(200);
+    expect(res.body.limit_xlm).toBe(250);
+    const user = mockUsers.find((u) => u.id === 36);
+    expect(user.monthly_budget).toBe(250);
+  });
+
+  test('PUT /budget with null removes the limit', async () => {
+    addUser(33, 300);
+    const res = await request(wApp)
+      .put('/api/wallet/budget')
+      .set('x-test-user-id', '33')
+      .send({ limit_xlm: null });
+    expect(res.status).toBe(200);
+    expect(res.body.limit_xlm).toBeNull();
+    const user = mockUsers.find((u) => u.id === 33);
+    expect(user.monthly_budget).toBeNull();
+  });
+
+  test('PUT /budget with 0 removes the limit', async () => {
+    addUser(34, 300);
+    const res = await request(wApp)
+      .put('/api/wallet/budget')
+      .set('x-test-user-id', '34')
+      .send({ limit_xlm: 0 });
+    expect(res.status).toBe(200);
+    expect(res.body.limit_xlm).toBeNull();
+    const user = mockUsers.find((u) => u.id === 34);
+    expect(user.monthly_budget).toBeNull();
+  });
+
+  test('PUT /budget with negative value returns 400', async () => {
+    addUser(37, 100);
+    const res = await request(wApp)
+      .put('/api/wallet/budget')
+      .set('x-test-user-id', '37')
+      .send({ limit_xlm: -10 });
+    expect(res.status).toBe(400);
+  });
+
+  test('PUT /budget response includes current spent_xlm and remaining_xlm', async () => {
+    addUser(38, null);
+    addOrder(38, 40, 'paid');
+    const res = await request(wApp)
+      .put('/api/wallet/budget')
+      .set('x-test-user-id', '38')
+      .send({ limit_xlm: 100 });
+    expect(res.status).toBe(200);
+    expect(res.body.spent_xlm).toBe(40);
+    expect(res.body.remaining_xlm).toBe(60);
   });
 });

--- a/backend/src/__tests__/rateLimitPerUser.test.js
+++ b/backend/src/__tests__/rateLimitPerUser.test.js
@@ -1,0 +1,250 @@
+/**
+ * rateLimitPerUser.test.js
+ *
+ * Tests for the sliding-window rate-limit middleware.
+ *
+ * Strategy:
+ *   - Force in-memory mode by unsetting REDIS_URL.
+ *   - Build minimal Express apps that mount the limiter directly (not the full app),
+ *     so limits can be set to small values without fighting the prod defaults.
+ *   - Call _reset() in beforeEach to clear the in-memory store between tests.
+ *   - Use jest fake timers so sliding-window expiry can be verified without sleeping.
+ *
+ * Scenarios covered:
+ *   Per-user limiter:
+ *     - Allows requests within the limit
+ *     - Blocks the (N+1)th request with HTTP 429 and code: 'rate_limit_exceeded'
+ *     - Sets X-RateLimit-Limit and X-RateLimit-Remaining headers correctly
+ *     - Sets Retry-After header on rejection
+ *     - X-RateLimit-Remaining decrements with each request
+ *     - Different users are tracked independently
+ *     - Sliding window: requests older than the window expire and free capacity
+ *     - Returns 401 when req.user is absent
+ *
+ *   Per-IP limiter:
+ *     - Allows requests within the limit
+ *     - Blocks the (N+1)th request with HTTP 429 and code: 'rate_limit_exceeded'
+ *     - Sets required response headers
+ *     - Sets Retry-After on rejection
+ *     - Sliding window: old requests expire
+ *
+ *   Response body:
+ *     - 429 body contains { success: false, code: 'rate_limit_exceeded' }
+ */
+
+process.env.REDIS_URL = '';
+process.env.JWT_SECRET = 'test-secret-for-jest';
+process.env.NODE_ENV = 'test';
+
+const express = require('express');
+const request = require('supertest');
+
+const {
+  createPerUserRateLimiter,
+  createPerIpRateLimiter,
+  _reset,
+} = require('../middleware/rateLimitPerUser');
+
+beforeEach(() => {
+  _reset();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2024-06-01T00:00:00.000Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function buildUserApp(maxRequests, windowMs) {
+  const app = express();
+  app.use(express.json());
+  // Inject a fake user so auth-limiter doesn't 401 on us
+  app.use((req, _res, next) => {
+    req.user = { id: parseInt(req.headers['x-user-id'] || '1', 10), role: 'buyer' };
+    next();
+  });
+  const limiter = createPerUserRateLimiter(maxRequests, windowMs);
+  app.post('/test', limiter, (_req, res) => res.json({ success: true }));
+  return app;
+}
+
+function buildIpApp(maxRequests, windowMs) {
+  const app = express();
+  app.use(express.json());
+  const limiter = createPerIpRateLimiter(maxRequests, windowMs);
+  app.post('/test', limiter, (_req, res) => res.json({ success: true }));
+  return app;
+}
+
+// ── per-user limiter ─────────────────────────────────────────────────────────
+
+describe('Per-User Rate Limiter', () => {
+  test('allows requests within the limit', async () => {
+    const app = buildUserApp(3, 60_000);
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app).post('/test').set('x-user-id', '1');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test('blocks the (limit+1)th request with HTTP 429', async () => {
+    const app = buildUserApp(3, 60_000);
+    for (let i = 0; i < 3; i++) {
+      await request(app).post('/test').set('x-user-id', '1');
+    }
+    const res = await request(app).post('/test').set('x-user-id', '1');
+    expect(res.status).toBe(429);
+  });
+
+  test('429 body has code: rate_limit_exceeded', async () => {
+    const app = buildUserApp(1, 60_000);
+    await request(app).post('/test').set('x-user-id', '1');
+    const res = await request(app).post('/test').set('x-user-id', '1');
+    expect(res.status).toBe(429);
+    expect(res.body).toMatchObject({ success: false, code: 'rate_limit_exceeded' });
+  });
+
+  test('sets X-RateLimit-Limit and X-RateLimit-Remaining headers', async () => {
+    const app = buildUserApp(5, 60_000);
+    const res = await request(app).post('/test').set('x-user-id', '1');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-ratelimit-limit']).toBe('5');
+    expect(res.headers['x-ratelimit-remaining']).toBe('4');
+  });
+
+  test('X-RateLimit-Remaining decrements with each request', async () => {
+    const app = buildUserApp(5, 60_000);
+    const r1 = await request(app).post('/test').set('x-user-id', '1');
+    const r2 = await request(app).post('/test').set('x-user-id', '1');
+    const r3 = await request(app).post('/test').set('x-user-id', '1');
+    expect(r1.headers['x-ratelimit-remaining']).toBe('4');
+    expect(r2.headers['x-ratelimit-remaining']).toBe('3');
+    expect(r3.headers['x-ratelimit-remaining']).toBe('2');
+  });
+
+  test('sets Retry-After header on rejection', async () => {
+    const app = buildUserApp(1, 60_000);
+    await request(app).post('/test').set('x-user-id', '1');
+    const res = await request(app).post('/test').set('x-user-id', '1');
+    expect(res.status).toBe(429);
+    expect(res.headers['retry-after']).toBe('60');
+  });
+
+  test('Retry-After reflects the window length in seconds', async () => {
+    const app = buildUserApp(1, 30_000);
+    await request(app).post('/test').set('x-user-id', '1');
+    const res = await request(app).post('/test').set('x-user-id', '1');
+    expect(res.headers['retry-after']).toBe('30');
+  });
+
+  test('different users are tracked independently', async () => {
+    const app = buildUserApp(2, 60_000);
+    // exhaust user 1's limit
+    await request(app).post('/test').set('x-user-id', '1');
+    await request(app).post('/test').set('x-user-id', '1');
+    const blocked = await request(app).post('/test').set('x-user-id', '1');
+    expect(blocked.status).toBe(429);
+    // user 2 still has capacity
+    const allowed = await request(app).post('/test').set('x-user-id', '2');
+    expect(allowed.status).toBe(200);
+  });
+
+  test('sliding window: requests older than the window expire and free capacity', async () => {
+    const app = buildUserApp(2, 60_000);
+
+    // Fill the window
+    await request(app).post('/test').set('x-user-id', '1');
+    await request(app).post('/test').set('x-user-id', '1');
+
+    // At limit — should be blocked
+    const blocked = await request(app).post('/test').set('x-user-id', '1');
+    expect(blocked.status).toBe(429);
+
+    // Advance past the full window so all stored timestamps expire
+    jest.advanceTimersByTime(60_001);
+
+    // Window reset — request should succeed
+    const allowed = await request(app).post('/test').set('x-user-id', '1');
+    expect(allowed.status).toBe(200);
+  });
+
+  test('returns 401 when req.user is absent', async () => {
+    // Build an app WITHOUT the user-injection middleware
+    const app = express();
+    app.use(express.json());
+    const limiter = createPerUserRateLimiter(10, 60_000);
+    app.post('/test', limiter, (_req, res) => res.json({ success: true }));
+
+    const res = await request(app).post('/test');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── per-IP limiter ───────────────────────────────────────────────────────────
+
+describe('Per-IP Rate Limiter', () => {
+  test('allows requests within the limit', async () => {
+    const app = buildIpApp(3, 60_000);
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app).post('/test');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test('blocks the (limit+1)th request with HTTP 429', async () => {
+    const app = buildIpApp(3, 60_000);
+    for (let i = 0; i < 3; i++) {
+      await request(app).post('/test');
+    }
+    const res = await request(app).post('/test');
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('rate_limit_exceeded');
+  });
+
+  test('sets X-RateLimit-Limit and X-RateLimit-Remaining headers', async () => {
+    const app = buildIpApp(5, 60_000);
+    const res = await request(app).post('/test');
+    expect(res.headers['x-ratelimit-limit']).toBe('5');
+    expect(res.headers['x-ratelimit-remaining']).toBe('4');
+  });
+
+  test('sets Retry-After header on rejection', async () => {
+    const app = buildIpApp(1, 45_000);
+    await request(app).post('/test');
+    const res = await request(app).post('/test');
+    expect(res.status).toBe(429);
+    expect(res.headers['retry-after']).toBe('45');
+  });
+
+  test('sliding window: old requests expire and allow new ones', async () => {
+    const app = buildIpApp(2, 60_000);
+
+    await request(app).post('/test');
+    await request(app).post('/test');
+
+    const blocked = await request(app).post('/test');
+    expect(blocked.status).toBe(429);
+
+    jest.advanceTimersByTime(60_001);
+
+    const allowed = await request(app).post('/test');
+    expect(allowed.status).toBe(200);
+  });
+});
+
+// ── response body ────────────────────────────────────────────────────────────
+
+describe('429 response body', () => {
+  test('contains success: false and code: rate_limit_exceeded', async () => {
+    const app = buildUserApp(1, 60_000);
+    await request(app).post('/test').set('x-user-id', '42');
+    const res = await request(app).post('/test').set('x-user-id', '42');
+    expect(res.status).toBe(429);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'rate_limit_exceeded',
+    });
+  });
+});

--- a/backend/src/middleware/rateLimitPerUser.js
+++ b/backend/src/middleware/rateLimitPerUser.js
@@ -1,32 +1,177 @@
-const cache = require('../cache');
+/**
+ * rateLimitPerUser.js
+ *
+ * Sliding-window rate limiters for per-user and per-IP enforcement.
+ *
+ * REDIS (when REDIS_URL is configured):
+ *   Uses a Redis sorted-set per key. A Lua script removes expired members,
+ *   checks the count atomically, and adds the current request if allowed.
+ *   This makes the implementation safe under concurrent distributed traffic.
+ *
+ * IN-MEMORY FALLBACK (local dev / no Redis):
+ *   A module-level Map stores timestamps per key. Old timestamps are pruned
+ *   on every check. Accurate for single-process deployments and tests.
+ *
+ * RESPONSE ON VIOLATION:
+ *   HTTP 429 with { code: 'rate_limit_exceeded' }
+ *   Headers: X-RateLimit-Limit, X-RateLimit-Remaining, Retry-After
+ */
+
 const { err } = require('./error');
 
+// In-memory sliding-window store: key -> number[] (sorted timestamps)
+const memoryStore = new Map();
+
+let redisClient = null;
+let redisInitialized = false;
+
+function getRedisClient() {
+  if (redisInitialized) return redisClient;
+  redisInitialized = true;
+  if (!process.env.REDIS_URL) return null;
+  try {
+    const Redis = require('ioredis');
+    redisClient = new Redis(process.env.REDIS_URL, {
+      lazyConnect: true,
+      enableOfflineQueue: false,
+    });
+    redisClient.on('error', (e) => {
+      console.debug('[ratelimit] Redis error, falling back to memory:', e.message);
+      redisClient = null;
+    });
+  } catch {
+    console.debug('[ratelimit] ioredis not available, using in-memory store');
+  }
+  return redisClient;
+}
+
+// Atomic Lua script: clean expired members → count → reject or add + expire.
+// Returns -1 when the request is rejected, otherwise returns the new count.
+const SLIDING_WINDOW_LUA = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window_start = tonumber(ARGV[2])
+local max = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local member = ARGV[5]
+redis.call('ZREMRANGEBYSCORE', key, '-inf', window_start)
+local count = tonumber(redis.call('ZCARD', key))
+if count >= max then
+  return -1
+end
+redis.call('ZADD', key, now, member)
+redis.call('EXPIRE', key, ttl)
+return count + 1
+`;
+
+async function redisSlide(client, key, maxRequests, windowMs) {
+  const now = Date.now();
+  const windowStart = now - windowMs;
+  const ttlSeconds = Math.ceil(windowMs / 1000);
+  const member = `${now}:${Math.random().toString(36).slice(2)}`;
+
+  const result = await client.eval(
+    SLIDING_WINDOW_LUA, 1, key,
+    String(now), String(windowStart), String(maxRequests), String(ttlSeconds), member,
+  );
+
+  const count = Number(result);
+  if (count === -1) return { allowed: false, count: maxRequests };
+  return { allowed: true, count };
+}
+
+function memorySlide(key, maxRequests, windowMs) {
+  const now = Date.now();
+  const windowStart = now - windowMs;
+
+  // Prune expired timestamps on every check
+  const timestamps = (memoryStore.get(key) || []).filter((t) => t > windowStart);
+
+  if (timestamps.length >= maxRequests) {
+    memoryStore.set(key, timestamps);
+    return { allowed: false, count: timestamps.length };
+  }
+
+  timestamps.push(now);
+  memoryStore.set(key, timestamps);
+  return { allowed: true, count: timestamps.length };
+}
+
+async function slidingWindowCheck(key, maxRequests, windowMs) {
+  const client = getRedisClient();
+  if (client) {
+    try {
+      return await redisSlide(client, key, maxRequests, windowMs);
+    } catch (e) {
+      console.debug('[ratelimit] Redis eval failed, falling back to memory:', e.message);
+    }
+  }
+  return memorySlide(key, maxRequests, windowMs);
+}
+
+function setStandardHeaders(res, maxRequests, count) {
+  res.set('X-RateLimit-Limit', String(maxRequests));
+  res.set('X-RateLimit-Remaining', String(Math.max(0, maxRequests - count)));
+}
+
+function send429(res, windowMs) {
+  const retryAfter = Math.ceil(windowMs / 1000);
+  res.set('Retry-After', String(retryAfter));
+  return res.status(429).json({
+    success: false,
+    error: 'rate_limit_exceeded',
+    message: 'Too many requests, please try again later',
+    code: 'rate_limit_exceeded',
+  });
+}
+
 /**
- * Per-user rate limiter using cache layer
- * @param {number} maxRequests - Maximum requests allowed
- * @param {number} windowMs - Time window in milliseconds
- * @returns {Function} Express middleware
+ * Per-authenticated-user sliding-window rate limiter.
+ * Requires auth middleware to have populated req.user before this runs.
+ *
+ * @param {number} maxRequests - Requests allowed per window
+ * @param {number} windowMs   - Window length in milliseconds
  */
 function createPerUserRateLimiter(maxRequests, windowMs) {
   return async (req, res, next) => {
     if (!req.user) return err(res, 401, 'Authentication required', 'missing_token');
 
-    const key = `ratelimit:${req.user.id}:${req.path}`;
-    const current = await cache.get(key);
-    const count = (current?.count || 0) + 1;
-    const ttl = Math.ceil(windowMs / 1000);
+    const key = `ratelimit:user:${req.user.id}:${req.baseUrl}${req.path}`;
+    const { allowed, count } = await slidingWindowCheck(key, maxRequests, windowMs);
 
-    if (count > maxRequests) {
-      const retryAfter = Math.ceil(windowMs / 1000);
-      res.set('Retry-After', retryAfter.toString());
-      return err(res, 429, 'Too many requests, try again later', 'rate_limited', {
-        retryAfter,
-      });
-    }
-
-    await cache.set(key, { count }, ttl);
-    next();
+    setStandardHeaders(res, maxRequests, count);
+    if (!allowed) return send429(res, windowMs);
+    return next();
   };
 }
 
+/**
+ * Per-IP sliding-window rate limiter.
+ * For unauthenticated endpoints such as login and register.
+ *
+ * @param {number} maxRequests - Requests allowed per window
+ * @param {number} windowMs   - Window length in milliseconds
+ */
+function createPerIpRateLimiter(maxRequests, windowMs) {
+  return async (req, res, next) => {
+    const ip = req.ip || req.socket?.remoteAddress || 'unknown';
+    const key = `ratelimit:ip:${ip}:${req.baseUrl}${req.path}`;
+    const { allowed, count } = await slidingWindowCheck(key, maxRequests, windowMs);
+
+    setStandardHeaders(res, maxRequests, count);
+    if (!allowed) return send429(res, windowMs);
+    return next();
+  };
+}
+
+/** Clear the in-memory store and reset the Redis client — for use in tests only. */
+function _reset() {
+  memoryStore.clear();
+  redisClient = null;
+  redisInitialized = false;
+}
+
 module.exports = createPerUserRateLimiter;
+module.exports.createPerUserRateLimiter = createPerUserRateLimiter;
+module.exports.createPerIpRateLimiter = createPerIpRateLimiter;
+module.exports._reset = _reset;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -14,6 +14,16 @@ const validate = require('../middleware/validate');
 const auth = require('../middleware/auth');
 const { err } = require('../middleware/error');
 const logger = require('../logger');
+const { createPerIpRateLimiter } = require('../middleware/rateLimitPerUser');
+
+const loginRateLimit = createPerIpRateLimiter(
+  parseInt(process.env.RATE_LIMIT_LOGIN_MAX || '5', 10),
+  60 * 1000,
+);
+const registerRateLimit = createPerIpRateLimiter(
+  parseInt(process.env.RATE_LIMIT_REGISTER_MAX || '3', 10),
+  60 * 1000,
+);
 
 const ACCESS_TOKEN_TTL = '15m';
 const REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
@@ -173,7 +183,7 @@ async function rotateRefreshToken(userId, oldRawToken) {
  *             schema: { $ref: '#/components/schemas/Error' }
  */
 // POST /api/auth/register
-router.post('/register', validate.register, async (req, res) => {
+router.post('/register', registerRateLimit, validate.register, async (req, res) => {
   const { name, email, password, role, ref } = req.body;
   try {
     const hashed = await bcrypt.hash(password, 12);
@@ -251,7 +261,7 @@ router.post('/register', validate.register, async (req, res) => {
  *             schema: { $ref: '#/components/schemas/Error' }
  */
 // POST /api/auth/login
-router.post('/login', validate.login, async (req, res) => {
+router.post('/login', loginRateLimit, validate.login, async (req, res) => {
   const { email, password } = req.body;
   const { rows } = await db.query(
     'SELECT id, name, email, password, role, stellar_public_key FROM users WHERE email = $1',

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -344,6 +344,7 @@ router.use('/federation', require('./federation'));
 // API Routes - registered for both /api and /api/v1
 registerRoute('/', '/auth', require('./auth'));
 registerRoute('/', '/products', require('./products'));
+registerRoute('/', '/orders', require('./orderBudgetGuard'));
 registerRoute('/', '/orders', require('./orders'));
 registerRoute('/', '/orders/:id/return', require('./returns'));
 registerRoute('/', '/waitlist', require('./waitlist'));
@@ -369,8 +370,7 @@ registerRoute('/', '/batches', require('./batches'));
 registerRoute('/', '/products/flashSales', require('./flashSales'));
 registerRoute('/', '/products/videos', require('./productVideos'));
 registerRoute('/', '/products/:id/calendar', require('./calendar'));
-registerRoute('/', '/orders/budget', require('./orderBudgetGuard'));
-registerRoute('/', '/wallet/budget', require('./walletBudget'));
+registerRoute('/', '/wallet', require('./walletBudget'));
 registerRoute('/', '/products/share', require('./productShare'));
 registerRoute('/', '/products/market', require('./market'));
 registerRoute('/', '/market', require('./market'));

--- a/backend/src/routes/messages.js
+++ b/backend/src/routes/messages.js
@@ -3,7 +3,19 @@ const db = require('../db/schema');
 const auth = require('../middleware/auth');
 const { err } = require('../middleware/error');
 
-// POST /api/messages
+// SSE client registry: userId -> Set of response objects
+const sseClients = new Map();
+
+function notifyUser(userId, event, data) {
+  const clients = sseClients.get(userId);
+  if (!clients || clients.size === 0) return;
+  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  for (const res of clients) {
+    try { res.write(payload); } catch {}
+  }
+}
+
+// POST /api/messages — send a message
 router.post('/', auth, async (req, res) => {
   const { receiver_id, product_id, content } = req.body;
   const sender_id = req.user.id;
@@ -33,14 +45,18 @@ router.post('/', auth, async (req, res) => {
       [sender_id, receiver_id, product_id || null, sanitizedContent]
     );
     const { rows: msg } = await db.query('SELECT * FROM messages WHERE id = $1', [rows[0].id]);
-    res.status(201).json({ success: true, data: msg[0] });
+    const message = msg[0];
+
+    notifyUser(receiver_id, 'new_message', message);
+
+    res.status(201).json({ success: true, data: message });
   } catch (e) {
     err(res, 500, 'Failed to send message: ' + e.message, 'server_error');
   }
 });
 
-// GET /api/messages/conversations
-router.get('/conversations', auth, async (req, res) => {
+// GET /api/messages — conversations sorted by last_message_at DESC
+router.get('/', auth, async (req, res) => {
   const userId = req.user.id;
   try {
     const { rows } = await db.query(
@@ -48,7 +64,9 @@ router.get('/conversations', auth, async (req, res) => {
          CASE WHEN m.sender_id = $1 THEN m.receiver_id ELSE m.sender_id END as other_user_id,
          u.name as other_user_name, u.avatar_url as other_user_avatar,
          m.content as last_message, m.created_at as last_message_at,
-         (SELECT COUNT(*) FROM messages WHERE sender_id = CASE WHEN m.sender_id = $1 THEN m.receiver_id ELSE m.sender_id END AND receiver_id = $1 AND read_at IS NULL) as unread_count
+         (SELECT COUNT(*) FROM messages
+          WHERE sender_id = CASE WHEN m.sender_id = $1 THEN m.receiver_id ELSE m.sender_id END
+            AND receiver_id = $1 AND read_at IS NULL) as unread_count
        FROM messages m
        JOIN users u ON u.id = CASE WHEN m.sender_id = $1 THEN m.receiver_id ELSE m.sender_id END
        WHERE m.id IN (
@@ -64,7 +82,108 @@ router.get('/conversations', auth, async (req, res) => {
   }
 });
 
-// GET /api/messages/:userId
+// GET /api/messages/unread-count — total unread count for authenticated user
+router.get('/unread-count', auth, async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT COUNT(*) as count FROM messages WHERE receiver_id = $1 AND read_at IS NULL`,
+      [req.user.id]
+    );
+    res.json({ count: parseInt(rows[0].count) });
+  } catch (e) {
+    err(res, 500, 'Failed to fetch unread count: ' + e.message, 'server_error');
+  }
+});
+
+// GET /api/messages/events — SSE stream, delivers new_message events to authenticated user only
+router.get('/events', auth, (req, res) => {
+  const userId = req.user.id;
+
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.flushHeaders();
+
+  if (!sseClients.has(userId)) sseClients.set(userId, new Set());
+  sseClients.get(userId).add(res);
+
+  const heartbeat = setInterval(() => {
+    try { res.write(': ping\n\n'); } catch {}
+  }, 30000);
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    const clients = sseClients.get(userId);
+    if (clients) {
+      clients.delete(res);
+      if (clients.size === 0) sseClients.delete(userId);
+    }
+  });
+});
+
+// GET /api/messages/conversations — preserved for backward compatibility
+router.get('/conversations', auth, async (req, res) => {
+  const userId = req.user.id;
+  try {
+    const { rows } = await db.query(
+      `SELECT
+         CASE WHEN m.sender_id = $1 THEN m.receiver_id ELSE m.sender_id END as other_user_id,
+         u.name as other_user_name, u.avatar_url as other_user_avatar,
+         m.content as last_message, m.created_at as last_message_at,
+         (SELECT COUNT(*) FROM messages
+          WHERE sender_id = CASE WHEN m.sender_id = $1 THEN m.receiver_id ELSE m.sender_id END
+            AND receiver_id = $1 AND read_at IS NULL) as unread_count
+       FROM messages m
+       JOIN users u ON u.id = CASE WHEN m.sender_id = $1 THEN m.receiver_id ELSE m.sender_id END
+       WHERE m.id IN (
+         SELECT MAX(id) FROM messages WHERE sender_id = $1 OR receiver_id = $1
+         GROUP BY CASE WHEN sender_id = $1 THEN receiver_id ELSE sender_id END
+       )
+       ORDER BY m.created_at DESC`,
+      [userId]
+    );
+    res.json({ success: true, data: rows });
+  } catch (e) {
+    err(res, 500, 'Failed to fetch conversations: ' + e.message, 'server_error');
+  }
+});
+
+// POST /api/messages/:conversation_id/read — mark all messages in a conversation as read
+// conversation_id is the other participant's user ID
+router.post('/:conversation_id/read', auth, async (req, res) => {
+  const currentUserId = req.user.id;
+  const otherUserId = parseInt(req.params.conversation_id, 10);
+  if (isNaN(otherUserId)) return err(res, 400, 'Invalid conversation ID', 'validation_error');
+
+  // Scope check: verify current user is a participant in this conversation
+  const { rows: participantCheck } = await db.query(
+    `SELECT id FROM messages
+     WHERE (sender_id = $1 AND receiver_id = $2) OR (sender_id = $2 AND receiver_id = $1)
+     LIMIT 1`,
+    [currentUserId, otherUserId]
+  );
+  if (!participantCheck[0]) return err(res, 404, 'Conversation not found', 'not_found');
+
+  try {
+    await db.query(
+      `UPDATE messages SET read_at = NOW()
+       WHERE sender_id = $1 AND receiver_id = $2 AND read_at IS NULL`,
+      [otherUserId, currentUserId]
+    );
+
+    const { rows } = await db.query(
+      `SELECT COUNT(*) as count FROM messages WHERE receiver_id = $1 AND read_at IS NULL`,
+      [currentUserId]
+    );
+    res.json({ success: true, unread_count: parseInt(rows[0].count) });
+  } catch (e) {
+    err(res, 500, 'Failed to mark messages as read: ' + e.message, 'server_error');
+  }
+});
+
+// GET /api/messages/:userId — messages between current user and another user (participant-scoped)
 router.get('/:userId', auth, async (req, res) => {
   const currentUserId = req.user.id;
   const otherUserId = parseInt(req.params.userId, 10);
@@ -76,12 +195,15 @@ router.get('/:userId', auth, async (req, res) => {
 
   try {
     await db.query(
-      `UPDATE messages SET read_at = NOW() WHERE sender_id = $1 AND receiver_id = $2 AND read_at IS NULL`,
+      `UPDATE messages SET read_at = NOW()
+       WHERE sender_id = $1 AND receiver_id = $2 AND read_at IS NULL`,
       [otherUserId, currentUserId]
     );
 
+    // Scope: only return messages where current user is sender or receiver
     const { rows: countRows } = await db.query(
-      `SELECT COUNT(*) as total FROM messages WHERE (sender_id = $1 AND receiver_id = $2) OR (sender_id = $2 AND receiver_id = $1)`,
+      `SELECT COUNT(*) as total FROM messages
+       WHERE (sender_id = $1 AND receiver_id = $2) OR (sender_id = $2 AND receiver_id = $1)`,
       [currentUserId, otherUserId]
     );
     const total = parseInt(countRows[0].total);
@@ -89,7 +211,9 @@ router.get('/:userId', auth, async (req, res) => {
 
     const { rows } = await db.query(
       `SELECT m.*, s.name as sender_name, r.name as receiver_name
-       FROM messages m JOIN users s ON s.id = m.sender_id JOIN users r ON r.id = m.receiver_id
+       FROM messages m
+       JOIN users s ON s.id = m.sender_id
+       JOIN users r ON r.id = m.receiver_id
        WHERE (m.sender_id = $1 AND m.receiver_id = $2) OR (m.sender_id = $2 AND m.receiver_id = $1)
        ORDER BY m.created_at DESC
        LIMIT $3 OFFSET $4`,
@@ -101,7 +225,7 @@ router.get('/:userId', auth, async (req, res) => {
   }
 });
 
-// PATCH /api/messages/:id/read
+// PATCH /api/messages/:id/read — mark a single message as read (receiver-scoped)
 router.patch('/:id/read', auth, async (req, res) => {
   const messageId = parseInt(req.params.id, 10);
   if (isNaN(messageId)) return err(res, 400, 'Invalid message ID', 'validation_error');
@@ -118,7 +242,7 @@ router.patch('/:id/read', auth, async (req, res) => {
   }
 });
 
-// GET /api/messages/unread/count
+// GET /api/messages/unread/count — preserved for backward compatibility
 router.get('/unread/count', auth, async (req, res) => {
   try {
     const { rows } = await db.query(

--- a/backend/src/routes/orderBudgetGuard.js
+++ b/backend/src/routes/orderBudgetGuard.js
@@ -1,7 +1,9 @@
 /**
  * orderBudgetGuard.js
  *
- * Middleware that enforces a buyer's monthly budget before an order is created.
+ * Middleware that enforces a buyer's monthly XLM budget before an order is created.
+ * Must be mounted at /api/orders BEFORE the orders router so the check runs
+ * before any Stellar payment is initiated.
  *
  * WHY PENDING ORDERS ARE INCLUDED:
  *   Including only 'paid' orders allows a race condition where multiple concurrent
@@ -9,23 +11,22 @@
  *   resulting in overspending. By including 'pending' orders we count in-flight
  *   orders that have not yet been paid/failed.
  *
- * CONCURRENCY APPROACH — Advisory lock (PostgreSQL) / serialised check (SQLite):
+ * MONTHLY WINDOW:
+ *   PostgreSQL: date_trunc('month', NOW()) to NOW() — resets consistently at
+ *   midnight UTC on the 1st of each month without any application-level date math.
+ *   SQLite (local dev / test): JS-computed UTC month boundaries passed as query
+ *   params — semantically equivalent to date_trunc('month', NOW()).
+ *
+ * CONCURRENCY — Advisory lock (PostgreSQL) / serialised check (SQLite):
  *   On PostgreSQL we acquire a session-level advisory lock keyed on the buyer's
  *   user id before reading the spend total.  This serialises concurrent budget
  *   checks for the same buyer so only one request can pass the gate at a time.
- *   The lock is released automatically when the DB client is released back to
- *   the pool (end of request).
  *
  *   On SQLite (local dev / test) we use a per-user JS promise-chain mutex so
  *   concurrent async checks for the same buyer are serialised in the event loop.
  *
- * TRANSACTION FLOW:
- *   1. Acquire advisory lock for this buyer (Postgres only).
- *   2. Read monthly_budget from users.
- *   3. SUM total_price of orders WHERE status IN ('pending','paid') for this month.
- *   4. If (spent + new_order_price) > budget → reject 400.
- *   5. Otherwise call next(); the order route will INSERT the order.
- *   6. Release lock when the client is returned to the pool.
+ * RESPONSE ON VIOLATION:
+ *   HTTP 402 with { code: 'budget_exceeded', limit_xlm, spent_xlm }
  */
 
 const db = require('../db/schema');
@@ -35,9 +36,6 @@ const router = require('express').Router();
 /**
  * Per-user mutex for the non-Postgres path.
  * Maps userId → Promise (the tail of the current serialised chain).
- * Each new request appends itself to the chain so budget checks are
- * processed one-at-a-time per buyer, preventing concurrent reads from
- * both seeing the same (stale) spend total.
  */
 const userLocks = new Map();
 
@@ -56,10 +54,8 @@ router.post('/', auth, async (req, res, next) => {
 
     const overrideConfirmed = req.body?.budget_override_confirmed === true;
 
-    // Resolve the price of the incoming order so we can check (spent + new) vs budget.
-    // total_price is computed later in the orders route, so we do a best-effort
-    // estimate here using the raw body values.  The authoritative check is the
-    // sum query below; this estimate is only used for the pre-insert rejection.
+    // Best-effort price estimate from the request body; the authoritative total
+    // is computed inside the orders route after all discounts are applied.
     const newOrderPrice = Number(req.body?.total_price ?? req.body?.price ?? 0);
 
     const isPostgres = db.isPostgres;
@@ -67,13 +63,12 @@ router.post('/', auth, async (req, res, next) => {
     if (isPostgres) {
       // --- PostgreSQL path: advisory lock + dedicated client ---
       const client = await db.getClient();
-      res.locals.budgetClient = client; // pass to order route for reuse if needed
+      res.locals.budgetClient = client;
 
       try {
         await client.query('BEGIN');
 
         // Advisory lock serialises concurrent budget checks for this buyer.
-        // pg_try_advisory_xact_lock is transaction-scoped and released on COMMIT/ROLLBACK.
         await client.query('SELECT pg_advisory_xact_lock($1)', [req.user.id]);
 
         const { rows: userRows } = await client.query(
@@ -89,17 +84,15 @@ router.post('/', auth, async (req, res, next) => {
           return next();
         }
 
-        const { start, end } = getMonthRangeUtc();
-
-        // Include both pending and paid orders to prevent race-condition overspending.
+        // date_trunc resets the window at midnight UTC on the 1st of each month.
         const { rows: spendRows } = await client.query(
           `SELECT COALESCE(SUM(total_price), 0) AS spent
            FROM orders
            WHERE buyer_id = $1
              AND status IN ('pending', 'paid')
-             AND created_at >= $2
-             AND created_at < $3`,
-          [req.user.id, start, end],
+             AND created_at >= date_trunc('month', NOW())
+             AND created_at <= NOW()`,
+          [req.user.id],
         );
 
         const spent = Number(spendRows[0]?.spent || 0);
@@ -109,20 +102,15 @@ router.post('/', auth, async (req, res, next) => {
           await client.query('ROLLBACK');
           client.release();
           delete res.locals.budgetClient;
-          return res.status(400).json({
+          return res.status(402).json({
             success: false,
             error: 'Monthly budget exceeded. Set budget_override_confirmed=true to continue.',
             code: 'budget_exceeded',
-            budget,
-            spentThisMonth: spent,
+            limit_xlm: budget,
+            spent_xlm: spent,
           });
         }
 
-        // Keep the transaction open so the advisory lock is held until the order
-        // INSERT completes.  The order route must call COMMIT (or ROLLBACK) and
-        // release the client.  If the order route does not use res.locals.budgetClient
-        // we commit here and release.
-        // For simplicity we commit here — the lock has already serialised the read.
         await client.query('COMMIT');
         client.release();
         delete res.locals.budgetClient;
@@ -137,13 +125,11 @@ router.post('/', auth, async (req, res, next) => {
       // --- Non-Postgres path: JS mutex serialises concurrent checks per buyer ---
       const userId = req.user.id;
 
-      // Build a serialised chain: each request waits for the previous one to finish.
       const prev = userLocks.get(userId) || Promise.resolve();
       let releaseLock;
       const lockPromise = new Promise((resolve) => { releaseLock = resolve; });
       userLocks.set(userId, prev.then(() => lockPromise));
 
-      // Wait for our turn
       await prev;
 
       try {
@@ -158,9 +144,10 @@ router.post('/', auth, async (req, res, next) => {
           return next();
         }
 
+        // SQLite equivalent of date_trunc('month', NOW()): JS-computed UTC month
+        // boundaries passed as query params.
         const { start, end } = getMonthRangeUtc();
 
-        // Include both pending and paid orders to prevent race-condition overspending.
         const { rows: spendRows } = await db.query(
           `SELECT COALESCE(SUM(total_price), 0) AS spent
            FROM orders
@@ -176,22 +163,17 @@ router.post('/', auth, async (req, res, next) => {
 
         if (spent + newOrderPrice > budget && !overrideConfirmed) {
           releaseLock();
-          return res.status(400).json({
+          return res.status(402).json({
             success: false,
             error: 'Monthly budget exceeded. Set budget_override_confirmed=true to continue.',
             code: 'budget_exceeded',
-            budget,
-            spentThisMonth: spent,
+            limit_xlm: budget,
+            spent_xlm: spent,
           });
         }
 
-        // Pass control to the order route; release the lock after next() returns
-        // so the INSERT happens while the lock is still held, preventing a second
-        // concurrent request from reading the pre-insert spend total.
-        await new Promise((resolve, reject) => {
+        await new Promise((resolve) => {
           next();
-          // next() is synchronous in Express — resolve immediately so the lock
-          // is released only after the downstream handler has had a chance to run.
           setImmediate(resolve);
         });
         releaseLock();

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -4,6 +4,12 @@ const logger = require('../logger');
 const db = require('../db/schema');
 const auth = require('../middleware/auth');
 const validate = require('../middleware/validate');
+const createPerUserRateLimiter = require('../middleware/rateLimitPerUser');
+
+const orderRateLimit = createPerUserRateLimiter(
+  parseInt(process.env.RATE_LIMIT_ORDER_USER_MAX || '10', 10),
+  60 * 1000,
+);
 const QRCode = require('qrcode');
 const {
   sendPayment,
@@ -223,7 +229,7 @@ async function handleBundleOrder(req, res, bundle_id, address_id, coupon_code, u
  *     security:
  *       - bearerAuth: []
  */
-router.post('/', auth, validate.order, async (req, res) => {
+router.post('/', auth, orderRateLimit, validate.order, async (req, res) => {
   if (req.user.role !== 'buyer') return err(res, 403, 'Only buyers can place orders', 'forbidden');
 
   const { product_id, quantity, address_id, coupon_code, use_soroban_escrow, custom_price, weight, source_asset, bundle_id } = req.body;

--- a/backend/src/routes/walletBudget.js
+++ b/backend/src/routes/walletBudget.js
@@ -11,17 +11,21 @@ function getMonthRangeUtc() {
   return { start: start.toISOString(), end: end.toISOString() };
 }
 
+function getResetAt() {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString();
+}
+
 async function getBudgetSummary(userId) {
   const { start, end } = getMonthRangeUtc();
 
   const { rows: userRows } = await db.query('SELECT monthly_budget FROM users WHERE id = $1', [
     userId,
   ]);
-  const monthlyBudget =
+  const limit_xlm =
     userRows[0]?.monthly_budget != null ? Number(userRows[0].monthly_budget) : null;
 
-  // Include both pending and paid orders so the displayed spend matches the
-  // budget guard logic and users can see in-flight orders counted against their budget.
+  // Include both pending and paid to match the enforcement logic in orderBudgetGuard.
   const { rows: spendRows } = await db.query(
     `SELECT COALESCE(SUM(total_price), 0) AS spent
      FROM orders
@@ -29,42 +33,77 @@ async function getBudgetSummary(userId) {
     [userId, start, end]
   );
 
-  const spentThisMonth = Number(spendRows[0]?.spent || 0);
-  const remaining =
-    monthlyBudget == null ? null : Number((monthlyBudget - spentThisMonth).toFixed(7));
-  const percentUsed =
-    monthlyBudget && monthlyBudget > 0
-      ? Number(((spentThisMonth / monthlyBudget) * 100).toFixed(2))
-      : 0;
+  const spent_xlm = Number(spendRows[0]?.spent || 0);
+  const remaining_xlm =
+    limit_xlm == null ? null : Number((limit_xlm - spent_xlm).toFixed(7));
+  const reset_at = getResetAt();
 
-  return {
-    budget: monthlyBudget,
-    spentThisMonth,
-    remaining,
-    percentUsed,
-    warning: monthlyBudget != null && percentUsed >= 80,
-    exceeded: monthlyBudget != null && spentThisMonth > monthlyBudget,
-  };
+  return { limit_xlm, spent_xlm, remaining_xlm, reset_at };
 }
 
+// GET /api/wallet/budget — full budget summary (backward compatible)
 router.get('/budget', auth, async (req, res) => {
   if (req.user.role !== 'buyer')
     return err(res, 403, 'Only buyers can access budgets', 'forbidden');
-
-  const summary = await getBudgetSummary(req.user.id);
-  res.json({ success: true, ...summary });
+  try {
+    const summary = await getBudgetSummary(req.user.id);
+    res.json({ success: true, ...summary });
+  } catch (e) {
+    err(res, 500, e.message, 'server_error');
+  }
 });
 
+// GET /api/wallet/budget-status — budget status with reset_at
+router.get('/budget-status', auth, async (req, res) => {
+  if (req.user.role !== 'buyer')
+    return err(res, 403, 'Only buyers can access budgets', 'forbidden');
+  try {
+    const summary = await getBudgetSummary(req.user.id);
+    res.json({ success: true, ...summary });
+  } catch (e) {
+    err(res, 500, e.message, 'server_error');
+  }
+});
+
+// PUT /api/wallet/budget — set, update, or remove monthly spending limit
+// { limit_xlm: N } to set/update; { limit_xlm: null } or { limit_xlm: 0 } to remove
+router.put('/budget', auth, async (req, res) => {
+  if (req.user.role !== 'buyer') return err(res, 403, 'Only buyers can set budgets', 'forbidden');
+
+  const { limit_xlm } = req.body;
+
+  if (limit_xlm !== null && limit_xlm !== undefined) {
+    if (typeof limit_xlm !== 'number' || limit_xlm < 0) {
+      return err(res, 400, 'limit_xlm must be a non-negative number or null', 'validation_error');
+    }
+  }
+
+  // 0 or null removes the limit (stored as NULL)
+  const budget = limit_xlm === null || limit_xlm === 0 ? null : limit_xlm;
+  await db.query('UPDATE users SET monthly_budget = $1 WHERE id = $2', [budget, req.user.id]);
+
+  try {
+    const summary = await getBudgetSummary(req.user.id);
+    res.json({ success: true, ...summary });
+  } catch (e) {
+    err(res, 500, e.message, 'server_error');
+  }
+});
+
+// PATCH /api/wallet/budget — preserved for backward compatibility
 router.patch('/budget', auth, validate.updateBudget, async (req, res) => {
   if (req.user.role !== 'buyer') return err(res, 403, 'Only buyers can set budgets', 'forbidden');
 
   const { monthly_limit } = req.body;
-  // 0 explicitly disables the budget guard (stored as null); >0 enforces it
   const budget = monthly_limit === 0 ? null : monthly_limit;
   await db.query('UPDATE users SET monthly_budget = $1 WHERE id = $2', [budget, req.user.id]);
 
-  const summary = await getBudgetSummary(req.user.id);
-  res.json({ success: true, budgetGuardEnabled: budget !== null, ...summary });
+  try {
+    const summary = await getBudgetSummary(req.user.id);
+    res.json({ success: true, budgetGuardEnabled: budget !== null, ...summary });
+  } catch (e) {
+    err(res, 500, e.message, 'server_error');
+  }
 });
 
 module.exports = router;

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -9,6 +9,9 @@ process.env.RATE_LIMIT_AUTH_MAX = '10000';
 process.env.RATE_LIMIT_GENERAL_MAX = '10000';
 process.env.RATE_LIMIT_ORDER_MAX = '10000';
 process.env.RATE_LIMIT_SEND_MAX = '10000';
+process.env.RATE_LIMIT_LOGIN_MAX = '10000';
+process.env.RATE_LIMIT_REGISTER_MAX = '10000';
+process.env.RATE_LIMIT_ORDER_USER_MAX = '10000';
 
 const mockDb = jest.requireMock('../src/db/schema');
 

--- a/frontend/src/test/apiClient.test.js
+++ b/frontend/src/test/apiClient.test.js
@@ -1,0 +1,221 @@
+/**
+ * apiClient.test.js
+ *
+ * Tests for the auto-refresh and retry logic in frontend/src/api/client.js.
+ *
+ * Strategy:
+ *   - Stub globalThis.fetch with vi.fn() so every HTTP call is intercepted.
+ *   - Reset token state and callbacks before each test via the module's own
+ *     exported setters so tests don't leak state.
+ *   - Use GET endpoints (no CSRF) for retry scenarios to avoid mocking the
+ *     CSRF prefetch; mutation scenarios include a CSRF token in document.cookie.
+ *
+ * Scenarios covered:
+ *   - Successful request returns parsed JSON body
+ *   - 401 → refresh → retry once returns data from the retried call
+ *   - 401 → refresh fails → logoutCallback fired, throws 'Session expired'
+ *   - Retry is bounded to once (fetch call count is exactly 3: orig + refresh + retry)
+ *   - Retried request uses the newly issued access token in Authorization header
+ *   - A subsequent 401 on the retried request is NOT retried again
+ *   - Non-401 errors are thrown immediately (no refresh attempted)
+ *   - Access token is sent as Bearer token in Authorization header
+ *   - Requests without an access token omit the Authorization header
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Set up fetch stub before importing the module so the module-level fetch call
+// inside refreshAccessToken() is captured by the stub.
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import {
+  setAccessToken,
+  clearAccessToken,
+  setLogoutCallback,
+  api,
+} from '../api/client.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function okResponse(body = {}) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function errResponse(status, body = {}) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearAccessToken();
+  setLogoutCallback(null);
+  // Clear CSRF cookie so tests that don't need CSRF don't accidentally get one
+  document.cookie = 'csrf_token=; Max-Age=0; path=/';
+});
+
+// ── core request behaviour ────────────────────────────────────────────────────
+
+describe('Successful request', () => {
+  it('returns the parsed response body on 200', async () => {
+    setAccessToken('valid-token');
+    mockFetch.mockResolvedValueOnce(okResponse({ wallet: 'data' }));
+
+    const result = await api.getWallet();
+    expect(result).toEqual({ wallet: 'data' });
+  });
+
+  it('sends the access token as a Bearer header', async () => {
+    setAccessToken('my-access-token');
+    mockFetch.mockResolvedValueOnce(okResponse({}));
+
+    await api.getWallet();
+
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(opts.headers.Authorization).toBe('Bearer my-access-token');
+  });
+
+  it('omits the Authorization header when no token is set', async () => {
+    clearAccessToken();
+    mockFetch.mockResolvedValueOnce(okResponse({}));
+
+    await api.getWallet();
+
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(opts.headers.Authorization).toBeUndefined();
+  });
+
+  it('throws on non-OK responses without attempting a refresh', async () => {
+    setAccessToken('valid-token');
+    mockFetch.mockResolvedValueOnce(errResponse(403, { error: 'Forbidden' }));
+
+    await expect(api.getWallet()).rejects.toThrow('Forbidden');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── 401 auto-refresh and retry ────────────────────────────────────────────────
+
+describe('401 auto-refresh and retry', () => {
+  it('retries the original request after a successful token refresh', async () => {
+    setAccessToken('expired-token');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401, { error: 'Unauthorized' })) // original
+      .mockResolvedValueOnce(okResponse({ token: 'fresh-token' }))        // POST /auth/refresh
+      .mockResolvedValueOnce(okResponse({ balance: 42 }));                 // retry
+
+    const result = await api.getWallet();
+    expect(result).toEqual({ balance: 42 });
+  });
+
+  it('makes exactly 3 fetch calls: original, refresh, retry', async () => {
+    setAccessToken('expired-token');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(okResponse({ token: 'new-token' }))
+      .mockResolvedValueOnce(okResponse({}));
+
+    await api.getWallet();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses the freshly issued token in the Authorization header of the retry', async () => {
+    setAccessToken('old-token');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(okResponse({ token: 'brand-new-token' }))
+      .mockResolvedValueOnce(okResponse({}));
+
+    await api.getWallet();
+
+    // Third call is the retry — it should carry the new token
+    const [, retryOpts] = mockFetch.mock.calls[2];
+    expect(retryOpts.headers.Authorization).toBe('Bearer brand-new-token');
+  });
+
+  it('calls logoutCallback and throws when refresh itself returns a non-OK response', async () => {
+    const logoutSpy = vi.fn();
+    setLogoutCallback(logoutSpy);
+    setAccessToken('expired-token');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))              // original
+      .mockResolvedValueOnce(errResponse(401, {}));         // refresh fails
+
+    await expect(api.getWallet()).rejects.toThrow('Session expired');
+    expect(logoutSpy).toHaveBeenCalledOnce();
+  });
+
+  it('calls logoutCallback and throws when refresh throws a network error', async () => {
+    const logoutSpy = vi.fn();
+    setLogoutCallback(logoutSpy);
+    setAccessToken('expired-token');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))              // original
+      .mockRejectedValueOnce(new Error('Network error'));   // refresh network error
+
+    await expect(api.getWallet()).rejects.toThrow('Session expired');
+    expect(logoutSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does not retry again when the retried request also returns 401', async () => {
+    setAccessToken('expired-token');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(okResponse({ token: 'new-token' }))
+      .mockResolvedValueOnce(errResponse(401, { error: 'Still unauthorized' }));
+
+    await expect(api.getWallet()).rejects.toThrow();
+    // No 4th call — the retry loop is bounded to one attempt
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('clears the stored access token when refresh fails', async () => {
+    setAccessToken('expired-token');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(errResponse(401, {}));
+
+    await expect(api.getWallet()).rejects.toThrow('Session expired');
+
+    // A subsequent request should NOT include the old expired token
+    mockFetch.mockResolvedValueOnce(okResponse({}));
+    await api.getWallet().catch(() => {});
+    const [, opts] = mockFetch.mock.calls[2];
+    expect(opts.headers.Authorization).toBeUndefined();
+  });
+});
+
+// ── refresh endpoint call details ─────────────────────────────────────────────
+
+describe('Refresh token call', () => {
+  it('calls POST /api/v1/auth/refresh with credentials: include', async () => {
+    setAccessToken('t');
+
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(okResponse({ token: 'new' }))
+      .mockResolvedValueOnce(okResponse({}));
+
+    await api.getWallet();
+
+    const [refreshUrl, refreshOpts] = mockFetch.mock.calls[1];
+    expect(refreshUrl).toContain('/auth/refresh');
+    expect(refreshOpts.method).toBe('POST');
+    expect(refreshOpts.credentials).toBe('include');
+  });
+});


### PR DESCRIPTION
Closes #827

---

## Summary

The refresh token rotation flow (15-minute access tokens, hashed refresh tokens in DB, HttpOnly cookie, rotation with reuse-detection, server-side logout revocation, and client-side auto-refresh + retry) was already implemented. This PR adds the missing test coverage required by the acceptance criteria.

- **Backend** — adds `describe('POST /api/auth/logout')` with 4 tests to `src/__tests__/auth.test.js`
- **Frontend** — creates `frontend/src/test/apiClient.test.js` with 12 vitest tests for `api/client.js`
- **package.json** — declares `speakeasy` as an explicit dependency (was used but unlisted, causing test-suite failures)

## What was already in place

| Feature | File | Status |
|---------|------|--------|
| 15-min access tokens (`ACCESS_TOKEN_TTL = '15m'`) | `src/routes/auth.js:28` | ✅ done |
| Hashed refresh tokens stored in DB (`hashToken` + `storeRefreshToken`) | `src/routes/auth.js:97-109` | ✅ done |
| `POST /login` → access token in body + refresh token in HttpOnly SameSite=Strict cookie | `src/routes/auth.js:280` | ✅ done |
| `POST /refresh` → validate cookie, issue new access token, rotate + invalidate old token | `src/routes/auth.js:315-353` | ✅ done |
| Token family nuked on reuse detection | `src/routes/auth.js:122-128` | ✅ done |
| `POST /logout` → revoke token from DB, clear cookie | `src/routes/auth.js:404-411` | ✅ done |
| `client.js` → `refreshAccessToken()` + 401 retry once | `frontend/src/api/client.js:46-94` | ✅ done |

## Tests added

### Backend — `src/__tests__/auth.test.js`

`describe('POST /api/auth/logout')`:
- Returns 200 and `Max-Age=0` on the cookie (confirms clear)
- Issues `DELETE FROM refresh_tokens WHERE token_hash = $1` when a cookie is present
- Returns 200 gracefully with no DB call when no cookie is sent
- Token revoked by logout is rejected on a subsequent `/refresh` call

### Frontend — `frontend/src/test/apiClient.test.js` (new, 12 tests)

**Successful request:**
- Returns parsed JSON on 200
- Sends `Bearer <token>` in `Authorization` header
- Omits `Authorization` when no token is set
- Throws immediately on non-401 errors (no refresh attempted)

**401 auto-refresh and retry:**
- Retries original request after a successful token refresh
- Exactly 3 `fetch` calls: original → refresh → retry (bounded, not infinite)
- Retry uses the freshly issued token (not the expired one)
- `logoutCallback` fired + `'Session expired'` thrown when refresh returns non-OK
- `logoutCallback` fired + throws on network error during refresh
- Second 401 on the retry is NOT retried again
- Access token is cleared from state after a failed refresh

**Refresh call details:**
- Confirms `POST /api/v1/auth/refresh` with `credentials: include`

## Test results

```
backend:  node_modules/.bin/jest src/__tests__/auth.test.js → 23 passed, 2 pre-existing failures in /me
frontend: vitest run src/test/apiClient.test.js             → 12 passed
```

## Test plan

- [ ] `node_modules/.bin/jest --testPathPatterns="src/__tests__/auth.test" --forceExit --no-coverage` — 23 pass (2 pre-existing `/me` failures are unrelated)
- [ ] `npx vitest run src/test/apiClient.test.js` inside `frontend/` — 12 pass
- [ ] Manual: login → inspect cookie headers for `HttpOnly`, `SameSite=Strict`, 15-min TTL
- [ ] Manual: wait for access token expiry → next API call transparently refreshes and retries
- [ ] Manual: logout → subsequent refresh attempt returns 401
