### PR TITLE
Creator Earnings & Escrow: batch credit, pause, lifetime tracking, streaming module wiring

### DIFF
--- a/contracts/creator-earnings/src/lib.rs
+++ b/contracts/creator-earnings/src/lib.rs
@@ -54,6 +54,8 @@ pub enum DataKey {
     Platform,
     /// Admin pause flag: if true, credit() and claim() return Paused error.
     PausedState,
+    /// Lifetime total earnings for a creator (farmer_amount only, never reset).
+    LifetimeEarned(Address),
 }
 
 // ---------------------------------------------------------------------------
@@ -116,9 +118,14 @@ impl CreatorEarningsContract {
         let farmer_amount: i128 = amount - fee_amount;
 
         // Accumulate the creator's claimable balance.
-        let key = DataKey::Balance(creator.clone());
-        let prev: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-        env.storage().persistent().set(&key, &(prev + farmer_amount));
+        let balance_key = DataKey::Balance(creator.clone());
+        let prev: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
+        env.storage().persistent().set(&balance_key, &(prev + farmer_amount));
+
+        // Accumulate lifetime earnings (independent of claimable balance, never reset).
+        let lifetime_key = DataKey::LifetimeEarned(creator.clone());
+        let lifetime_prev: i128 = env.storage().persistent().get(&lifetime_key).unwrap_or(0);
+        env.storage().persistent().set(&lifetime_key, &(lifetime_prev + farmer_amount));
 
         Ok((farmer_amount, fee_amount))
     }
@@ -198,6 +205,16 @@ impl CreatorEarningsContract {
         env.storage()
             .persistent()
             .get(&DataKey::Balance(creator))
+            .unwrap_or(0)
+    }
+
+    /// Read-only: return the lifetime total earnings (farmer_amount only) for
+    /// `creator`. This counter is incremented on every credit() and never reset
+    /// by claim() — it reflects total earnings across all time.
+    pub fn lifetime_earned(env: Env, creator: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::LifetimeEarned(creator))
             .unwrap_or(0)
     }
 }
@@ -596,5 +613,69 @@ mod test {
         let result = CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0);
         assert!(result.is_ok());
         assert_eq!(CreatorEarningsContract::balance(env.clone(), creator), 1_000);
+    }
+
+    #[test]
+    fn lifetime_earned_tracks_total_credits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        CreatorEarningsContract::init(env.clone(), Address::generate(&env));
+
+        let creator = Address::generate(&env);
+
+        // Initially zero.
+        assert_eq!(CreatorEarningsContract::lifetime_earned(env.clone(), creator.clone()), 0);
+
+        // Credit 1_000 with 0 fee → farmer gets 1_000, lifetime becomes 1_000.
+        CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0).unwrap();
+        assert_eq!(CreatorEarningsContract::lifetime_earned(env.clone(), creator.clone()), 1_000);
+
+        // Credit 500 with 250 bps fee → farmer gets 487.5 (truncated to 487 due to integer division).
+        // 500 * 250 / 10_000 = 12.5 (truncated to 12), so farmer gets 500 - 12 = 488.
+        CreatorEarningsContract::credit(env.clone(), creator.clone(), 500, 250).unwrap();
+        // lifetime_earned should be 1_000 + 488 = 1_488.
+        assert_eq!(CreatorEarningsContract::lifetime_earned(env.clone(), creator.clone()), 1_488);
+    }
+
+    #[test]
+    fn lifetime_earned_survives_claim() {
+        let env = Env::default();
+        env.mock_all_auths();
+        CreatorEarningsContract::init(env.clone(), Address::generate(&env));
+
+        let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        // Credit 1_000.
+        CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0).unwrap();
+        assert_eq!(CreatorEarningsContract::lifetime_earned(env.clone(), creator.clone()), 1_000);
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), creator.clone()), 1_000);
+
+        // Manually reset balance to 0 (simulates a successful claim).
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(creator.clone()), &0_i128);
+
+        // balance() is now zero, but lifetime_earned should be unchanged.
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), creator.clone()), 0);
+        assert_eq!(CreatorEarningsContract::lifetime_earned(env.clone(), creator.clone()), 1_000);
+    }
+
+    #[test]
+    fn lifetime_earned_accumulates_across_multiple_credits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        CreatorEarningsContract::init(env.clone(), Address::generate(&env));
+
+        let creator = Address::generate(&env);
+
+        // Multiple credits with various fees.
+        CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0).unwrap();
+        CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0).unwrap();
+        CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 500).unwrap(); // 50% fee
+
+        // Last credit: 1_000 * 500 / 10_000 = 50 fee, farmer gets 950.
+        // Total: 1_000 + 1_000 + 950 = 2_950.
+        assert_eq!(CreatorEarningsContract::lifetime_earned(env.clone(), creator), 2_950);
     }
 }

--- a/contracts/creator-earnings/src/lib.rs
+++ b/contracts/creator-earnings/src/lib.rs
@@ -37,6 +37,8 @@ pub enum EarningsError {
     NotInitialised = 4,
     /// `batch_credit` was called with more than `MAX_BATCH_CREDIT` entries.
     BatchTooLarge = 5,
+    /// Contract is paused; credit() and claim() are disabled.
+    Paused = 6,
 }
 
 // ---------------------------------------------------------------------------
@@ -50,6 +52,8 @@ pub enum DataKey {
     Balance(Address),
     /// Platform fee recipient address.
     Platform,
+    /// Admin pause flag: if true, credit() and claim() return Paused error.
+    PausedState,
 }
 
 // ---------------------------------------------------------------------------
@@ -67,6 +71,20 @@ impl CreatorEarningsContract {
         env.storage().instance().set(&DataKey::Platform, &platform);
     }
 
+    /// Admin-only: set or clear the pause flag.
+    /// When paused, credit() and claim() return Paused error.
+    /// balance() continues to work.
+    pub fn set_paused(env: Env, paused: bool) -> Result<(), EarningsError> {
+        let platform: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Platform)
+            .ok_or(EarningsError::NotInitialised)?;
+        platform.require_auth();
+        env.storage().instance().set(&DataKey::PausedState, &paused);
+        Ok(())
+    }
+
     /// Credit `amount` tokens to `creator`, splitting off `fee_bps` basis
     /// points to the platform.  The caller must have already transferred
     /// `amount` tokens to this contract address before calling.
@@ -78,6 +96,15 @@ impl CreatorEarningsContract {
         amount: i128,
         fee_bps: u32,
     ) -> Result<(i128, i128), EarningsError> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::PausedState)
+            .unwrap_or(false);
+        if paused {
+            return Err(EarningsError::Paused);
+        }
+
         if amount <= 0 {
             return Err(EarningsError::InvalidAmount);
         }
@@ -137,6 +164,15 @@ impl CreatorEarningsContract {
         creator: Address,
         token: Address,
     ) -> Result<i128, EarningsError> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::PausedState)
+            .unwrap_or(false);
+        if paused {
+            return Err(EarningsError::Paused);
+        }
+
         creator.require_auth();
 
         let key = DataKey::Balance(creator.clone());
@@ -483,5 +519,82 @@ mod test {
         let entries: Vec<(Address, i128, u32)> = Vec::new(&env);
         let results = CreatorEarningsContract::batch_credit(env, entries).unwrap();
         assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn set_paused_and_credit_rejected_when_paused() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let platform = Address::generate(&env);
+        CreatorEarningsContract::init(env.clone(), platform.clone());
+
+        let creator = Address::generate(&env);
+
+        // Initially unpaused: credit should succeed.
+        let result = CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0);
+        assert!(result.is_ok());
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), creator.clone()), 1_000);
+
+        // Pause the contract.
+        let pause_result = CreatorEarningsContract::set_paused(env.clone(), true);
+        assert!(pause_result.is_ok());
+
+        // credit() should now return Paused error.
+        let result = CreatorEarningsContract::credit(env.clone(), creator.clone(), 500, 0);
+        assert_eq!(result, Err(EarningsError::Paused));
+
+        // balance() should still work while paused.
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), creator.clone()), 1_000);
+    }
+
+    #[test]
+    fn set_paused_and_claim_rejected_when_paused() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let platform = Address::generate(&env);
+        CreatorEarningsContract::init(env.clone(), platform.clone());
+
+        let creator = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        // Seed a balance.
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(creator.clone()), &500_i128);
+
+        // Pause the contract.
+        CreatorEarningsContract::set_paused(env.clone(), true).unwrap();
+
+        // claim() should return Paused error.
+        let result = CreatorEarningsContract::claim(env.clone(), creator.clone(), token);
+        assert_eq!(result, Err(EarningsError::Paused));
+
+        // balance() should still work while paused.
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), creator), 500);
+    }
+
+    #[test]
+    fn unpause_allows_credit_and_claim() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let platform = Address::generate(&env);
+        CreatorEarningsContract::init(env.clone(), platform.clone());
+
+        let creator = Address::generate(&env);
+
+        // Pause.
+        CreatorEarningsContract::set_paused(env.clone(), true).unwrap();
+
+        // Verify credit is rejected.
+        let result = CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0);
+        assert_eq!(result, Err(EarningsError::Paused));
+
+        // Unpause.
+        CreatorEarningsContract::set_paused(env.clone(), false).unwrap();
+
+        // credit() should now succeed.
+        let result = CreatorEarningsContract::credit(env.clone(), creator.clone(), 1_000, 0);
+        assert!(result.is_ok());
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), creator), 1_000);
     }
 }

--- a/contracts/creator-earnings/src/lib.rs
+++ b/contracts/creator-earnings/src/lib.rs
@@ -13,7 +13,11 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, token, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_short, token, Address, Env, Vec};
+
+/// Maximum number of entries accepted by `batch_credit` in a single call —
+/// keeps the transaction under Stellar's operation limit.
+const MAX_BATCH_CREDIT: u32 = 20;
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -31,6 +35,8 @@ pub enum EarningsError {
     ZeroBalance = 3,
     /// Platform address has not been initialised.
     NotInitialised = 4,
+    /// `batch_credit` was called with more than `MAX_BATCH_CREDIT` entries.
+    BatchTooLarge = 5,
 }
 
 // ---------------------------------------------------------------------------
@@ -88,6 +94,40 @@ impl CreatorEarningsContract {
         env.storage().persistent().set(&key, &(prev + farmer_amount));
 
         Ok((farmer_amount, fee_amount))
+    }
+
+    /// Batch credit multiple (creator, amount, fee_bps) tuples in a single call.
+    /// - At most `MAX_BATCH_CREDIT` (20) entries are accepted; otherwise
+    ///   `EarningsError::BatchTooLarge`.
+    /// - Each credit is independent: a failing one emits
+    ///   ("earnings", "batch_credit_error", creator) and the batch continues.
+    /// - Returns one `(creator, succeeded)` pair per input entry, in order.
+    pub fn batch_credit(
+        env: Env,
+        entries: Vec<(Address, i128, u32)>,
+    ) -> Result<Vec<(Address, bool)>, EarningsError> {
+        if entries.len() > MAX_BATCH_CREDIT as usize {
+            return Err(EarningsError::BatchTooLarge);
+        }
+
+        let mut results: Vec<(Address, bool)> = Vec::new(&env);
+        for (creator, amount, fee_bps) in entries.iter() {
+            match Self::credit(env.clone(), creator.clone(), amount, fee_bps) {
+                Ok(_) => results.push_back((creator.clone(), true)),
+                Err(_) => {
+                    env.events().publish(
+                        (
+                            symbol_short!("earnings"),
+                            soroban_sdk::Symbol::new(&env, "batch_credit_error"),
+                            creator.clone(),
+                        ),
+                        (),
+                    );
+                    results.push_back((creator.clone(), false));
+                }
+            }
+        }
+        Ok(results)
     }
 
     /// Transfer the caller's entire accumulated balance to themselves via
@@ -387,5 +427,61 @@ mod test {
 
         assert_eq!(CreatorEarningsContract::balance(env.clone(), alice), 1_000);
         assert_eq!(CreatorEarningsContract::balance(env.clone(), bob), 2_000);
+    }
+
+    #[test]
+    fn batch_credit_too_large() {
+        let env = Env::default();
+        env.mock_all_auths();
+        CreatorEarningsContract::init(env.clone(), Address::generate(&env));
+
+        let mut entries: Vec<(Address, i128, u32)> = Vec::new(&env);
+        for _ in 0..21 {
+            entries.push_back((Address::generate(&env), 1_000, 0));
+        }
+
+        let result = CreatorEarningsContract::batch_credit(env, entries);
+        assert_eq!(result, Err(EarningsError::BatchTooLarge));
+    }
+
+    #[test]
+    fn batch_credit_partial_failure_continues() {
+        let env = Env::default();
+        env.mock_all_auths();
+        CreatorEarningsContract::init(env.clone(), Address::generate(&env));
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let charlie = Address::generate(&env);
+
+        let mut entries: Vec<(Address, i128, u32)> = Vec::new(&env);
+        entries.push_back((alice.clone(), 1_000, 0));
+        entries.push_back((bob.clone(), 0, 0)); // Invalid: amount = 0
+        entries.push_back((charlie.clone(), 2_000, 250));
+
+        let results = CreatorEarningsContract::batch_credit(env.clone(), entries).unwrap();
+
+        // Should have 3 results, with bob's failing (false).
+        assert_eq!(results.len(), 3);
+        assert_eq!(results.get(0), (alice.clone(), true));
+        assert_eq!(results.get(1), (bob.clone(), false));
+        assert_eq!(results.get(2), (charlie.clone(), true));
+
+        // Verify balances — only alice and charlie should have credits.
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), alice), 1_000);
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), bob), 0); // Not credited due to error
+        // charlie: 2_000 - (2_000 * 250 / 10_000) = 2_000 - 50 = 1_950
+        assert_eq!(CreatorEarningsContract::balance(env.clone(), charlie), 1_950);
+    }
+
+    #[test]
+    fn batch_credit_empty_is_ok() {
+        let env = Env::default();
+        env.mock_all_auths();
+        CreatorEarningsContract::init(env.clone(), Address::generate(&env));
+
+        let entries: Vec<(Address, i128, u32)> = Vec::new(&env);
+        let results = CreatorEarningsContract::batch_credit(env, entries).unwrap();
+        assert_eq!(results.len(), 0);
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+mod stream;
+mod validate_id;
+
 use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_short, token, Address, Bytes, BytesN, Env, Vec};
 
 // TTL thresholds for persistent escrow entries (~57–115 days at 5 s/ledger).


### PR DESCRIPTION
## Summary

Adds batch operations, emergency circuit breaker, and lifetime earnings tracking to the Creator Earnings contract; wires payment streaming into the Escrow contract.

## Changes

### #968 — Escrow: wire stream.rs & validate_id.rs modules into contract
- Added `mod stream;` and `mod validate_id;` declarations to `contracts/escrow/src/lib.rs`
- Makes the 365-line PaymentStream implementation and ID validation logic part of the compiled contract
- Streaming tests now run under `cargo test`

### #965 — Creator Earnings: add batch_credit entrypoint
- Added `batch_credit(env, entries: Vec<(Address, i128, u32)>)` with 20-entry limit
- Per-entry error handling: failed credits emit a `batch_credit_error` event and batch continues
- Returns `Vec<(Address, bool)>` with success status per entry
- Reduces transaction overhead for high-volume settlement runs

### #966 — Creator Earnings: add pause/circuit breaker for credit() and claim()
- Added admin-only `set_paused(env, paused: bool)` function
- `PausedState` storage key; `Paused` error variant
- `credit()` and `claim()` return error when paused; `balance()` continues to work
- Enables rapid response to exploits without requiring a contract upgrade

### #967 — Creator Earnings: add lifetime_earned tracking for analytics/tax reporting
- Added `LifetimeEarned(Address)` counter, incremented on every `credit()`
- Survives `claim()` calls — provides complete earnings history
- New `lifetime_earned(env, creator) -> i128` getter for dashboard and 1099 reporting

## Test coverage

- Batch size validation, partial failure continuation, empty batch
- Pause/unpause blocking and allowing operations
- Lifetime counter accumulation and persistence across claims

Closes #968, Closes #965, Closes #966, Closes #967

---

🤖 Implemented with Claude Code