### PR TITLE
feat(stellar): validate Stellar/Soroban config at startup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,14 +49,22 @@ STELLAR_NETWORK=testnet
 # STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
 # Soroban escrow contract integration
+# Required for escrow features. validateStellarConfig() (run at startup in
+# src/index.js) throws if any of SOROBAN_RPC_URL, SOROBAN_ESCROW_CONTRACT_ID,
+# or SOROBAN_XLM_TOKEN_CONTRACT_ID is missing. Use testnet values with
+# STELLAR_NETWORK=testnet and mainnet values with STELLAR_NETWORK=mainnet.
 # Optional: funded account public key used only to build/simulate contract calls (POST /api/contracts/:id/simulate). Falls back to PLATFORM_WALLET_PUBLIC_KEY.
 # SOROBAN_SIMULATION_SOURCE_PUBLIC_KEY=G...
-# SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
-# SOROBAN_ESCROW_CONTRACT_ID=CB...
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+SOROBAN_ESCROW_CONTRACT_ID=CB...
 # Native XLM token contract address on the selected network
-# SOROBAN_XLM_TOKEN_CONTRACT_ID=CC...
+SOROBAN_XLM_TOKEN_CONTRACT_ID=CC...
 # Buyer refund timeout used when creating Soroban escrow deposits
 SOROBAN_ESCROW_TIMEOUT_DAYS=14
+
+# Reward token contract (optional — startup logs a warning if unset, does not throw)
+# REWARD_TOKEN_CONTRACT_ID=CD...
+# REWARD_TOKEN_ADMIN_SECRET=S...
 
 # Web Push (VAPID)
 # Generate keys with: npx web-push generate-vapid-keys

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,4 +1,6 @@
 require('./config'); // validate env vars before anything else
+const { validateStellarConfig } = require('./utils/stellar-config');
+validateStellarConfig(); // fail fast on missing Stellar/Soroban config
 const app = require('./app');
 const logger = require('./logger');
 const cron = require('node-cron');

--- a/backend/src/utils/stellar-config.js
+++ b/backend/src/utils/stellar-config.js
@@ -27,4 +27,63 @@ const horizonUrl =
 const server = new StellarSdk.Horizon.Server(horizonUrl);
 const networkPassphrase = isTestnet ? StellarSdk.Networks.TESTNET : StellarSdk.Networks.PUBLIC;
 
-module.exports = { StellarSdk, isTestnet, server, sorobanServer, networkPassphrase };
+// Required Soroban/escrow environment variables. Missing values cause cryptic
+// runtime failures at the contract call site, so we validate them at startup.
+// Variable names match backend/src/config.js (the typed config layer).
+const REQUIRED_STELLAR_VARS = [
+  'SOROBAN_RPC_URL',
+  'SOROBAN_ESCROW_CONTRACT_ID',
+  'SOROBAN_XLM_TOKEN_CONTRACT_ID',
+];
+
+// Optional variables: a warning is logged but startup is not blocked.
+const OPTIONAL_STELLAR_VARS = ['REWARD_TOKEN_CONTRACT_ID', 'REWARD_TOKEN_ADMIN_SECRET'];
+
+/**
+ * Validate that all required Stellar/Soroban environment variables are present.
+ *
+ * Throws a single descriptive error listing every missing required variable so
+ * misconfiguration is caught at startup instead of at the contract call site.
+ * Optional variables only log a warning. The detected network (testnet/mainnet)
+ * is reported so passphrase/network mismatches are obvious early.
+ *
+ * Note: SOROBAN_RPC_URL has a network-derived default, so it is only reported as
+ * missing when no value (explicit or default) is available.
+ *
+ * @returns {{ network: string, networkPassphrase: string }}
+ */
+function validateStellarConfig() {
+  const network = isTestnet ? 'testnet' : 'mainnet';
+  console.log(`[stellar-config] Validating Stellar config for ${network} (${networkPassphrase})`);
+
+  const resolved = {
+    SOROBAN_RPC_URL: sorobanRpcUrl, // always set (falls back to a network default)
+    SOROBAN_ESCROW_CONTRACT_ID: process.env.SOROBAN_ESCROW_CONTRACT_ID,
+    SOROBAN_XLM_TOKEN_CONTRACT_ID: process.env.SOROBAN_XLM_TOKEN_CONTRACT_ID,
+  };
+
+  const missing = REQUIRED_STELLAR_VARS.filter((name) => !resolved[name]);
+  if (missing.length > 0) {
+    throw new Error(
+      `[stellar-config] Missing required Stellar/Soroban environment variable(s): ${missing.join(', ')}. ` +
+        `Detected network: ${network}. Copy backend/.env.example to backend/.env and set these values.`
+    );
+  }
+
+  for (const name of OPTIONAL_STELLAR_VARS) {
+    if (!process.env[name]) {
+      console.warn(`[stellar-config] Optional variable ${name} is not set; related features are disabled.`);
+    }
+  }
+
+  return { network, networkPassphrase };
+}
+
+module.exports = {
+  StellarSdk,
+  isTestnet,
+  server,
+  sorobanServer,
+  networkPassphrase,
+  validateStellarConfig,
+};


### PR DESCRIPTION
## Summary
Adds fail-fast validation of Stellar/Soroban environment configuration so misconfiguration surfaces at startup with a clear message instead of cryptic errors at the contract call site.

- `stellar-config.js` now exports `validateStellarConfig()`, which throws a single descriptive error listing every missing required variable and reports the detected network (testnet/mainnet) with its passphrase.
- Required: `SOROBAN_RPC_URL`, `SOROBAN_ESCROW_CONTRACT_ID`, `SOROBAN_XLM_TOKEN_CONTRACT_ID`. Optional (`REWARD_TOKEN_CONTRACT_ID`, `REWARD_TOKEN_ADMIN_SECRET`) log a warning but do not throw.
- Called during app startup in `src/index.js` (right after the existing `config` env validation).
- `backend/.env.example` documents the required vs optional Stellar variables and the startup validation behaviour.

Note: variable names follow the codebase's typed config (`backend/src/config.js`) — e.g. `SOROBAN_ESCROW_CONTRACT_ID` — rather than the issue's shorthand, and the network passphrase is derived from `STELLAR_NETWORK` as the existing code does.

## Validation
- `node --check` on `stellar-config.js` and `index.js`: syntax OK.
- `eslint` on changed files: only `no-console` warnings, consistent with the existing `config.js` startup convention; no errors.

Closes #866