### PR TITLE
fix: remove duplicate route registrations and reconcile categories mount

### DIFF
--- a/backend/src/routes/categories.js
+++ b/backend/src/routes/categories.js
@@ -1,3 +1,58 @@
+/**
+ * @swagger
+ * tags:
+ *   name: Categories
+ *   description: Product category management
+ *
+ * /api/v1/categories:
+ *   get:
+ *     summary: List all categories with product counts
+ *     tags: [Categories]
+ *     responses:
+ *       200:
+ *         description: Array of categories
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id: { type: integer }
+ *                       name: { type: string }
+ *                       slug: { type: string }
+ *                       product_count: { type: integer }
+ *
+ * /api/v1/admin/categories:
+ *   post:
+ *     summary: Create a category (admin only)
+ *     tags: [Categories]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name: { type: string }
+ *               slug: { type: string }
+ *     responses:
+ *       201:
+ *         description: Category created
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       409:
+ *         description: Slug already taken
+ */
 const router = require('express').Router();
 const db = require('../db/schema');
 const auth = require('../middleware/auth');
@@ -83,11 +138,6 @@ router.delete('/admin/categories/:id', auth, (req, res) => {
 
   db.prepare('DELETE FROM categories WHERE id = ?').run(req.params.id);
   res.json({ success: true, message: 'Category deleted' });
-const db = require('../db/postgres');
-
-router.get('/', async (req, res) => {
-  const result = await db.query('SELECT * FROM categories ORDER BY name');
-  res.json(result.rows);
 });
 
 module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -384,14 +384,6 @@ registerRoute('/', '', require('./export'));
 registerRoute('/', '/announcements', require('./announcements'));
 registerRoute('/', '/auctions', require('./auctions'));
 
-router.use('/api/coupons',    require('./coupons'));
-router.use('/api/export',     require('./export'));
-router.use('/api/categories', require('./categories'));
-router.use('/api/reviews',    require('./reviews'));
-
-router.use('/api/coupons',    require('./coupons'));
-router.use('/api/export',     require('./export'));
-router.use('/api/categories', require('./categories'));
-router.use('/api/reviews',    require('./reviews'));
+registerRoute('/', '/categories', require('./categories'));
 
 module.exports = router;

--- a/backend/tests/routes-dedup.test.js
+++ b/backend/tests/routes-dedup.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const app = require('../src/app');
+
+/**
+ * Collect every path string registered on the root Express router stack,
+ * including nested routers mounted via router.use().
+ */
+function collectMountPaths(stack, prefix = '') {
+  const paths = [];
+  for (const layer of stack || []) {
+    const seg = layer.regexp?.source ?? '';
+    const path = prefix + (layer.route?.path ?? '');
+    if (layer.handle?.stack) {
+      // nested router
+      const mountPath = layer.regexp
+        ? prefix + (layer.keys?.length === 0 ? routerRegexpToPath(layer.regexp) : '')
+        : prefix;
+      paths.push(...collectMountPaths(layer.handle.stack, mountPath));
+    } else {
+      paths.push(path || seg);
+    }
+  }
+  return paths;
+}
+
+function routerRegexpToPath(re) {
+  // Express converts '/api/coupons' → /^\/api\/coupons\/?(?=\/|$)/i
+  const m = re.source.match(/^\^\\\/(.+?)\\\/\?\(\?=\\\/\|\$\)/);
+  return m ? '/' + m[1].replace(/\\\//g, '/') : '';
+}
+
+/**
+ * Walk app._router.stack and collect (mountPath, routerHandle) pairs so we
+ * can count how many times the same router object is wired in.
+ */
+function collectRouterEntries(stack, prefix = '') {
+  const entries = [];
+  for (const layer of stack || []) {
+    if (layer.handle?.stack) {
+      const mountPath = prefix + routerRegexpToPath(layer.regexp);
+      entries.push({ path: mountPath, handle: layer.handle });
+      entries.push(...collectRouterEntries(layer.handle.stack, mountPath));
+    }
+  }
+  return entries;
+}
+
+describe('Route deduplication', () => {
+  let routerStack;
+
+  beforeAll(() => {
+    // app._router is populated after the first request or after listen; force it.
+    routerStack = app._router ? app._router.stack : [];
+  });
+
+  const suspectPaths = [
+    '/api/coupons',
+    '/api/export',
+    '/api/categories',
+    '/api/reviews',
+  ];
+
+  test.each(suspectPaths)('%s is mounted exactly once', (mountPath) => {
+    const entries = collectRouterEntries(routerStack);
+    const matches = entries.filter((e) => e.path === mountPath);
+    expect(matches.length).toBe(1);
+  });
+
+  test('no router handle object appears more than once in the top-level stack', () => {
+    const seen = new Map();
+    for (const layer of routerStack) {
+      if (!layer.handle?.stack) continue;
+      const count = (seen.get(layer.handle) || 0) + 1;
+      seen.set(layer.handle, count);
+    }
+    for (const [handle, count] of seen) {
+      expect(count).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
Closes #987
backend/src/routes/index.js

Deleted both verbatim duplicate 4-line blocks at the bottom of the file

Replaced them with a single registerRoute('/', '/categories', require('./categories')) — this mounts categories at both /api/categories (with deprecation headers) and /api/v1/categories, fixing the companion 404

backend/src/routes/categories.js

Removed the orphaned postgres snippet that was appended after the DELETE handler without a closing brace — it contained a stray require('../db/postgres') and a duplicate router.get('/') that would have caused a runtime syntax error

backend/tests/routes-dedup.test.js (new)

Walks app._router.stack and asserts each of the four previously-duplicated paths (/api/coupons, /api/export, /api/categories, /api/reviews) is mounted exactly once

Also asserts no router handle object appears more than once in the top-level stack