### PR TITLE
feat(#862): escrow event indexer with DB updates and cursor persistence

### DIFF
--- a/backend/migrations/030_escrow_monitor_cursor.sql
+++ b/backend/migrations/030_escrow_monitor_cursor.sql
@@ -1,0 +1,9 @@
+-- Migration: 030_escrow_monitor_cursor
+-- Issue #862: persist last processed ledger so the event indexer resumes
+-- from where it left off after a restart instead of re-processing events.
+
+CREATE TABLE IF NOT EXISTS escrow_monitor_cursor (
+  contract_id  TEXT    NOT NULL PRIMARY KEY,
+  last_ledger  INTEGER NOT NULL DEFAULT 0,
+  updated_at   DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/migrations/030_escrow_monitor_cursor.undo.sql
+++ b/backend/migrations/030_escrow_monitor_cursor.undo.sql
@@ -1,0 +1,2 @@
+-- Undo: 030_escrow_monitor_cursor
+DROP TABLE IF EXISTS escrow_monitor_cursor;

--- a/backend/src/__tests__/contractMonitor.test.js
+++ b/backend/src/__tests__/contractMonitor.test.js
@@ -1,242 +1,478 @@
 /**
- * contractMonitor.test.js
- * Tests for exponential backoff retry logic and escrow event structures (#844)
+ * contractMonitor.test.js — Issue #862
+ *
+ * Tests for the escrow event indexer:
+ *   - deposit  → escrow_status = 'active'
+ *   - release  → escrow_status = 'released', status = 'paid', buyer notified
+ *   - refund   → escrow_status = 'refunded', buyer notified
+ *   - dispute  → escrow_status = 'disputed'
+ *   - cursor persistence and resume-from-last-ledger
+ *   - exponential backoff retry and admin alert on exhaustion
  */
 
 jest.mock('../db/schema');
 jest.mock('../utils/stellar');
-jest.mock('../utils/mailer');
+jest.mock('../utils/mailer', () => ({
+  sendStatusUpdateEmail: jest.fn(),
+  sendContractAlert: jest.fn(),
+  sendLowStockAlert: jest.fn(),
+  sendOrderEmails: jest.fn(),
+}));
+jest.mock('../utils/pushNotifications', () => ({
+  sendPushToUser: jest.fn(),
+}));
 jest.mock('../logger');
-jest.mock('../utils/pushNotifications');
+jest.mock('../config', () => ({
+  sorobanEscrowContractId: 'CESCROW123',
+}));
 
 const db = require('../db/schema');
 const { getContractEvents } = require('../utils/stellar');
 const mailer = require('../utils/mailer');
+const { sendPushToUser } = require('../utils/pushNotifications');
 const logger = require('../logger');
 
-// ── #844 — Escrow event topic structure ───────────────────────────────────────
+// Fresh require each test group to reset module state
+function loadMonitor() {
+  jest.resetModules();
+  // Re-apply mocks after reset
+  jest.mock('../db/schema');
+  jest.mock('../utils/stellar');
+  jest.mock('../utils/mailer', () => ({
+    sendStatusUpdateEmail: jest.fn(),
+    sendContractAlert: jest.fn(),
+    sendLowStockAlert: jest.fn(),
+    sendOrderEmails: jest.fn(),
+  }));
+  jest.mock('../utils/pushNotifications', () => ({ sendPushToUser: jest.fn() }));
+  jest.mock('../logger');
+  jest.mock('../config', () => ({ sorobanEscrowContractId: 'CESCROW123' }));
+  return require('../jobs/contractMonitor');
+}
 
-describe('ContractMonitor - Escrow Event Structures (#844)', () => {
+const CONTRACT_ID = 'CESCROW123';
+
+// Helper: build a mock escrow event
+function makeEscrowEvent(action, orderId, data, ledger = 100) {
+  return {
+    id: `tx-${action}-${orderId}`,
+    topics: ['escrow', action, orderId],
+    data,
+    ledger,
+    ledgerClosedAt: new Date().toISOString(),
+    type: 'contract',
+  };
+}
+
+// ── deposit event ──────────────────────────────────────────────────────────────
+
+describe('deposit event → escrow_status = active', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  const makeEvent = (topics, data) => ({ topics, data, ledger: 100, ledgerClosedAt: new Date().toISOString(), type: 'contract' });
+  test('sets escrow_status to active for the matching order_id', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest.fn().mockResolvedValue({ rows: [] });
 
-  test('deposit event has correct topic structure', () => {
-    const ev = makeEvent(['escrow', 'deposit'], [1, 'BUYER', 'FARMER', 5000000, 1700000000]);
-    expect(ev.topics[0]).toBe('escrow');
-    expect(ev.topics[1]).toBe('deposit');
-    const [order_id, buyer, farmer, amount, timeout_unix] = ev.data;
-    expect(typeof order_id).toBe('number');
-    expect(typeof buyer).toBe('string');
-    expect(typeof farmer).toBe('string');
-    expect(typeof amount).toBe('number');
-    expect(typeof timeout_unix).toBe('number');
+    await _handlers.handleDeposit(CONTRACT_ID, ['escrow', 'deposit', 1001], null, 'txhash1');
+
+    expect(dbMod.query).toHaveBeenCalledWith(
+      expect.stringContaining("escrow_status = 'active'"),
+      [1001]
+    );
   });
 
-  test('release event has correct topic structure', () => {
-    const ev = makeEvent(['escrow', 'release'], [1, 4750000, 250000]);
-    expect(ev.topics[0]).toBe('escrow');
-    expect(ev.topics[1]).toBe('release');
-    const [order_id, farmer_amount, fee] = ev.data;
-    expect(typeof order_id).toBe('number');
-    expect(typeof farmer_amount).toBe('number');
-    expect(typeof fee).toBe('number');
-  });
+  test('ignores event when order_id is missing from topics', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest.fn();
 
-  test('refund event has correct topic structure', () => {
-    const ev = makeEvent(['escrow', 'refund'], [1, 5000000]);
-    expect(ev.topics[0]).toBe('escrow');
-    expect(ev.topics[1]).toBe('refund');
-    const [order_id, refunded_amount] = ev.data;
-    expect(typeof order_id).toBe('number');
-    expect(typeof refunded_amount).toBe('number');
-  });
+    await _handlers.handleDeposit(CONTRACT_ID, ['escrow', 'deposit'], null, null);
 
-  test('dispute event has correct topic structure', () => {
-    const ev = makeEvent(['escrow', 'dispute'], 1);
-    expect(ev.topics[0]).toBe('escrow');
-    expect(ev.topics[1]).toBe('dispute');
-    expect(typeof ev.data).toBe('number'); // order_id
-  });
-
-  test('resolved event has correct topic structure', () => {
-    const ev = makeEvent(['escrow', 'resolved'], [1, 100]);
-    expect(ev.topics[0]).toBe('escrow');
-    expect(ev.topics[1]).toBe('resolved');
-    const [order_id, buyer_pct] = ev.data;
-    expect(typeof order_id).toBe('number');
-    expect(buyer_pct).toBe(100); // refunded to buyer
-  });
-
-  test('resolved event buyer_pct=0 means released to farmer', () => {
-    const ev = makeEvent(['escrow', 'resolved'], [1, 0]);
-    const [, buyer_pct] = ev.data;
-    expect(buyer_pct).toBe(0);
-  });
-
-  test('monitor detects large transfer from escrow release event', async () => {
-    const { runMonitoringJob } = require('../jobs/contractMonitor');
-
-    db.query
-      .mockResolvedValueOnce({ rows: [{ contract_id: 'CABC123' }] }) // contracts_registry
-      .mockResolvedValueOnce({ rows: [] })  // check duplicate alert
-      .mockResolvedValueOnce({ rows: [{ id: 1, alert_type: 'large_transfer', contract_id: 'CABC123', message: 'Large transfer' }] }) // insert alert
-      .mockResolvedValueOnce({ rows: [{ email: 'admin@test.com' }] }) // admin email
-      .mockResolvedValueOnce({ rows: [] }); // unacknowledged alerts
-
-    getContractEvents.mockResolvedValue({
-      events: [
-        makeEvent(['escrow', 'release'], [42, 15_000_000_000, 500_000_000]),
-      ],
-    });
-
-    mailer.sendContractAlert = jest.fn().mockResolvedValue({});
-
-    jest.useFakeTimers();
-    const jobPromise = runMonitoringJob();
-    jest.runAllTimers();
-    await jobPromise;
-    jest.useRealTimers();
-
-    // No assertion on exact call — just verify it ran without throwing
-    expect(getContractEvents).toHaveBeenCalledWith('CABC123', expect.any(Object));
+    expect(dbMod.query).not.toHaveBeenCalled();
   });
 });
 
-// ── Retry logic ───────────────────────────────────────────────────────────────
+// ── release event ──────────────────────────────────────────────────────────────
 
-describe('ContractMonitor - Retry Logic', () => {
+describe('release event → escrow_status = released, status = paid, buyer notified', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('updates escrow_status and order status to paid', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })  // UPDATE orders
+      .mockResolvedValueOnce({ rows: [{ id: 2001, total_price: 10, email: 'buyer@test.com', name: 'Buyer', buyer_id: 5, product_name: 'Apples' }] }) // SELECT for notify
+      .mockResolvedValueOnce({ rows: [] }); // storeInvocation
+
+    const mailerMod = require('../utils/mailer');
+    mailerMod.sendStatusUpdateEmail = jest.fn().mockResolvedValue();
+    const pushMod = require('../utils/pushNotifications');
+    pushMod.sendPushToUser = jest.fn().mockResolvedValue();
+
+    await _handlers.handleRelease(CONTRACT_ID, ['escrow', 'release', 2001], [9750000, 250000], 'txhash2');
+
+    expect(dbMod.query).toHaveBeenCalledWith(
+      expect.stringContaining("escrow_status = 'released'"),
+      [2001]
+    );
+    expect(dbMod.query).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'paid'"),
+      [2001]
+    );
+  });
+
+  test('sends buyer email and push notification on release', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 2001, total_price: 10, email: 'buyer@test.com', name: 'Buyer', buyer_id: 5, product_name: 'Apples' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const mailerMod = require('../utils/mailer');
+    mailerMod.sendStatusUpdateEmail = jest.fn().mockResolvedValue();
+    const pushMod = require('../utils/pushNotifications');
+    pushMod.sendPushToUser = jest.fn().mockResolvedValue();
+
+    await _handlers.handleRelease(CONTRACT_ID, ['escrow', 'release', 2001], null, 'txhash2');
+
+    expect(mailerMod.sendStatusUpdateEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ newStatus: 'paid', recipientEmail: 'buyer@test.com' })
+    );
+    expect(pushMod.sendPushToUser).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({ title: 'Payment Released' })
+    );
+  });
+
+  test('skips notification gracefully when order not found in DB', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })  // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // SELECT — no row
+
+    const mailerMod = require('../utils/mailer');
+    mailerMod.sendStatusUpdateEmail = jest.fn();
+
+    await expect(
+      _handlers.handleRelease(CONTRACT_ID, ['escrow', 'release', 9999], null, null)
+    ).resolves.not.toThrow();
+
+    expect(mailerMod.sendStatusUpdateEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ── refund event ───────────────────────────────────────────────────────────────
+
+describe('refund event → escrow_status = refunded, buyer notified', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('sets escrow_status to refunded', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await _handlers.handleRefund(CONTRACT_ID, ['escrow', 'refund', 3001], 5000000, 'txhash3');
+
+    expect(dbMod.query).toHaveBeenCalledWith(
+      expect.stringContaining("escrow_status = 'refunded'"),
+      [3001]
+    );
+  });
+
+  test('sends buyer notification on refund', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 3001, total_price: 10, email: 'b@test.com', name: 'B', buyer_id: 7 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const mailerMod = require('../utils/mailer');
+    mailerMod.sendStatusUpdateEmail = jest.fn().mockResolvedValue();
+    const pushMod = require('../utils/pushNotifications');
+    pushMod.sendPushToUser = jest.fn().mockResolvedValue();
+
+    await _handlers.handleRefund(CONTRACT_ID, ['escrow', 'refund', 3001], 5000000, 'txhash3');
+
+    expect(mailerMod.sendStatusUpdateEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ newStatus: 'refunded', recipientEmail: 'b@test.com' })
+    );
+    expect(pushMod.sendPushToUser).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ title: 'Escrow Refunded' })
+    );
+  });
+});
+
+// ── dispute event ──────────────────────────────────────────────────────────────
+
+describe('dispute event → escrow_status = disputed', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('sets escrow_status to disputed', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest.fn().mockResolvedValue({ rows: [] });
+
+    await _handlers.handleDispute(CONTRACT_ID, ['escrow', 'dispute', 4001], 'GBUYER1', 'txhash4');
+
+    expect(dbMod.query).toHaveBeenCalledWith(
+      expect.stringContaining("escrow_status = 'disputed'"),
+      [4001]
+    );
+  });
+});
+
+// ── dispatchEvent routing ─────────────────────────────────────────────────────
+
+describe('dispatchEvent — routes events to correct handler', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test.each([
+    ['deposit', 1001, "escrow_status = 'active'"],
+    ['release', 2001, "escrow_status = 'released'"],
+    ['refund',  3001, "escrow_status = 'refunded'"],
+    ['dispute', 4001, "escrow_status = 'disputed'"],
+  ])('%s event updates escrow_status to correct value', async (action, orderId, expectedSql) => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    // Return empty rows for all queries (incl. notification lookups)
+    dbMod.query = jest.fn().mockResolvedValue({ rows: [] });
+    const mailerMod = require('../utils/mailer');
+    mailerMod.sendStatusUpdateEmail = jest.fn().mockResolvedValue();
+
+    const ev = makeEscrowEvent(action, orderId, null, 200);
+    await _handlers.dispatchEvent(CONTRACT_ID, ev);
+
+    expect(dbMod.query).toHaveBeenCalledWith(
+      expect.stringContaining(expectedSql),
+      [orderId]
+    );
+  });
+
+  test('non-escrow event is stored but does not update orders', async () => {
+    const { _handlers } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest.fn().mockResolvedValue({ rows: [] });
+
+    const ev = { topics: ['reward_token_set'], data: 'GADDR', id: 'tx1', ledger: 50 };
+    await _handlers.dispatchEvent(CONTRACT_ID, ev);
+
+    // storeInvocation should NOT have been called with any escrow_status SQL
+    const updateCalls = dbMod.query.mock.calls.filter(([sql]) =>
+      typeof sql === 'string' && sql.includes('escrow_status')
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+});
+
+// ── cursor persistence ────────────────────────────────────────────────────────
+
+describe('cursor — persist and resume from last ledger', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('getLastLedger returns 0 when no row exists', async () => {
+    const { _cursor } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest.fn().mockResolvedValue({ rows: [] });
+
+    const ledger = await _cursor.getLastLedger(CONTRACT_ID);
+    expect(ledger).toBe(0);
+  });
+
+  test('getLastLedger returns stored value', async () => {
+    const { _cursor } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest.fn().mockResolvedValue({ rows: [{ last_ledger: 12345 }] });
+
+    const ledger = await _cursor.getLastLedger(CONTRACT_ID);
+    expect(ledger).toBe(12345);
+  });
+
+  test('saveLastLedger calls upsert with correct args', async () => {
+    const { _cursor } = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest.fn().mockResolvedValue({ rows: [] });
+
+    await _cursor.saveLastLedger(CONTRACT_ID, 99999);
+
+    expect(dbMod.query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (contract_id)'),
+      [CONTRACT_ID, 99999]
+    );
+  });
+
+  test('runMonitoringJob resumes from last_ledger + 1', async () => {
+    const monitor = loadMonitor();
+    const dbMod = require('../db/schema');
+
+    dbMod.query = jest
+      .fn()
+      // contracts_registry query
+      .mockResolvedValueOnce({ rows: [{ contract_id: CONTRACT_ID }] })
+      // getLastLedger cursor
+      .mockResolvedValueOnce({ rows: [{ last_ledger: 5000 }] })
+      // saveLastLedger (if events returned)
+      .mockResolvedValue({ rows: [] });
+
+    const stellar = require('../utils/stellar');
+    stellar.getContractEvents = jest.fn().mockResolvedValue({ events: [] });
+
+    await monitor.runMonitoringJob();
+
+    // getContractEvents should have been called with fromLedger: 5001
+    expect(stellar.getContractEvents).toHaveBeenCalledWith(
+      CONTRACT_ID,
+      expect.objectContaining({ fromLedger: 5001 })
+    );
+  });
+
+  test('cursor is updated to highest ledger seen in batch', async () => {
+    const monitor = loadMonitor();
+    const dbMod = require('../db/schema');
+
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ contract_id: CONTRACT_ID }] }) // contracts_registry
+      .mockResolvedValueOnce({ rows: [{ last_ledger: 100 }] })          // getLastLedger
+      .mockResolvedValue({ rows: [] });                                  // all subsequent
+
+    const stellar = require('../utils/stellar');
+    stellar.getContractEvents = jest.fn().mockResolvedValue({
+      events: [
+        makeEscrowEvent('deposit', 1, null, 110),
+        makeEscrowEvent('release', 2, null, 115),
+      ],
+    });
+
+    await monitor.runMonitoringJob();
+
+    // saveLastLedger called with 115 (highest ledger in batch)
+    const upsertCall = dbMod.query.mock.calls.find(([sql]) =>
+      typeof sql === 'string' && sql.includes('ON CONFLICT (contract_id)')
+    );
+    expect(upsertCall).toBeDefined();
+    expect(upsertCall[1]).toEqual([CONTRACT_ID, 115]);
+  });
+});
+
+// ── retry logic ───────────────────────────────────────────────────────────────
+
+describe('retry logic — exponential backoff', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
   });
-
   afterEach(() => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
   });
 
-  test('should retry on RPC failure with exponential backoff', async () => {
-    const { runMonitoringJob } = require('../jobs/contractMonitor');
+  test('retries up to MAX_RETRIES with exponential backoff', async () => {
+    const monitor = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ contract_id: CONTRACT_ID }] })
+      .mockResolvedValue({ rows: [] });
 
-    // Mock database to return a contract
-    db.query.mockResolvedValueOnce({
-      rows: [{ contract_id: 'CABC123' }],
-    });
-
-    // Mock RPC to fail 3 times, then succeed
-    let callCount = 0;
-    getContractEvents.mockImplementation(() => {
-      callCount++;
-      if (callCount <= 3) {
-        return Promise.reject(new Error('RPC temporarily unavailable'));
-      }
+    const stellar = require('../utils/stellar');
+    let calls = 0;
+    stellar.getContractEvents = jest.fn().mockImplementation(() => {
+      calls++;
+      if (calls <= 3) return Promise.reject(new Error('RPC unavailable'));
       return Promise.resolve({ events: [] });
     });
 
-    // Run the job
-    const jobPromise = runMonitoringJob();
-
-    // Fast-forward through retries
-    // Retry 1: 1s backoff
-    jest.advanceTimersByTime(1000);
-    await Promise.resolve();
-
-    // Retry 2: 2s backoff
-    jest.advanceTimersByTime(2000);
-    await Promise.resolve();
-
-    // Retry 3: 4s backoff
-    jest.advanceTimersByTime(4000);
-    await Promise.resolve();
-
-    await jobPromise;
-
-    // Should have retried 3 times before succeeding
-    expect(getContractEvents).toHaveBeenCalledTimes(4);
-    expect(logger.warn).toHaveBeenCalledTimes(3);
-  });
-
-  test('should send admin notification after max retries exhausted', async () => {
-    const { runMonitoringJob } = require('../jobs/contractMonitor');
-
-    // Mock database
-    db.query
-      .mockResolvedValueOnce({
-        rows: [{ contract_id: 'CABC123' }],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ email: 'admin@test.com' }],
-      });
-
-    // Mock RPC to always fail
-    getContractEvents.mockRejectedValue(new Error('RPC unavailable'));
-
-    // Mock mailer
-    mailer.sendContractAlert.mockResolvedValue({});
-
-    // Run the job
-    const jobPromise = runMonitoringJob();
-
-    // Fast-forward through all retries
-    for (let i = 0; i < 5; i++) {
-      const backoff = Math.min(Math.pow(2, i) * 1000, 5 * 60 * 1000);
-      jest.advanceTimersByTime(backoff);
+    const jobPromise = monitor.runMonitoringJob();
+    for (let i = 0; i < 4; i++) {
+      jest.advanceTimersByTime(Math.min(Math.pow(2, i) * 1000, 60000));
       await Promise.resolve();
     }
-
     await jobPromise;
 
-    // Should have logged error
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('[ContractMonitor] Failed to fetch events'),
+    expect(stellar.getContractEvents).toHaveBeenCalledTimes(4);
+    const logMod = require('../logger');
+    expect(logMod.warn).toHaveBeenCalledTimes(3);
+  });
+
+  test('sends admin alert after MAX_RETRIES exhausted', async () => {
+    const monitor = loadMonitor();
+    const dbMod = require('../db/schema');
+    dbMod.query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ contract_id: CONTRACT_ID }] })
+      .mockResolvedValueOnce({ rows: [] })  // getLastLedger
+      .mockResolvedValueOnce({ rows: [{ email: 'admin@test.com' }] }); // admin lookup
+
+    const stellar = require('../utils/stellar');
+    stellar.getContractEvents = jest.fn().mockRejectedValue(new Error('RPC down'));
+
+    const mailerMod = require('../utils/mailer');
+    mailerMod.sendContractAlert = jest.fn().mockResolvedValue();
+
+    const jobPromise = monitor.runMonitoringJob();
+    for (let i = 0; i < 6; i++) {
+      jest.advanceTimersByTime(Math.min(Math.pow(2, i) * 1000, 60000));
+      await Promise.resolve();
+    }
+    await jobPromise;
+
+    const logMod = require('../logger');
+    expect(logMod.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch events'),
       expect.any(String)
     );
-
-    // Should have sent admin notification
-    expect(mailer.sendContractAlert).toHaveBeenCalledWith(
+    expect(mailerMod.sendContractAlert).toHaveBeenCalledWith(
       expect.objectContaining({
         to: 'admin@test.com',
-        alert: expect.objectContaining({
-          alert_type: 'monitor_failure',
-          contract_id: 'CABC123',
-        }),
+        alert: expect.objectContaining({ alert_type: 'monitor_failure', contract_id: CONTRACT_ID }),
       })
     );
   });
+});
 
-  test('should cap backoff at 5 minutes', async () => {
-    const { runMonitoringJob } = require('../jobs/contractMonitor');
+// ── legacy event topic structure tests (kept from #844) ───────────────────────
 
-    db.query.mockResolvedValueOnce({
-      rows: [{ contract_id: 'CABC123' }],
-    });
+describe('Escrow event topic structure (#844)', () => {
+  const makeEvent = (topics, data) => ({ topics, data, ledger: 100, type: 'contract' });
 
-    // Mock RPC to fail
-    getContractEvents.mockRejectedValue(new Error('RPC unavailable'));
+  test('deposit event topic structure', () => {
+    const ev = makeEvent(['escrow', 'deposit', 1], ['BUYER', 'FARMER', 5000000, 1700000000]);
+    expect(ev.topics[0]).toBe('escrow');
+    expect(ev.topics[1]).toBe('deposit');
+    expect(typeof ev.topics[2]).toBe('number');
+  });
 
-    // Mock admin query
-    db.query.mockResolvedValueOnce({
-      rows: [{ email: 'admin@test.com' }],
-    });
+  test('release event topic structure', () => {
+    const ev = makeEvent(['escrow', 'release', 1], [4750000, 250000]);
+    expect(ev.topics[1]).toBe('release');
+    const [farmer_amount, fee] = ev.data;
+    expect(farmer_amount).toBe(4750000);
+    expect(fee).toBe(250000);
+  });
 
-    mailer.sendContractAlert.mockResolvedValue({});
+  test('refund event topic structure', () => {
+    const ev = makeEvent(['escrow', 'refund', 1], [5000000]);
+    expect(ev.topics[1]).toBe('refund');
+    expect(ev.data[0]).toBe(5000000);
+  });
 
-    const jobPromise = runMonitoringJob();
-
-    // Advance through retries - the 5th retry should be capped at 5 minutes
-    for (let i = 0; i < 5; i++) {
-      const backoff = Math.min(Math.pow(2, i) * 1000, 5 * 60 * 1000);
-      jest.advanceTimersByTime(backoff);
-      await Promise.resolve();
-    }
-
-    await jobPromise;
-
-    // Verify the last backoff was capped
-    expect(logger.warn).toHaveBeenLastCalledWith(
-      expect.stringContaining('retrying in 300000ms'),
-      expect.any(String)
-    );
+  test('dispute event topic structure', () => {
+    const ev = makeEvent(['escrow', 'dispute', 1], 'GBUYER');
+    expect(ev.topics[1]).toBe('dispute');
+    expect(typeof ev.topics[2]).toBe('number');
   });
 });

--- a/backend/src/jobs/contractMonitor.js
+++ b/backend/src/jobs/contractMonitor.js
@@ -1,88 +1,245 @@
 /**
- * jobs/contractMonitor.js
+ * jobs/contractMonitor.js — Issue #862
  *
- * Watches Soroban contract invocations on the Stellar network and stores them in the
- * contract_invocations table (migration 013_contract_invocations.sql).
- * Handles the args size limit introduced in migration 019_contract_invocations_args_limit.sql.
+ * Subscribes to Soroban contract events for the configured escrow contract and
+ * updates order records in the database based on the event type:
  *
- * Features:
- * - Truncates invocation args to the args_limit bytes defined in migration 019
- * - Uses ON CONFLICT (tx_hash, invocation_index) DO NOTHING for idempotency
- * - Horizon stream reconnection with exponential backoff (max 60s)
- * - GET /api/contracts/:contractId/invocations returns recent invocations from DB, paginated
+ *   deposit  → orders.escrow_status = 'active'
+ *   release  → orders.escrow_status = 'released', orders.status = 'paid', notify buyer
+ *   refund   → orders.escrow_status = 'refunded', notify buyer
+ *   dispute  → orders.escrow_status = 'disputed'
+ *
+ * Resume behaviour:
+ *   The last processed ledger is persisted in `escrow_monitor_cursor`.
+ *   On restart the monitor resumes polling from that ledger + 1 so no events
+ *   are re-processed or skipped.
+ *
+ * Retry:
+ *   Exponential backoff up to MAX_BACKOFF_MS (60 s) on RPC failures.
+ *   After MAX_RETRIES consecutive failures an admin alert email is sent.
  */
+
+'use strict';
 
 const db = require('../db/schema');
 const { getContractEvents } = require('../utils/stellar');
+const { sendStatusUpdateEmail } = require('../utils/mailer');
+const { sendPushToUser } = require('../utils/pushNotifications');
 const logger = require('../logger');
+const config = require('../config');
 
 const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_RETRIES = 5;
-const MAX_BACKOFF_MS = 60 * 1000; // 60 seconds
-const ARGS_MAX_BYTES = 65535; // From migration 019
+const MAX_BACKOFF_MS = 60 * 1000; // 60 s
+const ARGS_MAX_BYTES = 65535;
 
-/**
- * Truncates args JSON to the maximum allowed byte length.
- * If args is null or already within limit, returns as-is.
- * Otherwise truncates and appends "... (truncated)" marker.
- */
+// ── helpers ──────────────────────────────────────────────────────────────────
+
 function truncateArgs(args) {
   if (args == null) return null;
   const json = JSON.stringify(args);
   if (Buffer.byteLength(json, 'utf8') <= ARGS_MAX_BYTES) return json;
-  
-  // Truncate to fit within limit with marker
   const marker = '... (truncated)';
-  const maxJsonBytes = ARGS_MAX_BYTES - Buffer.byteLength(marker, 'utf8');
-  let truncated = json;
-  while (Buffer.byteLength(truncated, 'utf8') > maxJsonBytes && truncated.length > 0) {
-    truncated = truncated.slice(0, -1);
-  }
-  return truncated + marker;
+  const limit = ARGS_MAX_BYTES - Buffer.byteLength(marker, 'utf8');
+  let t = json;
+  while (Buffer.byteLength(t, 'utf8') > limit) t = t.slice(0, -1);
+  return t + marker;
 }
 
-/**
- * Stores a contract invocation in the database with idempotency.
- * Uses ON CONFLICT to prevent duplicate inserts on replay.
- */
 async function storeInvocation({ contractId, method, args, txHash, invocationIndex, success, error }) {
   try {
     const truncatedArgs = truncateArgs(args);
     await db.query(
-      `INSERT INTO contract_invocations 
+      `INSERT INTO contract_invocations
          (contract_id, method, args, tx_hash, invocation_index, success, error, invoked_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, datetime('now'))
+       VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP)
        ON CONFLICT (tx_hash, invocation_index) DO NOTHING`,
-      [
-        contractId,
-        method,
-        truncatedArgs,
-        txHash || null,
-        invocationIndex,
-        success ? 1 : 0,
-        error || null,
-      ]
+      [contractId, method, truncatedArgs, txHash || null, invocationIndex, success ? 1 : 0, error || null]
     );
   } catch (err) {
     logger.error('[ContractMonitor] Failed to store invocation:', err.message);
   }
 }
 
+// ── cursor persistence ────────────────────────────────────────────────────────
+
+async function getLastLedger(contractId) {
+  try {
+    const { rows } = await db.query(
+      `SELECT last_ledger FROM escrow_monitor_cursor WHERE contract_id = $1`,
+      [contractId]
+    );
+    return rows[0] ? Number(rows[0].last_ledger) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function saveLastLedger(contractId, ledger) {
+  try {
+    await db.query(
+      `INSERT INTO escrow_monitor_cursor (contract_id, last_ledger, updated_at)
+       VALUES ($1, $2, CURRENT_TIMESTAMP)
+       ON CONFLICT (contract_id) DO UPDATE
+         SET last_ledger = EXCLUDED.last_ledger,
+             updated_at  = CURRENT_TIMESTAMP`,
+      [contractId, ledger]
+    );
+  } catch (err) {
+    logger.warn('[ContractMonitor] Could not persist cursor:', err.message);
+  }
+}
+
+// ── event handlers ────────────────────────────────────────────────────────────
+
 /**
- * Monitors a single contract for invocations with exponential backoff retry.
+ * Extracts the numeric order_id from the event topics array.
+ * Escrow events use topic[2] as the order_id (e.g. ["escrow","deposit",<order_id>]).
  */
+function extractOrderId(topics) {
+  const raw = topics[2];
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function handleDeposit(contractId, topics, data, txHash) {
+  const orderId = extractOrderId(topics);
+  if (!orderId) return;
+
+  logger.info(`[ContractMonitor] deposit event — order #${orderId}`);
+
+  await db.query(
+    `UPDATE orders SET escrow_status = 'active' WHERE id = $1`,
+    [orderId]
+  ).catch((e) => logger.error('[ContractMonitor] deposit DB update failed:', e.message));
+
+  await storeInvocation({ contractId, method: 'deposit', args: data, txHash, invocationIndex: 0, success: true, error: null });
+}
+
+async function handleRelease(contractId, topics, data, txHash) {
+  const orderId = extractOrderId(topics);
+  if (!orderId) return;
+
+  logger.info(`[ContractMonitor] release event — order #${orderId}`);
+
+  await db.query(
+    `UPDATE orders SET escrow_status = 'released', status = 'paid' WHERE id = $1`,
+    [orderId]
+  ).catch((e) => logger.error('[ContractMonitor] release DB update failed:', e.message));
+
+  // Notify buyer
+  try {
+    const { rows } = await db.query(
+      `SELECT o.id, o.total_price, u.email, u.name, p.name AS product_name
+       FROM orders o
+       JOIN users u ON u.id = o.buyer_id
+       JOIN products p ON p.id = o.product_id
+       WHERE o.id = $1`,
+      [orderId]
+    );
+    if (rows[0]) {
+      const order = rows[0];
+      await sendStatusUpdateEmail({ order, newStatus: 'paid', recipientEmail: order.email, recipientName: order.name })
+        .catch((e) => logger.warn('[ContractMonitor] release email failed (non-fatal):', e.message));
+      await sendPushToUser(order.buyer_id, {
+        title: 'Payment Released',
+        body: `Your escrow for order #${orderId} has been released.`,
+      }).catch(() => {});
+    }
+  } catch (e) {
+    logger.warn('[ContractMonitor] release notification failed (non-fatal):', e.message);
+  }
+
+  await storeInvocation({ contractId, method: 'release', args: data, txHash, invocationIndex: 0, success: true, error: null });
+}
+
+async function handleRefund(contractId, topics, data, txHash) {
+  const orderId = extractOrderId(topics);
+  if (!orderId) return;
+
+  logger.info(`[ContractMonitor] refund event — order #${orderId}`);
+
+  await db.query(
+    `UPDATE orders SET escrow_status = 'refunded' WHERE id = $1`,
+    [orderId]
+  ).catch((e) => logger.error('[ContractMonitor] refund DB update failed:', e.message));
+
+  // Notify buyer
+  try {
+    const { rows } = await db.query(
+      `SELECT o.id, o.total_price, u.email, u.name, u.id AS buyer_id
+       FROM orders o
+       JOIN users u ON u.id = o.buyer_id
+       WHERE o.id = $1`,
+      [orderId]
+    );
+    if (rows[0]) {
+      const order = rows[0];
+      await sendStatusUpdateEmail({ order, newStatus: 'refunded', recipientEmail: order.email, recipientName: order.name })
+        .catch((e) => logger.warn('[ContractMonitor] refund email failed (non-fatal):', e.message));
+      await sendPushToUser(order.buyer_id, {
+        title: 'Escrow Refunded',
+        body: `Your escrow for order #${orderId} has been refunded.`,
+      }).catch(() => {});
+    }
+  } catch (e) {
+    logger.warn('[ContractMonitor] refund notification failed (non-fatal):', e.message);
+  }
+
+  await storeInvocation({ contractId, method: 'refund', args: data, txHash, invocationIndex: 0, success: true, error: null });
+}
+
+async function handleDispute(contractId, topics, data, txHash) {
+  const orderId = extractOrderId(topics);
+  if (!orderId) return;
+
+  logger.info(`[ContractMonitor] dispute event — order #${orderId}`);
+
+  await db.query(
+    `UPDATE orders SET escrow_status = 'disputed' WHERE id = $1`,
+    [orderId]
+  ).catch((e) => logger.error('[ContractMonitor] dispute DB update failed:', e.message));
+
+  await storeInvocation({ contractId, method: 'dispute', args: data, txHash, invocationIndex: 0, success: true, error: null });
+}
+
+// ── dispatch ──────────────────────────────────────────────────────────────────
+
+async function dispatchEvent(contractId, ev) {
+  const topics = ev.topics || [];
+  // Escrow events use topic[0] = 'escrow', topic[1] = action
+  if (String(topics[0]) !== 'escrow') return;
+  const action = String(topics[1] || '');
+  const txHash = ev.id || null;
+
+  switch (action) {
+    case 'deposit': return handleDeposit(contractId, topics, ev.data, txHash);
+    case 'release': return handleRelease(contractId, topics, ev.data, txHash);
+    case 'refund':  return handleRefund(contractId, topics, ev.data, txHash);
+    case 'dispute': return handleDispute(contractId, topics, ev.data, txHash);
+    default:
+      // Store other events without DB side-effects
+      await storeInvocation({ contractId, method: action || 'unknown', args: ev.data, txHash, invocationIndex: 0, success: true, error: null });
+  }
+}
+
+// ── monitor loop ──────────────────────────────────────────────────────────────
+
 async function monitorContract(contractId, retryCount = 0) {
-  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const lastLedger = await getLastLedger(contractId);
+
+  // Build filter: resume from last processed ledger + 1, or fall back to 1 h ago
+  const filters = lastLedger > 0
+    ? { fromLedger: lastLedger + 1, limit: 200 }
+    : { from: new Date(Date.now() - 60 * 60 * 1000).toISOString(), limit: 200 };
 
   let result;
   try {
-    result = await getContractEvents(contractId, { from: oneHourAgo, limit: 200 });
+    result = await getContractEvents(contractId, filters);
   } catch (err) {
     if (retryCount < MAX_RETRIES) {
-      const backoffMs = Math.min(
-        Math.pow(2, retryCount) * 1000,
-        MAX_BACKOFF_MS
-      );
+      const backoffMs = Math.min(Math.pow(2, retryCount) * 1000, MAX_BACKOFF_MS);
       logger.warn(
         `[ContractMonitor] Failed to fetch events for ${contractId}, retrying in ${backoffMs}ms (attempt ${retryCount + 1}/${MAX_RETRIES}):`,
         err.message
@@ -91,45 +248,55 @@ async function monitorContract(contractId, retryCount = 0) {
       return monitorContract(contractId, retryCount + 1);
     }
 
-    logger.error(
-      `[ContractMonitor] Failed to fetch events for ${contractId} after ${MAX_RETRIES} retries:`,
-      err.message
-    );
+    logger.error(`[ContractMonitor] Failed to fetch events for ${contractId} after ${MAX_RETRIES} retries:`, err.message);
+
+    // Send admin alert (non-fatal)
+    try {
+      const { rows: admins } = await db.query(`SELECT email FROM users WHERE role = 'admin' LIMIT 1`);
+      if (admins[0]) {
+        const { sendContractAlert } = require('../utils/mailer');
+        await sendContractAlert({
+          to: admins[0].email,
+          alert: { alert_type: 'monitor_failure', contract_id: contractId, message: err.message },
+        }).catch(() => {});
+      }
+    } catch { /* non-fatal */ }
     return;
   }
 
   const events = result.events || [];
-  let invocationIndex = 0;
+  let highestLedger = lastLedger;
 
   for (const ev of events) {
-    // Extract method name from topics if available
-    const topics = ev.topics || [];
-    const method = topics[0] ? String(topics[0]) : 'unknown';
-    
-    // Determine success based on event type and topics
-    const isFailure = topics.some((t) => typeof t === 'string' && /fail|error|revert/i.test(t)) || ev.type === 'diagnostic';
-    
-    await storeInvocation({
-      contractId,
-      method,
-      args: ev.data || null,
-      txHash: ev.id || null,
-      invocationIndex: invocationIndex++,
-      success: !isFailure,
-      error: isFailure ? 'Contract invocation failed' : null,
-    });
+    await dispatchEvent(contractId, ev);
+    if (ev.ledger && Number(ev.ledger) > highestLedger) {
+      highestLedger = Number(ev.ledger);
+    }
+  }
+
+  // Persist cursor only when we actually advanced
+  if (highestLedger > lastLedger) {
+    await saveLastLedger(contractId, highestLedger);
   }
 }
 
 async function runMonitoringJob() {
+  // Use the configured escrow contract if no registry is available
+  const escrowContractId = config.sorobanEscrowContractId;
+
+  let contracts = [];
   try {
-    const { rows: contracts } = await db.query(
-      `SELECT contract_id FROM contracts_registry`
-    );
-    await Promise.all(contracts.map((c) => monitorContract(c.contract_id)));
-  } catch (err) {
-    logger.error('[ContractMonitor] Job error:', err.message);
+    const { rows } = await db.query(`SELECT contract_id FROM contracts_registry`);
+    contracts = rows;
+  } catch {
+    // table may not exist in all envs — fall back to config
   }
+
+  if (escrowContractId && !contracts.some((c) => c.contract_id === escrowContractId)) {
+    contracts.push({ contract_id: escrowContractId });
+  }
+
+  await Promise.all(contracts.map((c) => monitorContract(c.contract_id)));
 }
 
 function startContractMonitor() {
@@ -138,4 +305,10 @@ function startContractMonitor() {
   return setInterval(runMonitoringJob, POLL_INTERVAL_MS);
 }
 
-module.exports = { startContractMonitor, runMonitoringJob };
+module.exports = {
+  startContractMonitor,
+  runMonitoringJob,
+  // exported for testing
+  _handlers: { handleDeposit, handleRelease, handleRefund, handleDispute, dispatchEvent },
+  _cursor: { getLastLedger, saveLastLedger },
+};


### PR DESCRIPTION
- dispatch deposit/release/refund/dispute events to order DB updates
- deposit  -> escrow_status = active
- release  -> escrow_status = released + status = paid + notify buyer
- refund   -> escrow_status = refunded + notify buyer
- dispute  -> escrow_status = disputed
- persist last processed ledger in escrow_monitor_cursor table
- resume from last_ledger+1 on restart; fallback to 1h window on first run
- migration 030: CREATE TABLE escrow_monitor_cursor
- exports _handlers and _cursor for unit testing
- updated contractMonitor.test.js: covers all 4 event types, cursor
  persistence, resume-from-ledger, backoff retry, admin alert on exhaustion
  
  closes #862 