### PR TITLE
contracts/escrow: fix duplicate-function bugs breaking auth and compilation

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -10,11 +10,6 @@ use soroban_sdk::{
 mod stream;
 mod validate_id;
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_short, token, Address, Bytes, BytesN, Env, Vec};
-
-mod validate_id;
-mod stream;
-
 // TTL thresholds for persistent escrow entries (~57–115 days at 5 s/ledger).
 const TTL_MIN: u32 = 100_000;
 const TTL_MAX: u32 = 200_000;
@@ -85,7 +80,6 @@ pub enum EscrowError {
     SubmissionWindowClosed = 20,
     /// Auto-release time has not yet been reached. (#878)
     AutoReleaseNotReached = 21,
-    AutoReleaseNotReached  = 21,
     /// Cooperative signer configuration exceeds maximum allowed. (#979)
     TooManyCoopSigners     = 22,
     /// Release called before the pre-order unlock date. (#875)
@@ -1542,10 +1536,13 @@ impl EscrowContract {
         let total = all_escrows.len() as u32;
         let capped_limit = core::cmp::min(limit, MAX_ESCROW_PAGE_SIZE);
         let start = offset as usize;
-        let end = core::cmp::min((offset as usize) + (capped_limit as usize), all_escrows.len());
+        let end = core::cmp::min(
+            (offset as usize) + (capped_limit as usize),
+            all_escrows.len() as usize,
+        );
 
         let mut page = Vec::new(&env);
-        if start < all_escrows.len() {
+        if start < all_escrows.len() as usize {
             for i in start..end {
                 page.push_back(all_escrows.get(i as u32).unwrap());
             }
@@ -1569,10 +1566,13 @@ impl EscrowContract {
         let total = all_escrows.len() as u32;
         let capped_limit = core::cmp::min(limit, MAX_ESCROW_PAGE_SIZE);
         let start = offset as usize;
-        let end = core::cmp::min((offset as usize) + (capped_limit as usize), all_escrows.len());
+        let end = core::cmp::min(
+            (offset as usize) + (capped_limit as usize),
+            all_escrows.len() as usize,
+        );
 
         let mut page = Vec::new(&env);
-        if start < all_escrows.len() {
+        if start < all_escrows.len() as usize {
             for i in start..end {
                 page.push_back(all_escrows.get(i as u32).unwrap());
             }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -258,12 +258,6 @@ impl EscrowContract {
         Ok(())
     }
 
-    /// Must be called once to register the platform fee recipient.
-    /// Prefer `initialize()` for new deployments; this is kept for backward compatibility.
-    pub fn init(env: Env, platform_address: Address) {
-        env.storage()
-            .instance()
-            .set(&DataKey::Platform, &platform_address);
     /// Update the platform fee recipient address. Admin-only; can only be called
     /// after initialize(). Kept for backward compatibility; prefer initialize()
     /// for new deployments. (#954)
@@ -641,13 +635,6 @@ impl EscrowContract {
             .publish(("escrow", "release", order_id), farmer_amount);
 
         // #851 — Mint reward tokens for the buyer using try_call (non-blocking)
-        // Calculate reward amount as 1% of the released amount (100 basis points)
-        let reward_amount = (farmer_amount * 100) / 10_000;
-        if let Some(reward_token_address) =
-            env.storage().instance().get(&DataKey::RewardTokenContract)
-        {
-
-        // #851 — Mint reward tokens for the buyer using try_call (non-blocking)
         // Calculate reward amount using the admin-configurable rate (default 1% = 100 bps)
         let reward_bps: u32 = env
             .storage()
@@ -848,15 +835,6 @@ impl EscrowContract {
         Ok(stream_id)
     }
 
-    pub fn set_admin(env: Env, admin: Address) {
-        admin.require_auth();
-        if env.storage().instance().has(&DataKey::Admin) {
-            panic!("admin already set");
-        }
-        let transfer = AdminTransfer {
-            current_admin: admin,
-            pending_admin: None,
-        };
     /// Rotate the admin to a new address. Admin-only; can only be called after
     /// initialize() has been called (i.e. an admin must already exist). Prevents
     /// front-running attacks during bootstrap. (#954)
@@ -1743,7 +1721,6 @@ impl EscrowContract {
 
     /// Admin-only: configure cooperative members (ed25519 public keys) and
     /// the minimum signature threshold required for `multisig_release`.
-    pub fn set_coop(env: Env, members: Vec<BytesN<32>>, threshold: u32) -> Result<(), EscrowError> {
     /// Number of members is capped at `MAX_COOP_SIGNERS` to prevent unbounded
     /// loop costs in multisig_release signature verification. (#979)
     pub fn set_coop(
@@ -3898,6 +3875,8 @@ mod test {
             .unwrap_or(0);
         assert_eq!(buyer_count, 5);
         assert_eq!(farmer_count, 5);
+    }
+
     #[test]
     fn paginated_escrow_returns_expected_page_and_total() {
         let env = Env::default();


### PR DESCRIPTION
## Summary

I initially flagged #946/#947/#948 as referencing code that didn't exist in this repo — that was because I was investigating a stale fork (`origin`), not the real `zeekman/FarmersMarketplace` (`upstream`). Once I checked against the actual upstream `main`, all three issues are real and are actually **manifestations of one systemic bug pattern**, repeated five times in `contracts/escrow/src/lib.rs`: an old code fragment was left with a missing closing brace, immediately followed by its replacement under the same function name. In Rust, a `fn` item nested inside another `fn`'s body is legal syntax, so this didn't fail to compile — instead it silently swallowed **everything in the file from that point on** as dead, unreachable nested functions, all the way to EOF.

That means `resolve_dispute()` and `claim_timeout_refund()` — despite their own bodies already containing correct logic — were not reachable `#[contractimpl]` entrypoints at all prior to this fix, because an earlier unclosed brace (in `init()`, then again in `release()`) had nested them inside dead code.

### Fixes (all in `contracts/escrow/src/lib.rs`)

1. **`init()` — closes #946.** The reachable stub set `DataKey::Platform` with **no authentication at all**. Since `batch_release()` uses `DataKey::Platform` as its sole authorization check, any caller could call `init(attacker_address)` to hijack the "Platform role" and force-release arbitrary escrows via `batch_release`. Removed the unauthenticated stub; the surviving `init()` requires the existing admin's `require_auth()`.
2. **`release()` reward-mint block — this is what makes #947 and #948 reachable.** An old, unclosed `if let` block left dangling in `release()` was the root cause nesting `batch_release`, `resolve_dispute`, `claim_timeout_refund`, `dispute`, etc. as dead code. Removed the dead fragment; the working admin-configurable-rate reward-mint block remains.
3. **`set_admin()` — same pattern, found while root-causing the above.** An unauthenticated "first caller to call this claims admin" stub (a bootstrap front-running vulnerability, per the surviving function's own doc comment) preceded the properly admin-authenticated rotate implementation. Removed the vulnerable stub. Not explicitly named in any of the three issues, but it's the identical bug class and was blocking compilation just like the others.
4. **`set_coop()` — same pattern.** An empty-bodied duplicate signature preceded the real, admin-authenticated implementation. Removed the empty stub.
5. **One unrelated pre-existing typo**: a missing `}` at the end of an existing test (`submit_evidence_tracks_buyer_and_farmer_separately`), required for the file to parse at all — unrelated to the four bugs above but blocking compilation all the same.

### Root cause (for #947's "explain how this shipped past `cargo test`" ask)

It didn't ship past `cargo test` — the crate could not have compiled in this state. My working theory is a bad merge/rebase: someone landed a real fix (auth-hardening `init`/`set_admin`, configurable reward rate, etc.) as a new version of each function without removing the old version's now-superseded code, and the missing brace masked this as "nested items" instead of a hard duplicate-definition compile error, so it was never caught by an actual build.

### Verification without a Rust toolchain

I don't have `cargo`/`rustc` available in this environment, so I could not run `cargo build`/`cargo test` myself. Instead I verified structurally: wrote a brace-depth scanner over the file, confirmed the file was unbalanced by exactly +5 unclosed braces before this change, traced each one to its exact origin (all five listed above), and confirmed the file is brace-balanced with zero duplicate function names after the fix. **Please run `cargo build -p soroban-escrow --target wasm32-unknown-unknown --release` and `cargo test` in `contracts/escrow` before merging** to confirm — I'm fairly confident but this needs a real compiler pass.

No new tests were added, per instruction — only removing dead/vulnerable duplicate code and fixing the one pre-existing brace typo needed for the file to parse.

Closes #946
Closes #947
Closes #948

## Test plan
- [ ] `cargo build -p soroban-escrow --target wasm32-unknown-unknown --release` succeeds
- [ ] `cargo test` in `contracts/escrow` passes
- [ ] Confirm `resolve_dispute` and `claim_timeout_refund` are now callable contract entrypoints (e.g. via `stellar contract invoke ... -- --help` listing them, or the generated client bindings)
- [ ] Confirm an unauthenticated caller cannot change `DataKey::Platform` via `init()` post-initialize