### PR TITLE
feat(reward-token): extract common burn logic into helper

### DIFF
--- a/contract/reward-token/src/lib.rs
+++ b/contract/reward-token/src/lib.rs
@@ -242,6 +242,19 @@ impl RewardToken {
         (total - locked).max(0)
     }
 
+    /// Private helper: centralizes balance decrement and supply update logic.
+    /// Returns the actual amount burned (which may be less than requested if capped). (#978)
+    fn burn_internal(env: &Env, from: &Address, amount: i128) -> i128 {
+        let balance = Self::balance(env.clone(), from.clone());
+        let actual = if amount > balance { balance } else { amount };
+        if actual > 0 {
+            env.storage().persistent().set(&DataKey::Balance(from.clone()), &(balance - actual));
+            let supply: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+            env.storage().instance().set(&DataKey::TotalSupply, &(supply - actual));
+        }
+        actual
+    }
+
     pub fn burn(env: Env, from: Address, amount: i128) {
         from.require_auth();
         if amount <= 0 {
@@ -251,31 +264,8 @@ impl RewardToken {
         if balance < amount {
             panic!("insufficient balance to burn");
         }
-        env.storage().persistent().set(&DataKey::Balance(from.clone()), &(balance - amount));
-        let supply: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
-        env.storage().instance().set(&DataKey::TotalSupply, &(supply - amount));
+        Self::burn_internal(&env, &from, amount);
         env.events().publish(("burn", from), amount);
-    }
-
-    /// Admin-callable burn for reward reclamation on refund/dispute (#847).
-    /// Burns up to `amount` from `from`; if balance < amount the burn is capped
-    /// at the available balance (safe, never panics on insufficient balance).
-    /// Emits ("reward", "burn", from, actual_amount).
-    pub fn burn_reward(env: Env, from: Address, amount: i128) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        admin.require_auth();
-        if amount <= 0 {
-            panic!("amount must be positive");
-        }
-        let balance = Self::balance(env.clone(), from.clone());
-        if balance == 0 {
-            return;
-        }
-        let actual = if amount > balance { balance } else { amount };
-        env.storage().persistent().set(&DataKey::Balance(from.clone()), &(balance - actual));
-        let supply: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
-        env.storage().instance().set(&DataKey::TotalSupply, &(supply - actual));
-        env.events().publish(("reward", "burn", from), actual);
     }
 
     /// Admin-callable burn for reward reclamation on refund/dispute (#847).
@@ -290,13 +280,9 @@ impl RewardToken {
         }
         let balance = Self::balance(env.clone(), from.clone());
         if balance == 0 {
-            return; // nothing to burn
+            return;
         }
-        // Cap at available balance (#847 acceptance criterion)
-        let actual = if amount > balance { balance } else { amount };
-        env.storage().persistent().set(&DataKey::Balance(from.clone()), &(balance - actual));
-        let supply: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
-        env.storage().instance().set(&DataKey::TotalSupply, &(supply - actual));
+        let actual = Self::burn_internal(&env, &from, amount);
         env.events().publish(("reward", "burn", from), actual);
     }
 


### PR DESCRIPTION
## Summary

- Add private burn_internal() helper centralizing balance/supply decrement logic
- Refactor burn() to use helper while maintaining self-auth requirement  
- Refactor burn_reward() to use helper with admin-auth and balance cap
- Remove duplicate burn_reward() function definition
- Existing test behavior unchanged; minimal diff

## Validation

- Both burn and burn_reward now use shared supply-accounting logic
- Authorization checks remain distinct (self vs admin)
- No functional changes to existing behavior
- Prevents future divergence in burn logic

Closes #978