### PR TITLE
fix(#819): bundle order row locks, 409 out-of-stock list, discount 1-50%, receipt email

### DIFF
--- a/backend/src/routes/bundleDiscounts.js
+++ b/backend/src/routes/bundleDiscounts.js
@@ -20,8 +20,8 @@ router.post('/me/bundle-discounts', auth, async (req, res) => {
   if (!Number.isInteger(min_products) || min_products < 2) {
     return err(res, 400, 'min_products must be an integer >= 2', 'validation_error');
   }
-  if (typeof discount_percent !== 'number' || discount_percent <= 0 || discount_percent > 100) {
-    return err(res, 400, 'discount_percent must be between 0 and 100', 'validation_error');
+  if (typeof discount_percent !== 'number' || discount_percent < 1 || discount_percent > 50) {
+    return err(res, 400, 'discount_percent must be between 1 and 50', 'validation_error');
   }
   try {
     const { rows } = await db.query(
@@ -45,8 +45,8 @@ router.put('/me/bundle-discounts/:id', auth, async (req, res) => {
   if (!Number.isInteger(min_products) || min_products < 2) {
     return err(res, 400, 'min_products must be an integer >= 2', 'validation_error');
   }
-  if (typeof discount_percent !== 'number' || discount_percent <= 0 || discount_percent > 100) {
-    return err(res, 400, 'discount_percent must be between 0 and 100', 'validation_error');
+  if (typeof discount_percent !== 'number' || discount_percent < 1 || discount_percent > 50) {
+    return err(res, 400, 'discount_percent must be between 1 and 50', 'validation_error');
   }
   const { rowCount, rows } = await db.query(
     `UPDATE bundle_discounts SET min_products = $1, discount_percent = $2

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -154,12 +154,29 @@ async function handleBundleOrder(req, res, bundle_id, address_id, coupon_code, u
   let orderIds = [];
   try {
     await db.query('BEGIN');
+    // Lock rows to prevent race conditions
+    const productIds = bundleItems.map((i) => i.product_id);
+    const placeholders = productIds.map((_, i) => `$${i + 1}`).join(',');
+    const { rows: lockedProducts } = await db.query(
+      `SELECT id, name, quantity FROM products WHERE id IN (${placeholders}) FOR UPDATE`,
+      productIds
+    );
+    const stockMap = {};
+    for (const p of lockedProducts) stockMap[p.id] = p;
+
+    const outOfStock = [];
     for (const item of bundleItems) {
-      const { rowCount } = await db.query(
-        'UPDATE products SET quantity = quantity - $1 WHERE id = $2 AND quantity >= $3',
-        [item.quantity, item.product_id, item.quantity]
-      );
-      if (rowCount === 0) throw new Error(`Insufficient stock for "${item.product_name}"`);
+      const stock = stockMap[item.product_id];
+      if (!stock || stock.quantity < item.quantity)
+        outOfStock.push({ product_id: item.product_id, product_name: item.product_name, available: stock?.quantity ?? 0, required: item.quantity });
+    }
+    if (outOfStock.length > 0) {
+      await db.query('ROLLBACK');
+      return res.status(409).json({ success: false, code: 'insufficient_stock', outOfStock });
+    }
+
+    for (const item of bundleItems) {
+      await db.query('UPDATE products SET quantity = quantity - $1 WHERE id = $2', [item.quantity, item.product_id]);
     }
     for (const item of bundleItems) {
       const itemPrice = (item.product_price * item.quantity) / individualTotal * bundle.price;
@@ -205,6 +222,12 @@ async function handleBundleOrder(req, res, bundle_id, address_id, coupon_code, u
       coupon: appliedCoupon ? { code: appliedCoupon.code, discount_type: appliedCoupon.discount_type } : undefined,
     };
     if (idempotencyKey) await cacheResponse(idempotencyKey, { ...responseData, _status: 200 });
+
+    // Send bundle receipt email (non-fatal)
+    const { sendBundleReceiptEmail } = require('../utils/mailer');
+    sendBundleReceiptEmail({ buyer, bundle, items: bundleItems, totalPrice, discount, txHash })
+      .catch(() => {});
+
     return res.json(responseData);
   } catch (e) {
     await db.query('BEGIN');


### PR DESCRIPTION
Atomic bundle ordering and discount guardrails.
  
  - handleBundleOrder (orders.js): replaced optimistic UPDATE … WHERE quantity >= ? with SELECT … FOR UPDATE inside the
  transaction — locks all bundle product rows before any deduction, preventing race conditions
  - If any item is short, transaction is rolled back and 409 is returned with { outOfStock: [{ product_id, product_name,
  available, required }] }
  - bundleDiscounts.js: discount validation tightened to 1–50% inclusive in both POST and PUT (was 0–100%)
  - sendBundleReceiptEmail called after successful payment, listing all items and applied discount
  closes #819 