### PR TITLE
fix(db): normalize success boolean for contract invocations

### DIFF
--- a/backend/migrations/013_contract_invocations.sql
+++ b/backend/migrations/013_contract_invocations.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS contract_invocations (
   args        TEXT,
   result      TEXT,
   tx_hash     TEXT,
-  success     INTEGER NOT NULL DEFAULT 1,
+  success     BOOLEAN NOT NULL DEFAULT TRUE,
   error       TEXT,
   invoked_by  INTEGER REFERENCES users(id),
   invoked_at  DATETIME DEFAULT CURRENT_TIMESTAMP

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -31,7 +31,7 @@ function normalizeBooleans(row) {
   if (!row || typeof row !== 'object') return row;
 
   const normalized = { ...row };
-  const booleanColumns = ['active', 'fee_bumped', 'is_preorder', 'low_stock_alerted', 'acknowledged'];
+  const booleanColumns = ['active', 'fee_bumped', 'is_preorder', 'low_stock_alerted', 'acknowledged', 'success'];
 
   for (const col of booleanColumns) {
     if (col in normalized) {


### PR DESCRIPTION
## Summary
Adds `success` to the boolean-normalization column list in `db/schema.js` so SQLite's 0/1 integers are returned as proper JS booleans for `contract_invocations` records, and switches the migration's `success` column to native `BOOLEAN` (PostgreSQL returns true/false). No reads of `invocation.success` exist in `contractMonitor.js` (only writes), so strict-equality criterion is already met.

## Validation
- `git diff` reviewed — change is limited to the normalization list and the migration column type.
- Note: `backend/src/db/schema.js` has a pre-existing syntax error on `main` (duplicated adapter blocks / stray `} else {` from prior merges) that prevents the module from loading; this blocks running `db-boolean-normalization.test.js` and is outside the scope of this issue.

Closes #864