### PR TITLE
feat(waitlist): deposit automatic orders into Soroban escrow

### DIFF
--- a/backend/src/__tests__/AutomaticOrderProcessor.test.js
+++ b/backend/src/__tests__/AutomaticOrderProcessor.test.js
@@ -14,13 +14,23 @@ jest.mock('../utils/stellar', () => ({
   getBalance: jest.fn(),
 }));
 
-// Mock the mailer utilities
+// Mock the mailer utilities (full surface so the shared jest.setup.js can stub them)
 jest.mock('../utils/mailer', () => ({
   sendOrderEmails: jest.fn(),
+  sendLowStockAlert: jest.fn(),
+  sendStatusUpdateEmail: jest.fn(),
+  sendBackInStockEmail: jest.fn(),
+  sendReturnEmail: jest.fn(),
+}));
+
+// Mock the Soroban escrow contract utility
+jest.mock('../utils/stellar-contracts', () => ({
+  invokeEscrowContract: jest.fn(),
 }));
 
 const { sendPayment, getBalance } = require('../utils/stellar');
 const { sendOrderEmails } = require('../utils/mailer');
+const { invokeEscrowContract } = require('../utils/stellar-contracts');
 
 describe('AutomaticOrderProcessor', () => {
   let processor;
@@ -195,6 +205,63 @@ describe('AutomaticOrderProcessor', () => {
       const result3 = await processor.createAutomaticOrder(mockWaitlistEntry, mockProduct, null);
       expect(result3.success).toBe(false);
       expect(result3.code).toBe('INVALID_INPUT');
+    });
+
+    test('should deposit into escrow when product uses Soroban escrow', async () => {
+      const escrowProduct = { ...mockProduct, use_soroban_escrow: true };
+      invokeEscrowContract.mockResolvedValue({ txHash: 'escrow_tx_hash', contractId: 'CESCROW' });
+
+      db.query
+        .mockResolvedValueOnce({ rows: [mockFarmer] }) // Get farmer
+        .mockResolvedValueOnce() // BEGIN transaction
+        .mockResolvedValueOnce({ rowCount: 1 }) // Update stock
+        .mockResolvedValueOnce({
+          rows: [{ id: 1001, ...mockWaitlistEntry, total_price: 21.0, status: 'pending' }],
+        }) // Insert order
+        .mockResolvedValueOnce() // Update order with escrow details
+        .mockResolvedValueOnce(); // COMMIT transaction
+
+      const result = await processor.createAutomaticOrder(mockWaitlistEntry, escrowProduct, mockBuyer);
+
+      expect(result.success).toBe(true);
+      expect(result.orderId).toBe(1001);
+      expect(result.txHash).toBe('escrow_tx_hash');
+      expect(result.escrowOrderId).toBe(1001);
+
+      // Direct payment must NOT be used for escrow products
+      expect(sendPayment).not.toHaveBeenCalled();
+      expect(invokeEscrowContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'deposit',
+          orderId: 1001,
+          buyerPublicKey: mockBuyer.stellar_public_key,
+          farmerPublicKey: mockFarmer.stellar_public_key,
+          amount: 21.0,
+          timeoutUnix: expect.any(Number),
+        })
+      );
+    });
+
+    test('should mark order escrow_failed when escrow deposit fails', async () => {
+      const escrowProduct = { ...mockProduct, use_soroban_escrow: true };
+      invokeEscrowContract.mockRejectedValue(new Error('contract reverted'));
+
+      db.query
+        .mockResolvedValueOnce({ rows: [mockFarmer] }) // Get farmer
+        .mockResolvedValueOnce() // BEGIN transaction
+        .mockResolvedValueOnce({ rowCount: 1 }) // Update stock
+        .mockResolvedValueOnce({
+          rows: [{ id: 1001, ...mockWaitlistEntry, total_price: 21.0, status: 'pending' }],
+        }) // Insert order
+        .mockResolvedValueOnce() // Mark order escrow_failed
+        .mockResolvedValueOnce() // Restore stock
+        .mockResolvedValueOnce(); // COMMIT transaction
+
+      const result = await processor.createAutomaticOrder(mockWaitlistEntry, escrowProduct, mockBuyer);
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe('ESCROW_FAILED');
+      expect(sendPayment).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/services/AutomaticOrderProcessor.js
+++ b/backend/src/services/AutomaticOrderProcessor.js
@@ -9,7 +9,11 @@
 
 const db = require('../db/schema');
 const { sendPayment, getBalance } = require('../utils/stellar');
+const { invokeEscrowContract } = require('../utils/stellar-contracts');
 const { sendOrderEmails } = require('../utils/mailer');
+
+// Default escrow timeout for automatic (waitlist) orders: 7 days from deposit.
+const DEFAULT_ESCROW_TIMEOUT_DAYS = 7;
 
 class AutomaticOrderProcessor {
   /**
@@ -85,6 +89,7 @@ class AutomaticOrderProcessor {
         success: true,
         orderId: orderResult.order.id,
         txHash: orderResult.order.stellar_tx_hash,
+        escrowOrderId: orderResult.escrowOrderId || null,
         totalPrice,
         code: 'ORDER_CREATED',
       };
@@ -223,23 +228,35 @@ class AutomaticOrderProcessor {
         };
       }
 
-      // Process payment
-      const paymentResult = await this.processPayment(order, buyer, farmer);
+      // Process payment — products opting into Soroban escrow use the escrow
+      // contract for buyer protection; all others use a direct Stellar payment.
+      const paymentResult = product.use_soroban_escrow
+        ? await this.processEscrowDeposit(order, buyer, farmer)
+        : await this.processPayment(order, buyer, farmer);
 
       if (!paymentResult.success) {
-        // Persist order as payment_failed and restore stock
-        await db.query('UPDATE orders SET status = $1 WHERE id = $2', ['payment_failed', order.id]);
+        // Persist order failure and restore stock. Escrow failures use a
+        // dedicated status so the waitlist entry can be marked 'escrow_failed'.
+        const failedStatus = paymentResult.code === 'ESCROW_FAILED' ? 'escrow_failed' : 'payment_failed';
+        await db.query('UPDATE orders SET status = $1 WHERE id = $2', [failedStatus, order.id]);
         await db.query('UPDATE products SET quantity = quantity + $1 WHERE id = $2', [waitlistEntry.quantity, product.id]);
         await db.query('COMMIT');
         return { ...paymentResult, orderId: order.id };
       }
 
       // Update order with payment details
-      await db.query('UPDATE orders SET status = $1, stellar_tx_hash = $2 WHERE id = $3', [
-        'paid',
-        paymentResult.txHash,
-        order.id,
-      ]);
+      if (product.use_soroban_escrow) {
+        await db.query(
+          'UPDATE orders SET status = $1, stellar_tx_hash = $2, escrow_balance_id = $3, escrow_status = $4 WHERE id = $5',
+          ['paid', paymentResult.txHash, paymentResult.escrowOrderId, 'funded', order.id]
+        );
+      } else {
+        await db.query('UPDATE orders SET status = $1, stellar_tx_hash = $2 WHERE id = $3', [
+          'paid',
+          paymentResult.txHash,
+          order.id,
+        ]);
+      }
 
       // Commit transaction
       await db.query('COMMIT');
@@ -250,8 +267,10 @@ class AutomaticOrderProcessor {
           ...order,
           status: 'paid',
           stellar_tx_hash: paymentResult.txHash,
+          escrow_order_id: paymentResult.escrowOrderId || null,
         },
         txHash: paymentResult.txHash,
+        escrowOrderId: paymentResult.escrowOrderId || null,
       };
     } catch (error) {
       await db.query('ROLLBACK');
@@ -263,6 +282,49 @@ class AutomaticOrderProcessor {
   async _getBalance(publicKey) {
     const { getBalance } = require('../utils/stellar');
     return getBalance(publicKey);
+  }
+
+  /**
+   * Deposit an automatic order's funds into the Soroban escrow contract.
+   * Used when the product has `use_soroban_escrow = true` so auto-placed
+   * waitlist orders get the same buyer protection as manual escrow orders.
+   * @param {Object} order - The order details
+   * @param {Object} buyer - The buyer details
+   * @param {Object} farmer - The farmer details
+   * @returns {Promise<{success: boolean, txHash?: string, escrowOrderId?: number, error?: string, code?: string}>}
+   */
+  async processEscrowDeposit(order, buyer, farmer) {
+    try {
+      const timeoutDays = parseInt(
+        process.env.SOROBAN_ESCROW_TIMEOUT_DAYS || String(DEFAULT_ESCROW_TIMEOUT_DAYS),
+        10
+      );
+      const timeoutUnix = Math.floor(Date.now() / 1000) + timeoutDays * 24 * 60 * 60;
+
+      const result = await invokeEscrowContract({
+        action: 'deposit',
+        senderSecret: buyer.stellar_secret_key,
+        orderId: order.id,
+        buyerPublicKey: buyer.stellar_public_key,
+        farmerPublicKey: farmer.stellar_public_key,
+        amount: order.total_price,
+        timeoutUnix,
+      });
+
+      return {
+        success: true,
+        txHash: result.txHash,
+        escrowOrderId: order.id,
+        code: 'ESCROW_FUNDED',
+      };
+    } catch (error) {
+      console.error('[AutomaticOrderProcessor] Escrow deposit failed:', error.message);
+      return {
+        success: false,
+        error: 'Escrow deposit failed: ' + error.message,
+        code: 'ESCROW_FAILED',
+      };
+    }
   }
 
   /**
@@ -609,9 +671,10 @@ Farmers Marketplace`;
             code: orderResult.code,
           });
 
+          const failedStatus = orderResult.code === 'ESCROW_FAILED' ? 'escrow_failed' : 'payment_failed';
           await db.query(
             'UPDATE waitlist_entries SET status = $1 WHERE id = $2',
-            ['payment_failed', entry.id]
+            [failedStatus, entry.id]
           );
 
           sendOrderEmails({


### PR DESCRIPTION
## Summary
Automatic (waitlist) orders now route through the Soroban escrow contract when the product has `use_soroban_escrow = true`, giving auto-placed buyers the same protection as manual escrow orders.

- `AutomaticOrderProcessor` checks `product.use_soroban_escrow` before payment and, when set, calls `invokeEscrowContract({ action: 'deposit', ... })` with a default 7-day `timeoutUnix` (overridable via `SOROBAN_ESCROW_TIMEOUT_DAYS`).
- The order record stores the escrow tracking id (`escrow_balance_id`/`escrow_status='funded'`) and the result surfaces `escrowOrderId`.
- On escrow-deposit failure the order is marked `escrow_failed`, the waitlist entry is marked `escrow_failed`, stock is restored, and the next entry is processed.
- Non-escrow path is unchanged (direct `sendPayment`).
- Added tests for both the escrow-success and escrow-failure automatic-order paths.

## Validation
- `eslint` on changed files: no new errors/warnings (pre-existing `no-console` warnings and one pre-existing unused-var remain untouched).
- Note: the Jest suite cannot execute in this environment because `backend/src/db/schema.js` has a pre-existing syntax error (`} else {` with no matching `if`, from prior merges) that throws on `require`, blocking module load. This is unrelated to this change.

Closes #865