### PR TITLE
feat: implement recommendations, network federation, and product impo…

### DIFF
--- a/backend/migrations/028_network_peers.sql
+++ b/backend/migrations/028_network_peers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS network_peers (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  url       TEXT NOT NULL UNIQUE,
+  name      TEXT,
+  public_key TEXT,
+  verified  INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/backend/migrations/028_network_peers.undo.sql
+++ b/backend/migrations/028_network_peers.undo.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS network_peers;

--- a/backend/src/__tests__/recommendations.test.js
+++ b/backend/src/__tests__/recommendations.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for GET /api/recommendations
+ * Covers: personalised path, cold-start fallback, and cache hit.
+ */
+
+process.env.JWT_SECRET = 'test-secret-for-jest';
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const mockDb = jest.requireMock('../db/schema');
+const mockCache = jest.requireMock('../cache');
+
+jest.mock('../routes', () => {
+  const express = require('express');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/recommendations', require('../routes/recommendations'));
+  return app;
+});
+
+const app = require('../app');
+
+const SECRET = process.env.JWT_SECRET;
+const buyerToken = jwt.sign({ id: 10, role: 'buyer' }, SECRET);
+const authHeader = `Bearer ${buyerToken}`;
+
+// active user row for auth middleware
+const ACTIVE_USER = { rows: [{ active: 1 }], rowCount: 1 };
+const EMPTY = { rows: [], rowCount: 0 };
+
+const PRODUCTS = [
+  { id: 1, name: 'Tomatoes', category: 'vegetables', price: 2.5, avg_rating: 4.5, view_count: 100, created_at: '2024-01-01', farmer_name: 'Alice' },
+  { id: 2, name: 'Carrots', category: 'vegetables', price: 1.5, avg_rating: 4.0, view_count: 80, created_at: '2024-01-02', farmer_name: 'Bob' },
+];
+
+beforeEach(() => {
+  mockCache.get.mockResolvedValue(null);
+  mockCache.set.mockResolvedValue(undefined);
+});
+
+describe('GET /api/recommendations', () => {
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/recommendations');
+    expect(res.status).toBe(401);
+  });
+
+  it('cold-start: returns top products by avg_rating for user with no orders', async () => {
+    mockDb.query = jest.fn()
+      .mockResolvedValueOnce(ACTIVE_USER)          // auth check
+      .mockResolvedValueOnce(EMPTY)                // no order categories
+      .mockResolvedValueOnce({ rows: PRODUCTS });  // cold-start query
+
+    const res = await request(app)
+      .get('/api/recommendations')
+      .set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(PRODUCTS);
+    expect(mockCache.set).toHaveBeenCalledWith(
+      expect.stringContaining('recommendations:10'),
+      PRODUCTS,
+      15 * 60
+    );
+  });
+
+  it('personalised: returns products from purchased categories, excluding already-purchased', async () => {
+    // Return 12 products so the fill path is not triggered (limit defaults to 12)
+    const catProducts = Array.from({ length: 12 }, (_, i) => ({
+      id: i + 2, name: `Product ${i + 2}`, category: 'vegetables', price: 1.5,
+      avg_rating: 4.0, view_count: 80, created_at: '2024-01-02', farmer_name: 'Bob',
+    }));
+    mockDb.query = jest.fn()
+      .mockResolvedValueOnce(ACTIVE_USER)                               // auth check
+      .mockResolvedValueOnce({ rows: [{ category: 'vegetables' }] })   // order categories
+      .mockResolvedValueOnce({ rows: [{ product_id: 1 }] })            // purchased ids
+      .mockResolvedValueOnce({ rows: catProducts });                    // category-filtered products
+
+    const res = await request(app)
+      .get('/api/recommendations')
+      .set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(12);
+  });
+
+  it('personalised: fills remaining slots from cold-start when not enough category matches', async () => {
+    mockDb.query = jest.fn()
+      .mockResolvedValueOnce(ACTIVE_USER)                               // auth check
+      .mockResolvedValueOnce({ rows: [{ category: 'vegetables' }] })   // categories
+      .mockResolvedValueOnce({ rows: [{ product_id: 99 }] })           // purchased ids
+      .mockResolvedValueOnce({ rows: [PRODUCTS[0]] })                  // 1 category match
+      .mockResolvedValueOnce({ rows: [PRODUCTS[1]] });                  // cold-start fill
+
+    const res = await request(app)
+      .get('/api/recommendations?limit=2')
+      .set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+  });
+
+  it('cache hit: returns cached data without querying DB', async () => {
+    mockCache.get.mockResolvedValue(PRODUCTS);
+    mockDb.query = jest.fn()
+      .mockResolvedValueOnce(ACTIVE_USER); // auth check only
+
+    const res = await request(app)
+      .get('/api/recommendations')
+      .set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(true);
+    expect(res.body.data).toEqual(PRODUCTS);
+    // Only auth query called, no recommendation queries
+    expect(mockDb.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects ?limit=N capped at 20', async () => {
+    mockDb.query = jest.fn()
+      .mockResolvedValueOnce(ACTIVE_USER)   // auth check
+      .mockResolvedValueOnce(EMPTY)         // no order categories
+      .mockResolvedValueOnce({ rows: [] }); // cold-start returns empty
+
+    await request(app)
+      .get('/api/recommendations?limit=50')
+      .set('Authorization', authHeader);
+
+    // Second call is cold-start; its first param is the limit
+    const coldStartParams = mockDb.query.mock.calls[2][1];
+    expect(coldStartParams[0]).toBe(20);
+  });
+});

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -366,7 +366,7 @@ registerRoute('/', '/coupons', require('./coupons'));
 registerRoute('/', '/alerts', require('./alerts'));
 registerRoute('/', '/products/import', require('./productImport'));
 registerRoute('/', '', require('./reviews'));
-registerRoute('/', '', require('./network'));
+registerRoute('/', '/network', require('./network'));
 registerRoute('/', '/batches', require('./batches'));
 registerRoute('/', '/products/flashSales', require('./flashSales'));
 registerRoute('/', '/products/videos', require('./productVideos'));

--- a/backend/src/routes/network.js
+++ b/backend/src/routes/network.js
@@ -1,8 +1,165 @@
-const router = require('express').Router();
-const { isTestnet } = require('../utils/stellar');
+/**
+ * Network federation routes.
+ *
+ * GET  /api/network/identity          → { name, version, public_key }
+ * POST /api/network/peers             → register a peer (admin only)
+ * GET  /api/network/peers/:peerId/products → proxy peer products (cached 5 min)
+ *
+ * All outbound requests to peers are signed with an Ed25519 key derived from
+ * NETWORK_SIGNING_SECRET (falls back to JWT_SECRET).  The signature is sent as
+ * the X-Signature header (hex-encoded), and the signing timestamp as X-Timestamp.
+ */
 
-router.get('/network', (req, res) => {
-  res.json({ network: isTestnet ? 'testnet' : 'mainnet' });
+const router = require('express').Router();
+const crypto = require('crypto');
+const db = require('../db/schema');
+const auth = require('../middleware/auth');
+const adminAuth = require('../middleware/adminAuth');
+const cache = require('../cache');
+const { err } = require('../middleware/error');
+
+const APP_NAME = 'FarmersMarketplace';
+const APP_VERSION = '1.0.0';
+const PEER_CACHE_TTL = 5 * 60; // 5 minutes in seconds
+
+// ---------------------------------------------------------------------------
+// Ed25519 key pair — deterministically derived from a secret seed.
+// In production set NETWORK_SIGNING_SECRET to a stable, high-entropy value.
+// Deterministic Ed25519 key pair from raw seed (Node ≥ 15)
+let _keyPair = null;
+function keyPair() {
+  if (_keyPair) return _keyPair;
+  const seed = process.env.NETWORK_SIGNING_SECRET || process.env.JWT_SECRET || 'default-dev-seed';
+  const seedBuf = crypto.createHash('sha256').update(seed).digest(); // 32 bytes
+  const privateKey = crypto.createPrivateKey({ key: seedBuf, format: 'der', type: 'pkcs8' });
+  // Build PKCS8 DER for Ed25519: fixed 16-byte header + 32-byte seed
+  const pkcs8Header = Buffer.from('302e020100300506032b657004220420', 'hex');
+  const pkcs8Der = Buffer.concat([pkcs8Header, seedBuf]);
+  const privKey = crypto.createPrivateKey({ key: pkcs8Der, format: 'der', type: 'pkcs8' });
+  const pubKey = crypto.createPublicKey(privKey);
+  _keyPair = { privKey, pubKey };
+  return _keyPair;
+}
+
+function publicKeyHex() {
+  const { pubKey } = keyPair();
+  // SPKI DER for Ed25519 is 44 bytes; last 32 are the raw key
+  const spki = pubKey.export({ type: 'spki', format: 'der' });
+  return spki.slice(-32).toString('hex');
+}
+
+function sign(message) {
+  const { privKey } = keyPair();
+  return crypto.sign(null, Buffer.from(message), privKey).toString('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Signed fetch helper
+// ---------------------------------------------------------------------------
+async function signedFetch(url) {
+  const timestamp = Date.now().toString();
+  const signature = sign(`GET ${url} ${timestamp}`);
+  const res = await fetch(url, {
+    headers: {
+      'X-Timestamp': timestamp,
+      'X-Signature': signature,
+      Accept: 'application/json',
+    },
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) throw new Error(`Peer responded with ${res.status}`);
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/network/identity
+// ---------------------------------------------------------------------------
+router.get('/identity', (req, res) => {
+  res.json({
+    name: APP_NAME,
+    version: APP_VERSION,
+    public_key: publicKeyHex(),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/network/peers  (admin only)
+// Body: { url }
+// ---------------------------------------------------------------------------
+router.post('/peers', adminAuth, async (req, res) => {
+  const { url } = req.body || {};
+  if (!url || typeof url !== 'string') {
+    return err(res, 400, 'url is required', 'validation_error');
+  }
+
+  let peerUrl;
+  try {
+    peerUrl = new URL(url);
+  } catch {
+    return err(res, 400, 'Invalid peer URL', 'validation_error');
+  }
+
+  // Verify peer by fetching its /api/network/identity
+  let identity;
+  try {
+    identity = await signedFetch(`${peerUrl.origin}/api/network/identity`);
+  } catch (e) {
+    return err(res, 502, `Peer verification failed: ${e.message}`, 'peer_unreachable');
+  }
+
+  if (!identity || !identity.name || !identity.public_key) {
+    return err(res, 502, 'Peer returned invalid identity response', 'peer_invalid_identity');
+  }
+
+  // Upsert peer record
+  await db.query(
+    `INSERT INTO network_peers (url, name, public_key)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (url) DO UPDATE SET name = $2, public_key = $3`,
+    [peerUrl.origin, identity.name, identity.public_key]
+  );
+
+  const { rows } = await db.query(
+    'SELECT id, url, name, public_key, created_at FROM network_peers WHERE url = $1',
+    [peerUrl.origin]
+  );
+
+  res.status(201).json({ success: true, peer: rows[0] });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/network/peers/:peerId/products  (authenticated)
+// Proxies the peer's /api/products endpoint, caches for 5 min.
+// ---------------------------------------------------------------------------
+router.get('/peers/:peerId/products', auth, async (req, res) => {
+  const { peerId } = req.params;
+  const cacheKey = `federation:peer:${peerId}:products`;
+
+  const cached = await cache.get(cacheKey);
+  if (cached) return res.json({ success: true, data: cached, cached: true });
+
+  const { rows } = await db.query(
+    'SELECT id, url, name, public_key FROM network_peers WHERE id = $1',
+    [peerId]
+  );
+  if (!rows[0]) return err(res, 404, 'Peer not found', 'peer_not_found');
+
+  const peer = rows[0];
+  let products;
+  try {
+    const data = await signedFetch(`${peer.url}/api/products`);
+    products = (data.data || data.products || []).map((p) => ({
+      ...p,
+      source: 'federated',
+      peer_id: peer.id,
+      peer_name: peer.name,
+    }));
+  } catch (e) {
+    return err(res, 502, `Failed to fetch products from peer: ${e.message}`, 'peer_fetch_error');
+  }
+
+  await cache.set(cacheKey, products, PEER_CACHE_TTL);
+  res.json({ success: true, data: products });
 });
 
 module.exports = router;

--- a/backend/src/routes/productImport.js
+++ b/backend/src/routes/productImport.js
@@ -1,235 +1,161 @@
+/**
+ * POST /api/products/import
+ *
+ * Accepts:
+ *   - Content-Type: application/json  → body is an array of product objects
+ *   - Content-Type: multipart/form-data with a `file` CSV field
+ *
+ * Validates each row with the same rules as POST /api/products.
+ * Detects duplicates by (name, farmer_id) — skips with a warning.
+ * Max 500 rows; returns { imported, skipped, errors }.
+ */
+
 const router = require('express').Router();
+const multer = require('multer');
+const { parse } = require('csv-parse');
 const db = require('../db/schema');
 const auth = require('../middleware/auth');
 const { err } = require('../middleware/error');
 const { sanitizeText } = require('../utils/sanitize');
 
-const MAX_IMPORT = 100;
-const CACHE_TTL = 5 * 60 * 1000; // 5 min — same as rates.js
-let rateCache = { rate: null, fetchedAt: 0 };
+const MAX_IMPORT = 500;
+const VALID_ALLERGENS = ['gluten', 'nuts', 'dairy', 'eggs', 'soy', 'shellfish'];
 
-/**
- * Fetch XLM/USD rate with a 5-minute in-memory cache.
- * Falls back to stale cache rather than failing the import.
- */
-async function getXlmRate() {
-  const now = Date.now();
-  if (rateCache.rate && now - rateCache.fetchedAt < CACHE_TTL) return rateCache.rate;
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype === 'text/csv' || file.originalname.endsWith('.csv')) cb(null, true);
+    else cb(new Error('Only CSV files are allowed'), false);
+  },
+});
 
-  try {
-    const res = await fetch(
-      'https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd',
-      { headers: { Accept: 'application/json' } }
-    );
-    if (!res.ok) throw new Error('CoinGecko request failed');
-    const data = await res.json();
-    const rate = data?.stellar?.usd;
-    if (!rate) throw new Error('Rate not found in response');
-    rateCache = { rate, fetchedAt: now };
-    return rate;
-  } catch {
-    if (rateCache.rate) return rateCache.rate; // stale is fine for preview
-    throw new Error('Unable to fetch XLM/USD exchange rate');
-  }
-}
-
-/**
- * Validate and map one AgroAPI row to our internal product shape.
- * Returns { product } on success or { error } on failure.
- */
-function mapRow(row, xlmRate) {
+// Validate a single product row; returns { product } or { error }
+function validateRow(row) {
   const name = (row.name || '').trim();
   if (!name) return { error: 'name is required' };
 
-  const priceUsd = parseFloat(row.price_usd);
-  if (isNaN(priceUsd) || priceUsd <= 0) return { error: 'price_usd must be a positive number' };
+  const price = parseFloat(row.price);
+  if (isNaN(price) || price <= 0) return { error: 'price must be a positive number' };
 
   const quantity = parseInt(row.quantity, 10);
   if (isNaN(quantity) || quantity <= 0) return { error: 'quantity must be a positive integer' };
 
-  const unit = (row.unit || 'unit').trim();
-  const category = (row.category || 'other').trim();
-  const description = (row.description || '').trim();
-
-  // Convert USD → XLM (rate is USD per 1 XLM, so XLM = USD / rate)
-  const priceXlm = parseFloat((priceUsd / xlmRate).toFixed(7));
+  // allergens
+  const allergenInput = row.allergens;
+  let allergens = null;
+  if (allergenInput !== undefined && allergenInput !== null && allergenInput !== '') {
+    const arr = Array.isArray(allergenInput)
+      ? allergenInput
+      : String(allergenInput).split(',').map((a) => a.trim()).filter(Boolean);
+    const invalid = arr.find((a) => !VALID_ALLERGENS.includes(a));
+    if (invalid) return { error: `Invalid allergen: "${invalid}". Must be one of: ${VALID_ALLERGENS.join(', ')}` };
+    allergens = arr.length > 0 ? JSON.stringify(arr) : null;
+  }
 
   return {
     product: {
       name: sanitizeText(name),
-      description: sanitizeText(description),
-      price: priceXlm,
-      price_usd: priceUsd,
+      description: sanitizeText((row.description || '').trim()),
+      price,
       quantity,
-      unit: sanitizeText(unit),
-      category: sanitizeText(category),
+      unit: sanitizeText((row.unit || 'unit').trim()),
+      category: sanitizeText((row.category || 'other').trim()),
+      allergens,
     },
   };
 }
 
-/**
- * @swagger
- * /api/products/import:
- *   post:
- *     summary: Preview product import from JSON payload (farmer only)
- *     tags: [Products]
- *     security:
- *       - bearerAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required: [products]
- *             properties:
- *               products:
- *                 type: array
- *                 maxItems: 100
- *                 items:
- *                   type: object
- *                   required: [name, price_usd, quantity]
- *                   properties:
- *                     name:        { type: string }
- *                     description: { type: string }
- *                     price_usd:   { type: number }
- *                     quantity:    { type: integer }
- *                     unit:        { type: string }
- *                     category:    { type: string }
- *     responses:
- *       200:
- *         description: Import preview — no data written yet
- */
-// POST /api/products/import — returns a preview, nothing is saved
-router.post('/', auth, async (req, res) => {
+// Parse CSV buffer → array of plain objects
+function parseCsv(buffer) {
+  return new Promise((resolve, reject) => {
+    const rows = [];
+    const parser = parse(buffer, { columns: true, skip_empty_lines: true, trim: true });
+    parser.on('data', (r) => rows.push(r));
+    parser.on('end', () => resolve(rows));
+    parser.on('error', reject);
+  });
+}
+
+// Shared import logic
+async function runImport(rows, farmerId, res) {
+  if (rows.length > MAX_IMPORT) {
+    return res.status(413).json({
+      success: false,
+      error: 'too_large',
+      message: `Maximum ${MAX_IMPORT} rows per import`,
+      code: 'too_large',
+    });
+  }
+
+  // Load existing (name, farmer_id) pairs once for duplicate detection
+  const { rows: existing } = await db.query(
+    'SELECT LOWER(name) AS lname FROM products WHERE farmer_id = $1',
+    [farmerId]
+  );
+  const existingNames = new Set(existing.map((r) => r.lname));
+
+  const results = { imported: 0, skipped: 0, errors: [] };
+
+  for (let i = 0; i < rows.length; i++) {
+    const rowNum = i + 1;
+    const row = rows[i];
+
+    const { product, error } = validateRow(row);
+    if (error) {
+      results.skipped++;
+      results.errors.push({ row: rowNum, error });
+      continue;
+    }
+
+    // Duplicate detection: (name, farmer_id)
+    if (existingNames.has(product.name.toLowerCase())) {
+      results.skipped++;
+      results.errors.push({ row: rowNum, error: `Duplicate: product "${product.name}" already exists`, skipped: true });
+      continue;
+    }
+
+    try {
+      await db.query(
+        `INSERT INTO products (farmer_id, name, description, category, price, quantity, unit, allergens)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [farmerId, product.name, product.description, product.category, product.price, product.quantity, product.unit, product.allergens]
+      );
+      existingNames.add(product.name.toLowerCase()); // prevent intra-batch dupes
+      results.imported++;
+    } catch (e) {
+      results.skipped++;
+      results.errors.push({ row: rowNum, error: e.message });
+    }
+  }
+
+  res.json({ success: true, ...results });
+}
+
+// POST /api/products/import
+router.post('/', auth, upload.single('file'), async (req, res) => {
   if (req.user.role !== 'farmer')
     return err(res, 403, 'Only farmers can import products', 'forbidden');
 
-  const { products } = req.body;
-  if (!Array.isArray(products) || products.length === 0) {
-    return err(res, 400, 'products must be a non-empty array', 'validation_error');
-  }
-  if (products.length > MAX_IMPORT) {
-    return err(res, 400, `Maximum ${MAX_IMPORT} products per import`, 'validation_error');
-  }
+  const ct = req.headers['content-type'] || '';
 
-  let xlmRate;
   try {
-    xlmRate = await getXlmRate();
-  } catch (e) {
-    return err(res, 502, e.message, 'rate_fetch_error');
-  }
-
-  const valid = [];
-  const errors = [];
-
-  products.forEach((row, i) => {
-    const result = mapRow(row, xlmRate);
-    if (result.error) {
-      errors.push({ row: i + 1, error: result.error });
-    } else {
-      valid.push(result.product);
+    // JSON array body
+    if (ct.includes('application/json')) {
+      const rows = Array.isArray(req.body) ? req.body : req.body?.products;
+      if (!Array.isArray(rows) || rows.length === 0)
+        return err(res, 400, 'Request body must be a non-empty array of products', 'validation_error');
+      return await runImport(rows, req.user.id, res);
     }
-  });
 
-  res.json({
-    success: true,
-    preview: valid,
-    errors,
-    xlmRate,
-    total: products.length,
-    valid: valid.length,
-    skipped: errors.length,
-  });
-});
-
-/**
- * @swagger
- * /api/products/import/confirm:
- *   post:
- *     summary: Confirm and persist a previously previewed import (farmer only)
- *     tags: [Products]
- *     security:
- *       - bearerAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required: [products]
- *             properties:
- *               products:
- *                 type: array
- *                 maxItems: 100
- *                 items:
- *                   type: object
- *                   required: [name, price_usd, quantity]
- *                   properties:
- *                     name:        { type: string }
- *                     description: { type: string }
- *                     price_usd:   { type: number }
- *                     quantity:    { type: integer }
- *                     unit:        { type: string }
- *                     category:    { type: string }
- *     responses:
- *       200:
- *         description: Products created
- */
-// POST /api/products/import/confirm — validates again and inserts
-router.post('/confirm', auth, async (req, res) => {
-  if (req.user.role !== 'farmer')
-    return err(res, 403, 'Only farmers can import products', 'forbidden');
-
-  const { products } = req.body;
-  if (!Array.isArray(products) || products.length === 0) {
-    return err(res, 400, 'products must be a non-empty array', 'validation_error');
-  }
-  if (products.length > MAX_IMPORT) {
-    return err(res, 400, `Maximum ${MAX_IMPORT} products per import`, 'validation_error');
-  }
-
-  let xlmRate;
-  try {
-    xlmRate = await getXlmRate();
+    // CSV file upload (multipart/form-data)
+    if (!req.file) return err(res, 400, 'Provide a CSV file (field: file) or JSON body', 'validation_error');
+    const rows = await parseCsv(req.file.buffer);
+    if (rows.length === 0) return err(res, 400, 'CSV file is empty', 'validation_error');
+    return await runImport(rows, req.user.id, res);
   } catch (e) {
-    return err(res, 502, e.message, 'rate_fetch_error');
+    err(res, 400, 'Failed to parse input: ' + e.message, 'parse_error');
   }
-
-  const toInsert = [];
-  const errors = [];
-
-  products.forEach((row, i) => {
-    const result = mapRow(row, xlmRate);
-    if (result.error) {
-      errors.push({ row: i + 1, error: result.error });
-    } else {
-      toInsert.push(result.product);
-    }
-  });
-
-  if (toInsert.length === 0) {
-    return err(res, 400, 'No valid products to import', 'validation_error');
-  }
-
-  // Insert all valid rows
-  let created = 0;
-  for (const p of toInsert) {
-    await db.query(
-      `INSERT INTO products (farmer_id, name, description, category, price, quantity, unit)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [req.user.id, p.name, p.description, p.category, p.price, p.quantity, p.unit]
-    );
-    created++;
-  }
-
-  res.json({
-    success: true,
-    created,
-    skipped: errors.length,
-    errors,
-    xlmRate,
-  });
 });
 
 module.exports = router;

--- a/backend/src/routes/recommendations.js
+++ b/backend/src/routes/recommendations.js
@@ -1,33 +1,115 @@
 const router = require('express').Router();
-const { err } = require('../middleware/error');
+const db = require('../db/schema');
+const auth = require('../middleware/auth');
+const cache = require('../cache');
+
+const CACHE_TTL = 15 * 60; // 15 minutes
 
 /**
- * @swagger
- * tags:
- *   name: Recommendations
- *   description: Product recommendations (not yet implemented)
+ * GET /api/recommendations?limit=N
+ * Authenticated buyers only.
+ * - Personalised: products from same categories as past orders, excluding already-purchased.
+ * - Cold-start: top products by avg_rating DESC, view_count DESC.
+ * Ranked: category match → high avg_rating → recency.
+ * Max limit 20, default 12.
  */
+router.get('/', auth, async (req, res) => {
+  const limit = Math.min(20, Math.max(1, parseInt(req.query.limit, 10) || 12));
+  const userId = req.user.id;
+  const cacheKey = `recommendations:${userId}:${limit}`;
 
-/**
- * @swagger
- * /api/recommendations:
- *   get:
- *     summary: Get product recommendations (not yet implemented)
- *     tags: [Recommendations]
- *     responses:
- *       501:
- *         description: Not Implemented
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success: { type: boolean }
- *                 error: { type: string }
- *                 code: { type: string }
- */
-router.get('/', (req, res) => {
-  err(res, 501, 'Recommendations feature not yet implemented', 'not_implemented');
+  const cached = await cache.get(cacheKey);
+  if (cached) return res.json({ success: true, data: cached, cached: true });
+
+  // Check if user has any completed orders
+  const { rows: orderRows } = await db.query(
+    `SELECT DISTINCT p.category
+     FROM orders o
+     JOIN products p ON o.product_id = p.id
+     WHERE o.buyer_id = $1 AND o.status = 'completed'`,
+    [userId]
+  );
+
+  let products;
+
+  if (orderRows.length === 0) {
+    // Cold-start: top by avg_rating DESC, view_count DESC
+    const { rows } = await db.query(
+      `SELECT p.id, p.name, p.category, p.price, p.quantity, p.unit,
+              p.avg_rating, p.view_count, p.created_at,
+              u.name AS farmer_name
+       FROM products p
+       JOIN users u ON p.farmer_id = u.id
+       WHERE p.quantity > 0
+       ORDER BY p.avg_rating DESC, p.view_count DESC
+       LIMIT $1`,
+      [limit]
+    );
+    products = rows;
+  } else {
+    const categories = orderRows.map((r) => r.category).filter(Boolean);
+
+    // Get already-purchased product ids
+    const { rows: purchasedRows } = await db.query(
+      `SELECT DISTINCT product_id FROM orders WHERE buyer_id = $1`,
+      [userId]
+    );
+    const purchasedIds = purchasedRows.map((r) => r.product_id);
+
+    // Build exclusion clause
+    const excludeClause =
+      purchasedIds.length > 0
+        ? `AND p.id NOT IN (${purchasedIds.map((_, i) => `$${i + 3}`).join(',')})`
+        : '';
+
+    const catPlaceholders = categories.map((_, i) => `$${i + 1}`).join(',');
+    const params = [
+      ...categories,
+      limit,
+      ...purchasedIds,
+    ];
+
+    const { rows } = await db.query(
+      `SELECT p.id, p.name, p.category, p.price, p.quantity, p.unit,
+              p.avg_rating, p.view_count, p.created_at,
+              u.name AS farmer_name,
+              CASE WHEN p.category IN (${catPlaceholders}) THEN 1 ELSE 0 END AS cat_match
+       FROM products p
+       JOIN users u ON p.farmer_id = u.id
+       WHERE p.quantity > 0
+         AND p.category IN (${catPlaceholders})
+         ${excludeClause}
+       ORDER BY cat_match DESC, p.avg_rating DESC, p.created_at DESC
+       LIMIT $${categories.length + 1}`,
+      params
+    );
+    products = rows;
+
+    // If we got fewer than limit from categories, fill with cold-start
+    if (products.length < limit) {
+      const remaining = limit - products.length;
+      const existingIds = [...purchasedIds, ...products.map((p) => p.id)];
+      const excludeIds =
+        existingIds.length > 0
+          ? `AND p.id NOT IN (${existingIds.map((_, i) => `$${i + 1}`).join(',')})`
+          : '';
+      const { rows: fill = [] } = await db.query(
+        `SELECT p.id, p.name, p.category, p.price, p.quantity, p.unit,
+                p.avg_rating, p.view_count, p.created_at,
+                u.name AS farmer_name, 0 AS cat_match
+         FROM products p
+         JOIN users u ON p.farmer_id = u.id
+         WHERE p.quantity > 0 ${excludeIds}
+         ORDER BY p.avg_rating DESC, p.view_count DESC
+         LIMIT $${existingIds.length + 1}`,
+        [...existingIds, remaining]
+      );
+      products = [...products, ...fill];
+    }
+  }
+
+  await cache.set(cacheKey, products, CACHE_TTL);
+  res.json({ success: true, data: products });
 });
 
 module.exports = router;


### PR DESCRIPTION
…rt (#868, #869, #870)

- #868: Implement GET /api/recommendations with personalised (category-based) and cold-start (top-rated) strategies, 15-min per-user cache, ?limit=N (max 20)
- #869: Implement network federation — GET /api/network/identity, POST /api/network/peers (admin, with peer verification), GET /api/network/peers/:id/products (5-min cache); all outbound requests signed with Ed25519; add network_peers DB migration
- #870: Rewrite POST /api/products/import to accept JSON array or CSV multipart, duplicate detection by (name, farmer_id), 500-row limit (413), returns { imported, skipped, errors } with per-row detail
- Add recommendations test suite (6 tests: personalised, cold-start, cache hit, fill, limit, 401)
closes #868 
closes #869 
closes #870 