### PR TITLE
Feat/issues 856 857 858 859

### DIFF
--- a/.github/workflows/contract-deploy.yml
+++ b/.github/workflows/contract-deploy.yml
@@ -1,0 +1,135 @@
+name: Contract Testnet Deploy + Smoke Test
+
+# #859 — Build the escrow contract Wasm, deploy it to Stellar Testnet, run an
+# end-to-end smoke test (deposit -> release) and verify the result on Horizon.
+#
+# Runs on manual dispatch and on pushes to main that touch the escrow contract.
+# It is intentionally NOT triggered by pull_request: deploying requires the
+# STELLAR_CI_SECRET_KEY secret, which is not exposed to fork PRs.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'contracts/escrow/**'
+      - 'contract/cli.sh'
+      - '.github/workflows/contract-deploy.yml'
+
+env:
+  STELLAR_NETWORK: testnet
+  HORIZON_URL: https://horizon-testnet.stellar.org
+  RPC_URL: https://soroban-testnet.stellar.org
+
+jobs:
+  deploy-and-smoke-test:
+    name: Deploy to Testnet & Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target
+          key: ${{ runner.os }}-cargo-escrow-${{ hashFiles('contracts/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-escrow-
+
+      # Acceptance: CI builds the contract Wasm.
+      - name: Build escrow contract Wasm
+        working-directory: contracts
+        run: cargo build -p soroban-escrow --target wasm32-unknown-unknown --release
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli@22.0.0
+
+      # Acceptance: a CI testnet key is stored as a secret and used to deploy.
+      - name: Guard — require deploy secret
+        env:
+          STELLAR_CI_SECRET_KEY: ${{ secrets.STELLAR_CI_SECRET_KEY }}
+        run: |
+          if [ -z "${STELLAR_CI_SECRET_KEY}" ]; then
+            echo "::error::STELLAR_CI_SECRET_KEY secret is not set; cannot deploy to testnet."
+            exit 1
+          fi
+
+      # Acceptance: deploy, smoke test (deposit 1 XLM -> release), and verify on
+      # Horizon. The job (and therefore the CI run) fails if any step fails.
+      - name: Deploy + smoke test (deposit -> release)
+        env:
+          STELLAR_SECRET_KEY: ${{ secrets.STELLAR_CI_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+
+          WASM=contracts/target/wasm32-unknown-unknown/release/soroban_escrow.wasm
+          ACCOUNT_PK="$(stellar keys public-key --secret-key "$STELLAR_SECRET_KEY")"
+          echo "CI account: $ACCOUNT_PK"
+
+          # Fund the CI account on testnet (idempotent; ignore 'already funded').
+          curl -sf "https://friendbot.stellar.org/?addr=${ACCOUNT_PK}" >/dev/null || true
+
+          # Native XLM Stellar Asset Contract address (the escrow token).
+          XLM_SAC="$(stellar contract id asset --asset native --network "$STELLAR_NETWORK")"
+          echo "Native SAC: $XLM_SAC"
+
+          # Deploy the freshly built Wasm.
+          CONTRACT_ID="$(stellar contract deploy \
+            --wasm "$WASM" \
+            --network "$STELLAR_NETWORK" \
+            --source-account "$STELLAR_SECRET_KEY")"
+          echo "Deployed contract: $CONTRACT_ID"
+
+          invoke() {
+            stellar contract invoke \
+              --id "$CONTRACT_ID" \
+              --network "$STELLAR_NETWORK" \
+              --source-account "$STELLAR_SECRET_KEY" \
+              -- "$@"
+          }
+
+          # Initialize: admin = CI account, 0% fee, fee dest = CI account.
+          invoke initialize \
+            --admin "$ACCOUNT_PK" \
+            --fee_bps 0 \
+            --fee_destination "$ACCOUNT_PK"
+
+          ORDER_ID=$(( RANDOM + 1 ))
+          NOW="$(date +%s)"
+          TIMEOUT=$(( NOW + 7200 ))           # 2h ahead (> MIN_TIMEOUT_SECS)
+
+          # Deposit 1 XLM (10_000_000 stroops) into escrow.
+          invoke deposit \
+            --token "$XLM_SAC" \
+            --order_id "$ORDER_ID" \
+            --buyer "$ACCOUNT_PK" \
+            --farmer "$ACCOUNT_PK" \
+            --amount 10000000 \
+            --timeout_unix "$TIMEOUT"
+
+          # Release the escrow to the farmer.
+          invoke release --order_id "$ORDER_ID" --platform_fee_bps 0
+
+          # On-chain assertion: escrow is now settled.
+          SETTLED="$(invoke is_settled --order_id "$ORDER_ID")"
+          echo "is_settled => $SETTLED"
+          if [ "$SETTLED" != "true" ]; then
+            echo "::error::Escrow $ORDER_ID was not settled after release."
+            exit 1
+          fi
+
+          # Acceptance: verify the transaction on Stellar Testnet via Horizon.
+          LATEST="$(curl -sf "${HORIZON_URL}/accounts/${ACCOUNT_PK}/transactions?order=desc&limit=1")"
+          SUCCESS="$(echo "$LATEST" | python3 -c 'import json,sys; print(json.load(sys.stdin)["_embedded"]["records"][0]["successful"])')"
+          echo "Latest Horizon tx successful => $SUCCESS"
+          if [ "$SUCCESS" != "True" ]; then
+            echo "::error::Most recent Horizon transaction was not successful."
+            exit 1
+          fi
+
+          echo "Smoke test passed: deploy -> deposit -> release -> Horizon verification ✓"

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,10 @@ frontend/.playwright/
 contract/target/
 contract/Cargo.lock
 contracts/target/
+contracts/Cargo.lock
 contracts/escrow/target/
+# Soroban test snapshot artifacts (written by `cargo test`)
+**/test_snapshots/
 # Test artifacts
 coverage/
 **/__snapshots__/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ frontend/.playwright/
 # Rust
 contract/target/
 contract/Cargo.lock
+contracts/target/
 contracts/escrow/target/
 # Test artifacts
 coverage/

--- a/contract/cli.sh
+++ b/contract/cli.sh
@@ -1,24 +1,59 @@
 #!/usr/bin/env bash
 # Escrow contract CLI — wraps `stellar contract invoke`
-# Usage: ./cli.sh <subcommand> [args]
+# Usage: ./cli.sh <subcommand> [args] [--secret-key S...]
 #
 # Required env vars:
 #   CONTRACT_ID   — deployed contract address
 #   NETWORK       — testnet | mainnet | standalone (default: testnet)
 #   SOURCE        — Stellar account key name (from `stellar keys`)
+#
+# Non-interactive signing (CI):
+#   Pass --secret-key S... as a flag, or set STELLAR_SECRET_KEY in the
+#   environment. When supplied, the raw secret key signs the transaction
+#   instead of a named `stellar keys` identity — no interactive prompt. (#859)
 
 set -euo pipefail
 
 CONTRACT_ID="${CONTRACT_ID:?Set CONTRACT_ID}"
 NETWORK="${NETWORK:-testnet}"
 SOURCE="${SOURCE:-default}"
+SECRET_KEY="${STELLAR_SECRET_KEY:-}"
+
+# Pre-scan argv for --secret-key so it can appear anywhere (CI convenience). (#859)
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --secret-key)
+      SECRET_KEY="${2:?--secret-key requires a value}"
+      shift 2
+      ;;
+    --secret-key=*)
+      SECRET_KEY="${1#*=}"
+      shift
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${ARGS[@]:-}"
 
 invoke() {
-  stellar contract invoke \
-    --id "$CONTRACT_ID" \
-    --network "$NETWORK" \
-    --source "$SOURCE" \
-    -- "$@"
+  if [ -n "$SECRET_KEY" ]; then
+    # CI path: sign non-interactively with a raw secret key.
+    stellar contract invoke \
+      --id "$CONTRACT_ID" \
+      --network "$NETWORK" \
+      --source-account "$SECRET_KEY" \
+      -- "$@"
+  else
+    stellar contract invoke \
+      --id "$CONTRACT_ID" \
+      --network "$NETWORK" \
+      --source "$SOURCE" \
+      -- "$@"
+  fi
 }
 
 case "${1:-help}" in

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -49,6 +49,9 @@ pub enum EscrowError {
     /// (Issue suggested extending InvalidAmount; a dedicated variant is clearer.
     /// Code 16 is used because 12/8 are already taken by other variants.)
     BelowMinDeposit     = 16,
+    /// `batch_release` was called with more than `MAX_BATCH_RELEASE` order IDs. (#856)
+    /// (Issue suggested code 12, but that is already `NotEnoughSignatures`; 17 is used.)
+    BatchTooLarge       = 17,
 }
 
 #[derive(Clone, PartialEq)]
@@ -494,6 +497,111 @@ impl EscrowContract {
             .instance()
             .get(&DataKey::MinDeposit)
             .unwrap_or(MIN_DEPOSIT_STROOPS)
+    }
+
+    /// Release many escrows to their farmers in a single transaction. (#856)
+    ///
+    /// Callable by the Platform role only (the platform address authorises the
+    /// whole batch, so individual buyer signatures are not required). Reduces the
+    /// per-release transaction fee for cron-driven settlement of many small orders.
+    ///
+    /// - At most `MAX_BATCH_RELEASE` (20) IDs are accepted, matching Stellar's
+    ///   per-transaction operation limit; otherwise `EscrowError::BatchTooLarge`.
+    /// - Each release is independent: a failing one emits
+    ///   ("escrow", "batch_release_error", order_id) and the batch continues.
+    /// - Returns one `(order_id, succeeded)` pair per input ID, in order.
+    pub fn batch_release(
+        env: Env,
+        order_ids: Vec<u64>,
+    ) -> Result<Vec<(u64, bool)>, EscrowError> {
+        // Platform-role authorization for the whole batch.
+        let platform: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Platform)
+            .ok_or(EscrowError::Unauthorized)?;
+        platform.require_auth();
+
+        if order_ids.len() > MAX_BATCH_RELEASE {
+            return Err(EscrowError::BatchTooLarge);
+        }
+
+        let mut results: Vec<(u64, bool)> = Vec::new(&env);
+        for order_id in order_ids.iter() {
+            match Self::release_internal(&env, order_id) {
+                Ok(()) => results.push_back((order_id, true)),
+                Err(_) => {
+                    env.events().publish(
+                        (
+                            symbol_short!("escrow"),
+                            soroban_sdk::Symbol::new(&env, "batch_release_error"),
+                            order_id,
+                        ),
+                        (),
+                    );
+                    results.push_back((order_id, false));
+                }
+            }
+        }
+        Ok(results)
+    }
+
+    /// Core release logic shared by `batch_release` (#856) — releases an escrow
+    /// to its farmer with the stored platform fee, WITHOUT requiring buyer auth
+    /// (the caller is responsible for authorization). Returns an error instead of
+    /// panicking so a batch can continue past individual failures.
+    fn release_internal(env: &Env, order_id: u64) -> Result<(), EscrowError> {
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(order_id))
+            .ok_or(EscrowError::NotFound)?;
+
+        match escrow.status {
+            EscrowStatus::Released | EscrowStatus::Refunded => {
+                return Err(EscrowError::AlreadySettled);
+            }
+            EscrowStatus::Disputed => return Err(EscrowError::InDispute),
+            EscrowStatus::Active => {}
+        }
+
+        // Enforce the token stored at deposit time.
+        let stored_token: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(order_id))
+            .ok_or(EscrowError::NotFound)?;
+        if stored_token != escrow.token {
+            return Err(EscrowError::InvalidToken);
+        }
+
+        let token_client = token::Client::new(env, &escrow.token);
+        let effective_bps: u32 = env.storage().instance().get(&DataKey::FeeBps).unwrap_or(0);
+        let fee_amount = (escrow.amount * effective_bps as i128) / 10_000;
+        let farmer_amount = escrow.amount - fee_amount;
+
+        if fee_amount > 0 {
+            let fee_dest: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::FeeDestination)
+                .or_else(|| env.storage().instance().get(&DataKey::Platform))
+                .ok_or(EscrowError::NotFound)?;
+            token_client.transfer(&env.current_contract_address(), &fee_dest, &fee_amount);
+        }
+        token_client.transfer(&env.current_contract_address(), &escrow.farmer, &farmer_amount);
+
+        escrow.status = EscrowStatus::Released;
+        env.storage().persistent().set(&DataKey::Escrow(order_id), &escrow);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Escrow(order_id), TTL_MIN, TTL_MAX);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("release")),
+            (order_id, farmer_amount, fee_amount),
+        );
+        Ok(())
     }
 
     /// Refund funds to the buyer after timeout.
@@ -1682,5 +1790,66 @@ mod test {
         for amount in [min, min + 1, 10_000_000, 1_000_000_000] {
             assert!(amount >= min, "amount {amount} should satisfy the minimum-deposit guard");
         }
+    }
+
+    // ── #856 batch release tests ──────────────────────────────────────────────
+
+    #[test]
+    fn batch_release_too_large() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let platform = Address::generate(&env);
+        env.storage().instance().set(&DataKey::Platform, &platform);
+
+        let mut ids: Vec<u64> = Vec::new(&env);
+        for i in 0..21u64 {
+            ids.push_back(i);
+        }
+        let result = EscrowContract::batch_release(env, ids);
+        assert_eq!(result, Err(EscrowError::BatchTooLarge));
+    }
+
+    #[test]
+    fn batch_release_partial_failure_continues() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let platform = Address::generate(&env);
+        env.storage().instance().set(&DataKey::Platform, &platform);
+
+        // order 800 does not exist -> NotFound; order 801 is already settled ->
+        // AlreadySettled. Both fail, but the batch must process both and report each.
+        let buyer = Address::generate(&env);
+        let farmer = Address::generate(&env);
+        let token = Address::generate(&env);
+        let settled = Escrow {
+            buyer,
+            farmer,
+            token,
+            amount: 1_000,
+            timeout_unix: 0,
+            status: EscrowStatus::Released,
+        };
+        env.storage().persistent().set(&DataKey::Escrow(801), &settled);
+
+        let mut ids: Vec<u64> = Vec::new(&env);
+        ids.push_back(800u64);
+        ids.push_back(801u64);
+
+        let results = EscrowContract::batch_release(env, ids).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap(), (800u64, false));
+        assert_eq!(results.get(1).unwrap(), (801u64, false));
+    }
+
+    #[test]
+    fn batch_release_empty_is_ok() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let platform = Address::generate(&env);
+        env.storage().instance().set(&DataKey::Platform, &platform);
+
+        let ids: Vec<u64> = Vec::new(&env);
+        let results = EscrowContract::batch_release(env, ids).unwrap();
+        assert_eq!(results.len(), 0);
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -11,6 +11,15 @@ const TTL_MAX: u32 = 200_000;
 /// Minimum timeout for a deposit — 1 hour in seconds. (#838)
 const MIN_TIMEOUT_SECS: u64 = 3_600;
 
+/// Default minimum deposit — 0.5 XLM in stroops. Matches the Stellar base
+/// reserve (0.5 XLM per entry) so an escrow record is never worth less than
+/// the ledger storage it occupies. Admin-configurable via `set_min_deposit`. (#857)
+const MIN_DEPOSIT_STROOPS: i128 = 5_000_000;
+
+/// Maximum number of order IDs accepted by `batch_release` in a single call —
+/// keeps the transaction under Stellar's operation limit. (#856)
+const MAX_BATCH_RELEASE: u32 = 20;
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -36,6 +45,10 @@ pub enum EscrowError {
     AlreadyInitialized  = 14,
     /// Caller is not the platform admin or does not hold the required role. (#837)
     NotAdmin            = 15,
+    /// Deposit amount is below the configured minimum (dust). (#857)
+    /// (Issue suggested extending InvalidAmount; a dedicated variant is clearer.
+    /// Code 16 is used because 12/8 are already taken by other variants.)
+    BelowMinDeposit     = 16,
 }
 
 #[derive(Clone, PartialEq)]
@@ -68,6 +81,9 @@ pub enum DataKey {
     FeeDestination,
     /// Flag set to true once initialize() has been called. (#837)
     Initialized,
+    /// Admin-configurable minimum deposit amount in stroops. Falls back to
+    /// `MIN_DEPOSIT_STROOPS` when unset. (#857)
+    MinDeposit,
 }
 
 /// Full escrow record. `token` stores the SAC address used for this escrow (#683).
@@ -195,6 +211,17 @@ impl EscrowContract {
         // #838: amount must be positive
         if amount <= 0 {
             return Err(EscrowError::InvalidAmount);
+        }
+
+        // #857: enforce a minimum deposit to prevent dust escrow records that
+        // cost more to store (Stellar base reserve) than they are worth.
+        let min_deposit: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinDeposit)
+            .unwrap_or(MIN_DEPOSIT_STROOPS);
+        if amount < min_deposit {
+            return Err(EscrowError::BelowMinDeposit);
         }
 
         // #838: duplicate order_id — immutable, regardless of settlement state
@@ -437,6 +464,36 @@ impl EscrowContract {
         }
         let transfer = AdminTransfer { current_admin: admin, pending_admin: None };
         env.storage().instance().set(&DataKey::Admin, &transfer);
+    }
+
+    /// Admin-only: update the minimum deposit amount (in stroops) to respond to
+    /// XLM price changes. Must be positive. (#857)
+    pub fn set_min_deposit(env: Env, amount: i128) -> Result<(), EscrowError> {
+        let admin_transfer: AdminTransfer = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(EscrowError::Unauthorized)?;
+        admin_transfer.current_admin.require_auth();
+
+        if amount <= 0 {
+            return Err(EscrowError::InvalidAmount);
+        }
+        env.storage().instance().set(&DataKey::MinDeposit, &amount);
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("min_dep")),
+            amount,
+        );
+        Ok(())
+    }
+
+    /// Read-only view: returns the current minimum deposit amount in stroops,
+    /// falling back to the `MIN_DEPOSIT_STROOPS` default when unset. (#857)
+    pub fn get_min_deposit(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinDeposit)
+            .unwrap_or(MIN_DEPOSIT_STROOPS)
     }
 
     /// Refund funds to the buyer after timeout.
@@ -1566,5 +1623,64 @@ mod test {
 
         let result = EscrowContract::multisig_release(env, 604, sigs);
         assert_eq!(result, Err(EscrowError::NotEnoughSignatures));
+    }
+
+    // ── #857 minimum deposit / dust-attack prevention tests ───────────────────
+
+    fn setup_admin_for(env: &Env) -> Address {
+        let admin = Address::generate(env);
+        let transfer = AdminTransfer { current_admin: admin.clone(), pending_admin: None };
+        env.storage().instance().set(&DataKey::Admin, &transfer);
+        admin
+    }
+
+    #[test]
+    fn min_deposit_default_is_half_xlm() {
+        let env = Env::default();
+        assert_eq!(EscrowContract::get_min_deposit(env), 5_000_000);
+    }
+
+    #[test]
+    fn set_min_deposit_updates_queryable_value() {
+        let env = Env::default();
+        env.mock_all_auths();
+        setup_admin_for(&env);
+        EscrowContract::set_min_deposit(env.clone(), 10_000_000).unwrap();
+        assert_eq!(EscrowContract::get_min_deposit(env), 10_000_000);
+    }
+
+    #[test]
+    fn set_min_deposit_rejects_non_positive() {
+        let env = Env::default();
+        env.mock_all_auths();
+        setup_admin_for(&env);
+        assert_eq!(
+            EscrowContract::set_min_deposit(env, 0),
+            Err(EscrowError::InvalidAmount)
+        );
+    }
+
+    #[test]
+    fn deposit_below_minimum_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let token = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let farmer = Address::generate(&env);
+        // 0.49 XLM — below the 0.5 XLM default minimum. The guard runs before any
+        // token transfer, so no real token client is required.
+        let result = EscrowContract::deposit(env, token, 700, buyer, farmer, 4_900_000, u64::MAX);
+        assert_eq!(result, Err(EscrowError::BelowMinDeposit));
+    }
+
+    #[test]
+    fn deposit_at_and_above_minimum_pass_amount_guard() {
+        // Mirrors the contract guard: amount >= MIN_DEPOSIT_STROOPS is accepted.
+        // (Full deposit past this point requires a live token client, exercised
+        // by the backend integration tests.)
+        let min = 5_000_000_i128;
+        for amount in [min, min + 1, 10_000_000, 1_000_000_000] {
+            assert!(amount >= min, "amount {amount} should satisfy the minimum-deposit guard");
+        }
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -52,6 +52,9 @@ pub enum EscrowError {
     /// `batch_release` was called with more than `MAX_BATCH_RELEASE` order IDs. (#856)
     /// (Issue suggested code 12, but that is already `NotEnoughSignatures`; 17 is used.)
     BatchTooLarge       = 17,
+    /// No escrow snapshot exists for the requested (order_id, ledger_sequence). (#858)
+    /// (Issue referenced code 8, but that is already `InvalidWasmHash` here; 18 is used.)
+    SnapshotNotFound    = 18,
 }
 
 #[derive(Clone, PartialEq)]
@@ -87,6 +90,9 @@ pub enum DataKey {
     /// Admin-configurable minimum deposit amount in stroops. Falls back to
     /// `MIN_DEPOSIT_STROOPS` when unset. (#857)
     MinDeposit,
+    /// Point-in-time snapshot of an escrow record, keyed by (order_id,
+    /// ledger_sequence). Stored in temporary storage for the audit trail. (#858)
+    Snapshot(u64, u64),
 }
 
 /// Full escrow record. `token` stores the SAC address used for this escrow (#683).
@@ -604,6 +610,58 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Store a point-in-time copy of the live escrow record for `order_id`,
+    /// keyed by the current ledger sequence. (#858)
+    ///
+    /// Snapshots live in temporary storage (same TTL as the escrow record) and
+    /// never mutate the live escrow. Used for dispute resolution and audit.
+    /// Internal: callers are responsible for any authorization.
+    fn store_snapshot(env: &Env, order_id: u64) -> Result<u64, EscrowError> {
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(order_id))
+            .ok_or(EscrowError::NotFound)?;
+
+        let seq = env.ledger().sequence() as u64;
+        let key = DataKey::Snapshot(order_id, seq);
+        env.storage().temporary().set(&key, &escrow);
+        env.storage().temporary().extend_ttl(&key, TTL_MIN, TTL_MAX);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("snapshot"), order_id),
+            seq,
+        );
+        Ok(seq)
+    }
+
+    /// Take a snapshot of the current escrow state for `order_id`. (#858)
+    ///
+    /// Callable by the Platform/Arbitrator role (the contract admin acts as the
+    /// arbitrator). Returns the ledger sequence the snapshot was stored under.
+    pub fn take_snapshot(env: Env, order_id: u64) -> Result<u64, EscrowError> {
+        let admin_transfer: AdminTransfer = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(EscrowError::Unauthorized)?;
+        admin_transfer.current_admin.require_auth();
+        Self::store_snapshot(&env, order_id)
+    }
+
+    /// Read-only view: return the escrow snapshot stored for
+    /// (`order_id`, `ledger_sequence`), or `SnapshotNotFound`. (#858)
+    pub fn get_snapshot(
+        env: Env,
+        order_id: u64,
+        ledger_sequence: u64,
+    ) -> Result<Escrow, EscrowError> {
+        env.storage()
+            .temporary()
+            .get(&DataKey::Snapshot(order_id, ledger_sequence))
+            .ok_or(EscrowError::SnapshotNotFound)
+    }
+
     /// Refund funds to the buyer after timeout.
     ///
     /// Uses the token stored in the escrow record (#683).
@@ -679,6 +737,10 @@ impl EscrowContract {
             }
             _ => {}
         }
+
+        // #858: capture a snapshot of the pre-dispute state before mutating it,
+        // so the arbitrator can inspect the escrow as it was when the dispute opened.
+        Self::store_snapshot(&env, order_id)?;
 
         escrow.status = EscrowStatus::Disputed;
         env.storage().persistent().set(&DataKey::Escrow(order_id), &escrow);
@@ -1851,5 +1913,59 @@ mod test {
         let ids: Vec<u64> = Vec::new(&env);
         let results = EscrowContract::batch_release(env, ids).unwrap();
         assert_eq!(results.len(), 0);
+    }
+
+    // ── #858 snapshot audit trail tests ───────────────────────────────────────
+
+    #[test]
+    fn take_snapshot_stores_retrievable_copy() {
+        let env = Env::default();
+        env.mock_all_auths();
+        setup_admin_for(&env);
+        let buyer = Address::generate(&env);
+        let farmer = Address::generate(&env);
+        let token = Address::generate(&env);
+        store_escrow(&env, 900, buyer.clone(), farmer, token);
+
+        let seq = EscrowContract::take_snapshot(env.clone(), 900).unwrap();
+        let snap = EscrowContract::get_snapshot(env, 900, seq).unwrap();
+        assert_eq!(snap.buyer, buyer);
+        assert_eq!(snap.amount, 1_000_0000);
+        assert_eq!(snap.status, EscrowStatus::Active);
+    }
+
+    #[test]
+    fn get_snapshot_missing_returns_not_found() {
+        let env = Env::default();
+        let result = EscrowContract::get_snapshot(env, 999, 1);
+        assert_eq!(result, Err(EscrowError::SnapshotNotFound));
+    }
+
+    #[test]
+    fn take_snapshot_missing_escrow_returns_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        setup_admin_for(&env);
+        let result = EscrowContract::take_snapshot(env, 12345);
+        assert_eq!(result, Err(EscrowError::NotFound));
+    }
+
+    #[test]
+    fn dispute_takes_snapshot_of_pre_dispute_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let buyer = Address::generate(&env);
+        let farmer = Address::generate(&env);
+        let token = Address::generate(&env);
+        store_escrow(&env, 901, buyer.clone(), farmer, token);
+
+        let seq = env.ledger().sequence() as u64;
+        EscrowContract::dispute(env.clone(), 901, buyer).unwrap();
+
+        // Snapshot captured the Active state from before the dispute…
+        let snap = EscrowContract::get_snapshot(env.clone(), 901, seq).unwrap();
+        assert_eq!(snap.status, EscrowStatus::Active);
+        // …while the live record is now Disputed.
+        assert_eq!(EscrowContract::get(env, 901).unwrap().status, EscrowStatus::Disputed);
     }
 }


### PR DESCRIPTION
# Escrow contract: dust prevention, batch release, snapshots & testnet deploy CI

Implements four escrow contract issues on one branch.

Closes #857
Closes #859
Closes #858
Closes #856

## What changed
- **#857 — Minimum deposit / dust prevention:** `MIN_DEPOSIT_STROOPS` (0.5 XLM), admin `set_min_deposit`, `get_min_deposit`; `deposit` rejects sub-minimum amounts with `EscrowError::BelowMinDeposit`.
- **#856 — Batch release:** `batch_release(order_ids)` (Platform role), capped at 20 (`BatchTooLarge`), per-item independent failures emit `("escrow","batch_release_error",order_id)` and return `Vec<(order_id, bool)>`.
- **#858 — Snapshots:** `DataKey::Snapshot(order_id, ledger_seq)` in temporary storage, `take_snapshot` / `get_snapshot` (`SnapshotNotFound`); `dispute` auto-snapshots pre-dispute state.
- **#859 — Deploy CI:** `contract-deploy.yml` builds the Wasm, deploys to testnet with `STELLAR_CI_SECRET_KEY`, runs a deposit→release smoke test verified via Horizon; `cli.sh` gains `--secret-key` for non-interactive signing.

Each issue is a separate commit; tests added for all contract changes.

## Notes
- Error codes 16/17/18 used for the new variants (the codes named in the issues collide with existing variants).
- Pre-existing, unrelated to this PR: `contracts/escrow/src/lib.rs` does not currently compile (duplicate definitions from prior auto-merges) and the `creator-earnings` tests fail (`env.as_contract()` misuse) on `main`. Left untouched per scope.
