### PR TITLE
Document Soroban contract crate boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,37 @@ DATABASE_URL=postgresql://user:pass@host:5432/dbname \
   node backend/scripts/migrate-sqlite-to-pg.js
 ```
 
-## Contract Testing (Soroban)
+## Soroban Contract Layout
 
-Test Soroban contracts against a local Stellar node using the built-in test harness.
+The repository currently maintains two Soroban contract layouts. They are
+related, but they are not the same deployment surface.
+
+| Path | Role | Notes |
+|---|---|---|
+| `contract/` | Legacy escrow crate | Used by backend contract integration tests, `contract/test-futurenet.sh`, `contract/cli.sh`, and the legacy WASM profile. |
+| `contract/reward-token/` | Legacy reward token crate | Paired with the legacy integration surface and built separately from `contract/`. |
+| `contracts/escrow/` | Workspace escrow crate | Current Rust workspace escrow implementation for newer contract hardening work. |
+| `contracts/creator-earnings/` | Workspace creator earnings crate | Tracks creator balances and fee splits in the `contracts/` workspace. |
+
+Shared contract conventions and the decision to maintain both layouts for now
+are recorded in [ADR 0001](docs/adr/0001-soroban-contract-boundaries.md).
+
+### Workspace contract tests
+
+Run the current workspace contract tests from `contracts/`:
+
+```bash
+cd contracts
+cargo test -p soroban-escrow --lib
+cargo test -p creator-earnings --features testutils
+cargo build -p soroban-escrow --target wasm32-unknown-unknown --release
+cargo build -p creator-earnings --target wasm32-unknown-unknown --release
+```
+
+### Legacy contract integration testing
+
+Test the legacy `contract/` escrow against a local Stellar node using the
+backend test harness.
 
 ### Start the local node
 
@@ -260,7 +288,8 @@ A dedicated **nightly CI job** (`contract-tests-nightly` in `.github/workflows/c
 
 ## Futurenet E2E Integration Test (#861)
 
-The script `contract/test-futurenet.sh` runs a full end-to-end test of the escrow contract on **Stellar Futurenet** using real XLM transfers.
+The script `contract/test-futurenet.sh` runs a full end-to-end test of the
+legacy `contract/` escrow on **Stellar Futurenet** using real XLM transfers.
 
 ### What it tests
 
@@ -315,9 +344,12 @@ DEPOSIT_XLM=2 FEE_BPS=500 SKIP_BUILD=1 ./contract/test-futurenet.sh
 
 ---
 
-## Soroban Escrow Contract (`contract/`)
+## Legacy Soroban Escrow Contract (`contract/`)
 
-The `contract/` directory contains a Soroban smart contract that provides on-chain escrow for marketplace orders.
+The `contract/` directory contains the legacy Soroban escrow contract that
+provides on-chain escrow for marketplace orders. Do not treat it as
+interchangeable with the workspace escrow at `contracts/escrow/`; see
+[ADR 0001](docs/adr/0001-soroban-contract-boundaries.md) for the boundary.
 
 ### Functions
 
@@ -395,4 +427,3 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidance on:
 - Issue workflow and label guide
 
 For security vulnerabilities, follow the process in [SECURITY.md](./SECURITY.md) instead of opening a public issue.
-

--- a/contract/reward-token/README.md
+++ b/contract/reward-token/README.md
@@ -2,6 +2,11 @@
 
 SEP-0041 compliant Soroban fungible token for marketplace rewards.
 
+This crate belongs to the legacy `contract/` layout. The repository also has a
+newer `contracts/` workspace; see
+[`docs/adr/0001-soroban-contract-boundaries.md`](../../docs/adr/0001-soroban-contract-boundaries.md)
+for the maintained boundary and shared convention policy.
+
 ## Build & Deploy
 
 ```bash

--- a/docs/adr/0001-soroban-contract-boundaries.md
+++ b/docs/adr/0001-soroban-contract-boundaries.md
@@ -1,0 +1,75 @@
+# ADR 0001: Soroban Contract Crate Boundaries and Shared Conventions
+
+## Status
+
+Accepted.
+
+## Context
+
+FarmersMarketplace currently has Soroban contracts in two top-level layouts:
+
+- `contract/`: the legacy escrow crate used by the backend integration harness,
+  Futurenet E2E script, CLI helper, and legacy WASM size profile.
+- `contract/reward-token/`: a legacy-adjacent reward token crate using the same
+  `soroban-sdk = 21.0.0` generation as `contract/`.
+- `contracts/`: the newer Cargo workspace that contains `contracts/escrow/`
+  and `contracts/creator-earnings/`, both using `soroban-sdk = 22.0.0`.
+
+These crates define their own `#[contracterror]` enums, storage key enums, event
+topics, admin flows, pause flows, and basis-points arithmetic conventions. That
+keeps each contract easy to deploy independently, but it also makes hardening
+easy to apply in one crate and forget in another.
+
+## Decision
+
+Both layouts are intentionally maintained for now:
+
+- Keep `contract/` as the legacy escrow surface for backend integration tests,
+  Futurenet E2E, and compatibility work.
+- Keep `contract/reward-token/` as the reward-token contract paired with the
+  legacy integration surface.
+- Treat `contracts/` as the current workspace for new Rust-only contract work
+  and CI coverage.
+- Do not introduce a shared contract crate yet. The current crates span SDK
+  versions and deployment boundaries, so a shared crate would create migration
+  and release coupling before the interfaces have stabilized.
+
+Until a shared crate is introduced, common hardening must follow a
+copy-with-tests-per-crate convention: if a pattern is needed in more than one
+contract, copy the small implementation locally and add crate-local tests that
+prove the behavior in that contract's SDK/runtime context.
+
+## Shared Pattern Candidates
+
+The following patterns should be kept consistent across crates and are
+candidates for a future `contracts/common` crate once the repo converges on one
+Soroban SDK generation:
+
+| Pattern | Current examples | Convention |
+|---|---|---|
+| Two-step admin transfer | `contracts/escrow` uses `AdminTransfer`; `contract/reward-token` has `propose_admin` and `accept_admin` keys | Admin changes should be proposed by the current admin and accepted by the pending admin. Single-step admin replacement should be avoided for new state-changing admin paths. |
+| Pause/circuit breaker | `contract/` has pause/unpause coverage | New state-changing entrypoints should define whether they are blocked while paused. Read-only views should remain available. |
+| Basis-points arithmetic | `contract/`, `contract/reward-token/`, `contracts/escrow`, and `contracts/creator-earnings` all compute fee rates | Validate the maximum basis-points value before multiplication. Prefer `checked_mul`/`checked_div` or explicit bounded inputs when amounts can approach `i128::MAX`. Add boundary tests for `0`, max allowed bps, over-max bps, and large amount values. |
+| Storage keys | Every crate defines a `DataKey`-style enum | Keep key names stable after deployment. Document whether keys are instance, persistent, or temporary storage. Migration code must be idempotent and include preview/dry-run behavior when rewriting existing records. |
+| Event topics | Escrow crates emit overlapping topic names with different tuple shapes | Document event topic tuple shapes next to the emitting function. New subscribers should treat legacy `contract/` and workspace `contracts/escrow` events as separate schemas unless an explicit compatibility note says otherwise. |
+| WASM size/profile policy | `contract/wasm-profile.sh` covers legacy contracts; workspace contracts are tested through the newer workspace CI path | Each deployable crate should have a release build path, a size budget, and an artifact/report produced by CI. |
+
+## README Contract Documentation Rules
+
+Top-level documentation must not describe `contract/` and `contracts/` as if
+they are the same contract.
+
+- Use `contract/` when documenting backend integration tests, Futurenet E2E, or
+  legacy CLI workflows.
+- Use `contracts/` when documenting workspace Rust tests, current escrow
+  hardening work, creator earnings, or workspace WASM profiling.
+- Link this ADR from the README whenever contract ownership or shared
+  conventions are discussed.
+
+## Consequences
+
+This preserves existing deployment/test workflows while making the split
+explicit. The tradeoff is that common logic is still duplicated, but new
+duplication must be deliberate and covered by crate-local tests. A future ADR
+can replace this convention with a shared crate after the legacy and workspace
+contracts converge on one SDK version and release process.


### PR DESCRIPTION
Resolves zeekman/FarmersMarketplace#984

Summary:
- Added ADR 0001 documenting that legacy contract/ and workspace contracts/ are intentionally maintained in parallel for now.
- Identified shared pattern candidates for future commonization or copy-with-tests-per-crate convention: two-step admin transfer, pause/circuit breaker, basis-points math, storage keys, event topics, and WASM size policy.
- Reconciled README contract sections so legacy contract/, contract/reward-token/, contracts/escrow/, and contracts/creator-earnings/ are not described as the same deployment surface.

Verification:
- git diff --check
- test -f docs/adr/0001-soroban-contract-boundaries.md
- test -f README.md
- test -f contract/reward-token/README.md

Note: this is a docs/architecture issue; no Rust or Node source changed.