### PR TITLE
feat(escrow): add GET /api/escrow/:orderId/state endpoint

### DIFF
--- a/backend/src/routes/escrow.js
+++ b/backend/src/routes/escrow.js
@@ -1,0 +1,66 @@
+const router = require('express').Router();
+const auth = require('../middleware/auth');
+const db = require('../db/schema');
+const { getEscrowState } = require('../utils/stellar');
+const { err } = require('../middleware/error');
+
+// Escrow state changes infrequently, so responses are cached briefly (30s TTL)
+// to avoid hammering the Soroban RPC for repeated status checks.
+const CACHE_TTL_MS = 30 * 1000;
+const cache = new Map();
+
+// GET /api/escrow/:orderId/state  (authenticated)
+// Returns a human-readable escrow status for a single order. Buyers may query
+// their own orders, farmers orders for their products, and admins any order.
+router.get('/:orderId/state', auth, async (req, res) => {
+  const orderId = parseInt(req.params.orderId, 10);
+  if (!Number.isInteger(orderId) || orderId <= 0) {
+    return err(res, 400, 'Invalid orderId', 'invalid_order_id');
+  }
+
+  // Scope access to the caller's relationship with the order.
+  const { rows } = await db.query(
+    `SELECT o.id, o.buyer_id, p.farmer_id
+     FROM orders o JOIN products p ON p.id = o.product_id
+     WHERE o.id = $1`,
+    [orderId],
+  );
+  const order = rows[0];
+  if (!order) return err(res, 404, 'Order not found', 'order_not_found');
+
+  const isAdmin = req.user.role === 'admin';
+  const isBuyer = order.buyer_id === req.user.id;
+  const isFarmer = order.farmer_id === req.user.id;
+  if (!isAdmin && !isBuyer && !isFarmer) {
+    return err(res, 403, 'Access denied', 'forbidden');
+  }
+
+  const cached = cache.get(orderId);
+  if (cached && cached.expires > Date.now()) {
+    return res.json({ success: true, data: cached.data });
+  }
+
+  try {
+    const escrow = await getEscrowState(orderId);
+    if (!escrow) {
+      return err(res, 404, 'Escrow record not found on-chain', 'escrow_not_found');
+    }
+
+    const data = {
+      status: escrow.status,
+      buyer: escrow.buyer,
+      farmer: escrow.farmer,
+      amount_xlm: escrow.amount,
+      timeout_at: escrow.timeoutUnix ? new Date(escrow.timeoutUnix * 1000).toISOString() : null,
+      escrow_address: escrow.escrowAddress,
+      last_updated_ledger: escrow.lastUpdatedLedger,
+    };
+
+    cache.set(orderId, { data, expires: Date.now() + CACHE_TTL_MS });
+    res.json({ success: true, data });
+  } catch (error) {
+    err(res, 500, `Failed to fetch escrow state: ${error.message}`, 'rpc_error');
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -361,6 +361,7 @@ registerRoute('/', '/addresses', require('./addresses'));
 registerRoute('/', '/messages', require('./messages'));
 registerRoute('/', '/notifications', require('./notifications'));
 registerRoute('/', '/contracts', require('./contracts'));
+registerRoute('/', '/escrow', require('./escrow'));
 registerRoute('/', '/products/bulk', require('./bulkUpload'));
 registerRoute('/', '/coupons', require('./coupons'));
 registerRoute('/', '/alerts', require('./alerts'));

--- a/backend/src/utils/stellar-contracts.js
+++ b/backend/src/utils/stellar-contracts.js
@@ -374,6 +374,51 @@ async function invokeEscrowContract({ action, senderSecret, orderId, buyerPublic
 }
 
 /**
+ * Reads an order's escrow record from the Soroban escrow contract via simulation
+ * (read-only — no transaction is submitted). Returns `null` when the record does
+ * not exist on-chain so callers can respond with a 404.
+ * @param {number|string} orderId
+ * @returns {Promise<null | { status: string, buyer: string|null, farmer: string|null, amount: number|null, timeoutUnix: number|null, escrowAddress: string, lastUpdatedLedger: number|null }>}
+ */
+async function getEscrowState(orderId) {
+  const contractId = config.sorobanEscrowContractId;
+  if (!contractId) throw new Error('SOROBAN_ESCROW_CONTRACT_ID is not configured');
+
+  const sim = await simulateContractCall(contractId, 'get_escrow', [
+    { type: 'u64', value: Number(orderId) },
+  ]);
+
+  if (!sim.success) {
+    const msg = sim.error || '';
+    // The contract traps / returns an error when the escrow does not exist.
+    if (/not\s*found|missing|no\s*such|does not exist|UnreachableCodeReached/i.test(msg)) {
+      return null;
+    }
+    const e = new Error(`Failed to read escrow state: ${msg}`);
+    e.code = 'escrow_read_failed';
+    throw e;
+  }
+
+  const data = sim.result;
+  if (data === null || data === undefined) return null;
+
+  // scValToNative yields the contract struct's own field keys; map defensively.
+  const amountRaw = data.amount ?? data.amount_stroops ?? null;
+  const amount = amountRaw == null ? null : Number(amountRaw) / 10_000_000;
+  const timeoutUnix = data.timeout ?? data.timeout_unix ?? data.timeout_at ?? null;
+
+  return {
+    status: data.status != null ? String(data.status) : 'unknown',
+    buyer: data.buyer ?? null,
+    farmer: data.farmer ?? null,
+    amount,
+    timeoutUnix: timeoutUnix != null ? Number(timeoutUnix) : null,
+    escrowAddress: contractId,
+    lastUpdatedLedger: data.last_updated_ledger ?? null,
+  };
+}
+
+/**
  * General-purpose Soroban contract invocation. Prepares, signs, submits, and polls for confirmation.
  * @param {{ contractId: string, method: string, args?: Array<{ type: string, value: unknown }>, signerSecret: string }} params
  * @returns {Promise<{ hash: string, result: unknown }>}
@@ -690,6 +735,7 @@ module.exports = {
   getContractWasmHash,
   simulateContractCall,
   invokeEscrowContract,
+  getEscrowState,
   invokeContract,
   simulateContract,
   getContractABI,


### PR DESCRIPTION
## Summary
Adds an authenticated, order-scoped endpoint that returns a human-readable escrow status for a single order (useful for dispute resolution and support), instead of the raw Soroban storage exposed by the generic state endpoint.

- New `GET /api/escrow/:orderId/state` (registered for `/api` and `/api/v1`) returns `{ status, buyer, farmer, amount_xlm, timeout_at, escrow_address, last_updated_ledger }`.
- Authorization: buyers can query their own orders, farmers orders for their products, admins any; others get 403.
- Reads on-chain state via a new `getEscrowState(orderId)` helper that **simulates** the contract's `get_escrow` (read-only, no transaction/fees) and maps the Soroban response to the schema.
- Returns 404 with `code: 'escrow_not_found'` when no escrow record exists on-chain.
- Responses are cached for 30s (escrow state changes infrequently).

## Validation
- `node --check` on changed files: syntax OK.
- `eslint` on changed files: new `escrow.js` is clean; the only reported issues (`isTestnet` unused, one `no-console`) are pre-existing in `stellar-contracts.js` and untouched by this change.

Closes #867