### PR TITLE
Payment streaming migration/routes + cooperatives & messages test coverage

### DIFF
--- a/backend/migrations/032_payment_streams.sql
+++ b/backend/migrations/032_payment_streams.sql
@@ -1,0 +1,32 @@
+-- Migration: 032_payment_streams
+-- Issue #996: mirrors contracts/escrow/src/stream.rs's on-chain PaymentStream
+-- record so the backend can list "your active payment streams" without
+-- querying the chain on every page load.
+--
+-- stream_id is a per-contract counter (StreamKey::Stream(u64) on-chain), so
+-- it is only unique together with contract_id. The unique index below is
+-- what the eventual indexer job upserts against:
+--   INSERT INTO payment_streams (...) VALUES (...)
+--   ON CONFLICT (contract_id, stream_id) DO UPDATE SET ...
+
+CREATE TABLE IF NOT EXISTS payment_streams (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  contract_id           TEXT     NOT NULL,
+  stream_id             INTEGER  NOT NULL,
+  sender                TEXT     NOT NULL,
+  recipient             TEXT     NOT NULL,
+  rate_per_second       REAL     NOT NULL,
+  deposit               REAL     NOT NULL,
+  accrued_at_checkpoint REAL     NOT NULL DEFAULT 0,
+  last_checkpoint_at    INTEGER  NOT NULL DEFAULT 0,
+  end_time              INTEGER  NOT NULL,
+  cancelled             INTEGER  NOT NULL DEFAULT 0,
+  created_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_streams_contract_stream
+  ON payment_streams (contract_id, stream_id);
+
+CREATE INDEX IF NOT EXISTS idx_payment_streams_sender    ON payment_streams (sender);
+CREATE INDEX IF NOT EXISTS idx_payment_streams_recipient ON payment_streams (recipient);

--- a/backend/migrations/032_payment_streams.undo.sql
+++ b/backend/migrations/032_payment_streams.undo.sql
@@ -1,0 +1,5 @@
+-- Undo: 032_payment_streams
+DROP INDEX IF EXISTS idx_payment_streams_recipient;
+DROP INDEX IF EXISTS idx_payment_streams_sender;
+DROP INDEX IF EXISTS idx_payment_streams_contract_stream;
+DROP TABLE IF EXISTS payment_streams;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -362,6 +362,7 @@ registerRoute('/', '/messages', require('./messages'));
 registerRoute('/', '/notifications', require('./notifications'));
 registerRoute('/', '/contracts', require('./contracts'));
 registerRoute('/', '/escrow', require('./escrow'));
+registerRoute('/', '/paymentStreams', require('./paymentStreams'));
 registerRoute('/', '/products/bulk', require('./bulkUpload'));
 registerRoute('/', '/coupons', require('./coupons'));
 registerRoute('/', '/alerts', require('./alerts'));

--- a/backend/src/routes/paymentStreams.js
+++ b/backend/src/routes/paymentStreams.js
@@ -1,0 +1,259 @@
+/**
+ * Payment Streaming routes — issue #997
+ *
+ * Exposes contracts/escrow/src/stream.rs's streaming entrypoints
+ * (create_stream, withdraw, cancel_stream, decrease_rate_per_second,
+ * get_accrued_amount_on_chain) over HTTP, mirroring the auth rules the
+ * contract itself enforces:
+ *   - sender-only:    creating the stream, decreasing its rate, cancelling it
+ *   - recipient-only: withdrawing accrued funds
+ *
+ * Authorization is checked against the local `payment_streams` mirror table
+ * (#996) rather than the chain, so it stays fast; the row is kept current by
+ * the streaming indexer job once that lands.
+ *
+ * NOTE: create_stream / withdraw / cancel_stream are not yet implemented in
+ * stream.rs (only decrease_rate_per_second and get_accrued_amount_on_chain
+ * exist today) — see the contract-side companion issues. These handlers are
+ * wired ahead of that landing, same as the Creator Earnings gap.
+ */
+
+const router = require('express').Router();
+const auth = require('../middleware/auth');
+const db = require('../db/schema');
+const { err } = require('../middleware/error');
+const { invokeContract, simulateContract } = require('../utils/stellar');
+
+function validateContractId(contractId) {
+  return /^[A-Z2-7]{56}$|^[0-9a-fA-F]{64}$/.test(contractId);
+}
+
+function validateStellarAddress(address) {
+  return /^G[A-Z2-7]{55}$/.test(address);
+}
+
+function parseStreamId(raw) {
+  const id = Number(raw);
+  return Number.isInteger(id) && id >= 0 ? id : null;
+}
+
+function isPositiveNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0;
+}
+
+async function getCallerStellarAddress(userId) {
+  const { rows } = await db.query('SELECT stellar_public_key, stellar_secret_key FROM users WHERE id = $1', [
+    userId,
+  ]);
+  return rows[0] || null;
+}
+
+async function getStreamRow(contractId, streamId) {
+  const { rows } = await db.query(
+    'SELECT * FROM payment_streams WHERE contract_id = $1 AND stream_id = $2',
+    [contractId, streamId]
+  );
+  return rows[0] || null;
+}
+
+// POST /api/paymentStreams — create a stream (caller is the sender)
+// Body: { contract_id, recipient, rate_per_second, deposit, end_time }
+router.post('/', auth, async (req, res) => {
+  const { contract_id, recipient, rate_per_second, deposit, end_time } = req.body || {};
+
+  if (!validateContractId(contract_id)) {
+    return err(res, 400, 'Invalid contract_id format', 'invalid_contract_id');
+  }
+  if (!validateStellarAddress(recipient)) {
+    return err(res, 400, 'Invalid recipient address', 'invalid_recipient');
+  }
+  if (!isPositiveNumber(rate_per_second)) {
+    return err(res, 400, 'rate_per_second must be a positive number', 'validation_error');
+  }
+  if (!isPositiveNumber(deposit)) {
+    return err(res, 400, 'deposit must be a positive number', 'validation_error');
+  }
+  const endTimeNum = Number(end_time);
+  if (!Number.isInteger(endTimeNum) || endTimeNum <= Math.floor(Date.now() / 1000)) {
+    return err(res, 400, 'end_time must be a future unix timestamp', 'validation_error');
+  }
+
+  const caller = await getCallerStellarAddress(req.user.id);
+  if (!caller?.stellar_secret_key) {
+    return err(res, 400, 'No Stellar wallet on file for this account', 'no_wallet');
+  }
+  if (recipient === caller.stellar_public_key) {
+    return err(res, 400, 'sender and recipient must differ', 'validation_error');
+  }
+
+  try {
+    const { hash, result } = await invokeContract({
+      contractId: contract_id,
+      method: 'create_stream',
+      signerSecret: caller.stellar_secret_key,
+      args: [
+        { type: 'address', value: caller.stellar_public_key },
+        { type: 'address', value: recipient },
+        { type: 'i128', value: BigInt(Math.round(rate_per_second)) },
+        { type: 'i128', value: BigInt(Math.round(deposit)) },
+        { type: 'u64', value: endTimeNum },
+      ],
+    });
+    res.status(201).json({ success: true, txHash: hash, result });
+  } catch (e) {
+    err(res, 502, `Failed to create stream: ${e.message}`, 'contract_error');
+  }
+});
+
+// GET /api/paymentStreams/:contractId/:streamId/accrued — live accrued amount
+// Sender or recipient only.
+router.get('/:contractId/:streamId/accrued', auth, async (req, res) => {
+  const { contractId } = req.params;
+  const streamId = parseStreamId(req.params.streamId);
+  if (!validateContractId(contractId)) {
+    return err(res, 400, 'Invalid contractId format', 'invalid_contract_id');
+  }
+  if (streamId === null) return err(res, 400, 'Invalid streamId', 'validation_error');
+
+  const stream = await getStreamRow(contractId, streamId);
+  if (!stream) return err(res, 404, 'Stream not found', 'stream_not_found');
+
+  const caller = await getCallerStellarAddress(req.user.id);
+  const callerAddress = caller?.stellar_public_key;
+  if (callerAddress !== stream.sender && callerAddress !== stream.recipient) {
+    return err(res, 403, 'Not a participant in this stream', 'forbidden');
+  }
+
+  try {
+    const sim = await simulateContract({
+      contractId,
+      method: 'get_accrued_amount_on_chain',
+      args: [{ type: 'u64', value: streamId }],
+    });
+    res.json({ success: true, data: sim });
+  } catch (e) {
+    err(res, 502, `Failed to read accrued amount: ${e.message}`, 'contract_error');
+  }
+});
+
+// PATCH /api/paymentStreams/:contractId/:streamId/rate — decrease the streaming rate
+// Sender-only. Body: { new_rate }
+router.patch('/:contractId/:streamId/rate', auth, async (req, res) => {
+  const { contractId } = req.params;
+  const streamId = parseStreamId(req.params.streamId);
+  if (!validateContractId(contractId)) {
+    return err(res, 400, 'Invalid contractId format', 'invalid_contract_id');
+  }
+  if (streamId === null) return err(res, 400, 'Invalid streamId', 'validation_error');
+
+  const { new_rate } = req.body || {};
+  if (!isPositiveNumber(new_rate)) {
+    return err(res, 400, 'new_rate must be a positive number', 'validation_error');
+  }
+
+  const stream = await getStreamRow(contractId, streamId);
+  if (!stream) return err(res, 404, 'Stream not found', 'stream_not_found');
+  if (new_rate >= stream.rate_per_second) {
+    return err(res, 400, 'new_rate must be less than the current rate', 'validation_error');
+  }
+
+  const caller = await getCallerStellarAddress(req.user.id);
+  if (caller?.stellar_public_key !== stream.sender) {
+    return err(res, 403, 'Only the stream sender can decrease the rate', 'forbidden');
+  }
+  if (!caller?.stellar_secret_key) {
+    return err(res, 400, 'No Stellar wallet on file for this account', 'no_wallet');
+  }
+
+  try {
+    const { hash, result } = await invokeContract({
+      contractId,
+      method: 'decrease_rate_per_second',
+      signerSecret: caller.stellar_secret_key,
+      args: [
+        { type: 'u64', value: streamId },
+        { type: 'address', value: caller.stellar_public_key },
+        { type: 'i128', value: BigInt(Math.round(new_rate)) },
+      ],
+    });
+    res.json({ success: true, txHash: hash, result });
+  } catch (e) {
+    err(res, 502, `Failed to decrease rate: ${e.message}`, 'contract_error');
+  }
+});
+
+// POST /api/paymentStreams/:contractId/:streamId/withdraw — withdraw accrued funds
+// Recipient-only.
+router.post('/:contractId/:streamId/withdraw', auth, async (req, res) => {
+  const { contractId } = req.params;
+  const streamId = parseStreamId(req.params.streamId);
+  if (!validateContractId(contractId)) {
+    return err(res, 400, 'Invalid contractId format', 'invalid_contract_id');
+  }
+  if (streamId === null) return err(res, 400, 'Invalid streamId', 'validation_error');
+
+  const stream = await getStreamRow(contractId, streamId);
+  if (!stream) return err(res, 404, 'Stream not found', 'stream_not_found');
+
+  const caller = await getCallerStellarAddress(req.user.id);
+  if (caller?.stellar_public_key !== stream.recipient) {
+    return err(res, 403, 'Only the stream recipient can withdraw', 'forbidden');
+  }
+  if (!caller?.stellar_secret_key) {
+    return err(res, 400, 'No Stellar wallet on file for this account', 'no_wallet');
+  }
+
+  try {
+    const { hash, result } = await invokeContract({
+      contractId,
+      method: 'withdraw',
+      signerSecret: caller.stellar_secret_key,
+      args: [
+        { type: 'u64', value: streamId },
+        { type: 'address', value: caller.stellar_public_key },
+      ],
+    });
+    res.json({ success: true, txHash: hash, result });
+  } catch (e) {
+    err(res, 502, `Failed to withdraw: ${e.message}`, 'contract_error');
+  }
+});
+
+// POST /api/paymentStreams/:contractId/:streamId/cancel — cancel the stream
+// Sender-only.
+router.post('/:contractId/:streamId/cancel', auth, async (req, res) => {
+  const { contractId } = req.params;
+  const streamId = parseStreamId(req.params.streamId);
+  if (!validateContractId(contractId)) {
+    return err(res, 400, 'Invalid contractId format', 'invalid_contract_id');
+  }
+  if (streamId === null) return err(res, 400, 'Invalid streamId', 'validation_error');
+
+  const stream = await getStreamRow(contractId, streamId);
+  if (!stream) return err(res, 404, 'Stream not found', 'stream_not_found');
+
+  const caller = await getCallerStellarAddress(req.user.id);
+  if (caller?.stellar_public_key !== stream.sender) {
+    return err(res, 403, 'Only the stream sender can cancel', 'forbidden');
+  }
+  if (!caller?.stellar_secret_key) {
+    return err(res, 400, 'No Stellar wallet on file for this account', 'no_wallet');
+  }
+
+  try {
+    const { hash, result } = await invokeContract({
+      contractId,
+      method: 'cancel_stream',
+      signerSecret: caller.stellar_secret_key,
+      args: [
+        { type: 'u64', value: streamId },
+        { type: 'address', value: caller.stellar_public_key },
+      ],
+    });
+    res.json({ success: true, txHash: hash, result });
+  } catch (e) {
+    err(res, 502, `Failed to cancel stream: ${e.message}`, 'contract_error');
+  }
+});
+
+module.exports = router;

--- a/backend/tests/cooperatives.test.js
+++ b/backend/tests/cooperatives.test.js
@@ -1,0 +1,218 @@
+/**
+ * Tests for backend/src/routes/cooperatives.js — issue #999
+ *
+ * cooperativeRoyalty.test.js (src/__tests__/) covers royalty-bps accounting.
+ * This file covers the core membership CRUD lifecycle: create, join, leave,
+ * list, and the route's authorization guards.
+ */
+
+process.env.ENCRYPTION_SECRET = process.env.ENCRYPTION_SECRET || 'test-encryption-secret-for-jest';
+
+const jwt = require('jsonwebtoken');
+const { request, app, mockQuery } = require('./setup');
+
+const SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
+const farmer2Token = jwt.sign({ id: 2, role: 'farmer' }, SECRET);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+// ── POST /api/cooperatives ────────────────────────────────────────────────────
+describe('POST /api/cooperatives', () => {
+  it('creates a cooperative and adds the creator as its first admin member', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 }) // INSERT cooperatives RETURNING id
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });          // INSERT cooperative_members
+
+    const res = await request(app)
+      .post('/api/cooperatives')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send({ name: 'Green Valley Co-op' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.id).toBe(5);
+    expect(res.body.publicKey).toBeTruthy();
+
+    // Creator is inserted as an admin member of the new cooperative.
+    expect(mockQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining('INSERT INTO cooperative_members'),
+      [5, 1]
+    );
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/cooperatives')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).post('/api/cooperatives').send({ name: 'No Auth Co-op' });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── GET /api/cooperatives ──────────────────────────────────────────────────────
+describe('GET /api/cooperatives', () => {
+  it('returns public member counts for ?farmer_id= without requiring auth', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 5, name: 'Green Valley', created_at: '2026-01-01', member_count: 3 }],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get('/api/cooperatives?farmer_id=1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].member_count).toBe(3);
+  });
+
+  it('returns 400 for a non-numeric farmer_id', async () => {
+    const res = await request(app).get('/api/cooperatives?farmer_id=not-a-number');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when no farmer_id is given and the caller is unauthenticated', async () => {
+    const res = await request(app).get('/api/cooperatives');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── POST /api/cooperatives/:id/join ───────────────────────────────────────────
+describe('POST /api/cooperatives/:id/join', () => {
+  it('lets a farmer join an existing cooperative', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 }) // cooperative exists
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })           // not already a member
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });          // INSERT membership
+
+    const res = await request(app)
+      .post('/api/cooperatives/5/join')
+      .set('Authorization', `Bearer ${farmer2Token}`);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 404 when the cooperative does not exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const res = await request(app)
+      .post('/api/cooperatives/9999/join')
+      .set('Authorization', `Bearer ${farmer2Token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a duplicate join with 409', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 })   // cooperative exists
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 }); // already a member
+
+    const res = await request(app)
+      .post('/api/cooperatives/5/join')
+      .set('Authorization', `Bearer ${farmer2Token}`);
+
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).post('/api/cooperatives/5/join');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── POST /api/cooperatives/:id/leave ──────────────────────────────────────────
+describe('POST /api/cooperatives/:id/leave', () => {
+  it('lets a non-sole-admin member leave', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 }) // caller is a member
+      .mockResolvedValueOnce({ rows: [{ user_id: 99 }], rowCount: 1 })    // a different admin exists
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });                  // DELETE membership
+
+    const res = await request(app)
+      .post('/api/cooperatives/5/leave')
+      .set('Authorization', `Bearer ${farmer2Token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 404 when the caller is not a member', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const res = await request(app)
+      .post('/api/cooperatives/5/leave')
+      .set('Authorization', `Bearer ${farmer2Token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('blocks the sole admin from leaving without transferring admin role first', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 }) // caller is a member
+      .mockResolvedValueOnce({ rows: [{ user_id: 1 }], rowCount: 1 });    // caller is the only admin
+
+    const res = await request(app)
+      .post('/api/cooperatives/5/leave')
+      .set('Authorization', `Bearer ${farmerToken}`); // id 1
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('last_admin');
+  });
+});
+
+// ── Authorization edge cases ──────────────────────────────────────────────────
+describe('cooperative membership authorization edge cases', () => {
+  it('PATCH /:id/admin — a non-admin member cannot transfer admin role to someone else', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // caller is not an admin
+
+    const res = await request(app)
+      .patch('/api/cooperatives/5/admin')
+      .set('Authorization', `Bearer ${farmer2Token}`)
+      .send({ new_admin_id: 3 });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('PATCH /:id/admin — rejects transferring to a user who is not a member', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 }) // caller is admin
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });                  // target is not a member
+
+    const res = await request(app)
+      .patch('/api/cooperatives/5/admin')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .send({ new_admin_id: 999 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /:id/pending — a non-member cannot view pending transactions', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // membership check fails
+
+    const res = await request(app)
+      .get('/api/cooperatives/5/pending')
+      .set('Authorization', `Bearer ${farmer2Token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('POST /:id/multisig-setup — a non-member cannot configure signers', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // membership check fails
+
+    const res = await request(app)
+      .post('/api/cooperatives/5/multisig-setup')
+      .set('Authorization', `Bearer ${farmer2Token}`)
+      .send({ member_ids: [1, 2], threshold: 2 });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/tests/messages.test.js
+++ b/backend/tests/messages.test.js
@@ -1,0 +1,245 @@
+/**
+ * Tests for backend/src/routes/messages.js — issue #1000
+ *
+ * Covers sending a message, listing conversation history, the unread-count
+ * endpoint before/after marking as read, and that a user can never read or
+ * send as another account (every query is scoped by the authenticated
+ * req.user.id from the verified JWT, never by a client-supplied id).
+ */
+
+const jwt = require('jsonwebtoken');
+const { request, app, mockQuery } = require('./setup');
+
+const SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const buyerToken = jwt.sign({ id: 10, role: 'buyer' }, SECRET);
+const farmerToken = jwt.sign({ id: 20, role: 'farmer' }, SECRET);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+// ── POST /api/messages ────────────────────────────────────────────────────────
+describe('POST /api/messages', () => {
+  it('sends a message from an authenticated buyer to a farmer', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 20 }], rowCount: 1 }) // receiver exists
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })  // INSERT RETURNING id
+      .mockResolvedValueOnce({
+        rows: [{ id: 1, sender_id: 10, receiver_id: 20, content: 'Hello!' }],
+        rowCount: 1,
+      }); // SELECT the inserted row
+
+    const res = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ receiver_id: 20, content: 'Hello!' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe(1);
+  });
+
+  it('sanitizes HTML in the message content before storing it', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 20 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 2 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 2 }], rowCount: 1 });
+
+    await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ receiver_id: 20, content: '<script>alert(1)</script>' });
+
+    const insertCall = mockQuery.mock.calls.find(([sql]) => sql.includes('INSERT INTO messages'));
+    expect(insertCall[1][3]).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('always uses the authenticated user as sender, ignoring a spoofed sender_id', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 20 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 3 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 3 }], rowCount: 1 });
+
+    await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ sender_id: 999, receiver_id: 20, content: 'hi' });
+
+    const insertCall = mockQuery.mock.calls.find(([sql]) => sql.includes('INSERT INTO messages'));
+    expect(insertCall[1][0]).toBe(10); // buyerToken's id, not the spoofed 999
+  });
+
+  it('returns 400 when receiver_id or content is missing', async () => {
+    const res = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ content: 'no receiver' });
+    expect(res.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the receiver does not exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const res = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ receiver_id: 9999, content: 'hi' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when messaging yourself', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 10 }], rowCount: 1 }); // "receiver" is self
+    const res = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .send({ receiver_id: 10, content: 'hi me' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).post('/api/messages').send({ receiver_id: 20, content: 'hi' });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── GET /api/messages (conversation list) ──────────────────────────────────────
+describe('GET /api/messages', () => {
+  it('lists the authenticated user\'s conversations', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ other_user_id: 20, other_user_name: 'Farmer Joe', last_message: 'Hello!', unread_count: 0 }],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get('/api/messages').set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].other_user_name).toBe('Farmer Joe');
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/messages');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── GET /api/messages/:userId (conversation history) ───────────────────────────
+describe('GET /api/messages/:userId', () => {
+  it('returns messages exchanged with the given user, scoped to the caller', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })            // mark-as-read update
+      .mockResolvedValueOnce({ rows: [{ total: '2' }], rowCount: 1 }) // count
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 1, sender_id: 10, receiver_id: 20, content: 'Hi' },
+          { id: 2, sender_id: 20, receiver_id: 10, content: 'Hey back' },
+        ],
+        rowCount: 2,
+      });
+
+    const res = await request(app)
+      .get('/api/messages/20')
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+
+    // The history query is always scoped by the authenticated caller's id
+    // (from the verified JWT), never by anything the client can control —
+    // so a user can never read another account's conversation.
+    const historyCall = mockQuery.mock.calls.find(([sql]) => sql.includes('s.name as sender_name'));
+    expect(historyCall[1]).toEqual([10, 20, 20, 0]);
+  });
+
+  it('returns 400 for a non-numeric userId', async () => {
+    const res = await request(app)
+      .get('/api/messages/not-a-number')
+      .set('Authorization', `Bearer ${buyerToken}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/messages/20');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Unread count, before and after marking as read ─────────────────────────────
+describe('unread-count lifecycle', () => {
+  it('GET /api/messages/unread-count reflects unread messages before marking as read', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: '2' }], rowCount: 1 });
+
+    const res = await request(app)
+      .get('/api/messages/unread-count')
+      .set('Authorization', `Bearer ${farmerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(2);
+  });
+
+  it('POST /:conversation_id/read marks messages read and returns the updated unread_count', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 }) // participant check
+      .mockResolvedValueOnce({ rows: [], rowCount: 2 })           // UPDATE read_at
+      .mockResolvedValueOnce({ rows: [{ count: '0' }], rowCount: 1 }); // recomputed unread count
+
+    const res = await request(app)
+      .post('/api/messages/10/read')
+      .set('Authorization', `Bearer ${farmerToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.unread_count).toBe(0);
+  });
+
+  it('POST /:conversation_id/read returns 404 for a conversation the caller was never part of', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // no shared messages
+
+    const res = await request(app)
+      .post('/api/messages/999/read')
+      .set('Authorization', `Bearer ${farmerToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 for unread-count without auth', async () => {
+    const res = await request(app).get('/api/messages/unread-count');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── PATCH /api/messages/:id/read — cannot mark another account's message ──────
+describe('PATCH /api/messages/:id/read', () => {
+  it('marks the caller\'s own received message as read', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = await request(app)
+      .patch('/api/messages/1/read')
+      .set('Authorization', `Bearer ${farmerToken}`);
+
+    expect(res.status).toBe(200);
+
+    // Scoped by receiver_id = the authenticated caller — a user can never
+    // mark a message addressed to someone else as read.
+    const updateCall = mockQuery.mock.calls[0];
+    expect(updateCall[1]).toEqual([1, 20]);
+  });
+
+  it('returns 404 when the message does not belong to the caller (impersonation attempt)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // no row matched receiver_id = caller
+
+    const res = await request(app)
+      .patch('/api/messages/1/read')
+      .set('Authorization', `Bearer ${buyerToken}`); // not the actual receiver
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for a non-numeric message id', async () => {
+    const res = await request(app)
+      .patch('/api/messages/not-a-number/read')
+      .set('Authorization', `Bearer ${farmerToken}`);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Closes four backend gaps in one PR:

**#996 — No database migration/table exists for on-chain Payment Streams**
- Adds `backend/migrations/032_payment_streams.sql` (+ `.undo.sql`) creating a
  `payment_streams` table mirroring `contracts/escrow/src/stream.rs`'s
  `PaymentStream` (sender, recipient, rate_per_second, deposit,
  accrued_at_checkpoint, last_checkpoint_at, end_time, cancelled), plus
  stream_id, contract_id, created_at/updated_at.
- `stream_id` is only unique per contract on-chain (`StreamKey::Stream(u64)`),
  so the table carries a unique index on `(contract_id, stream_id)` — the key
  the eventual indexer job upserts against, matching the existing
  `contract_invocations` / `escrow_monitor_cursor` upsert pattern already
  used by `contractMonitor.js`.

**#997 — No backend route exposes Payment Streaming contract functions**
- Adds `backend/src/routes/paymentStreams.js`, registered via `registerRoute`
  for both `/api` and `/api/v1`.
- Endpoints: create a stream, read its live accrued amount, decrease its
  rate, withdraw, and cancel — each builds and submits the corresponding
  Soroban invocation via the existing `invokeContract` / `simulateContract`
  helpers.
- Authorization mirrors the on-chain rules: sender-only for creating,
  decreasing the rate, and cancelling; recipient-only for withdrawal. Checks
  are made against the local `payment_streams` mirror table (#996) rather
  than the chain, so they stay fast.
- `create_stream`, `withdraw`, and `cancel_stream` aren't implemented in
  `stream.rs` yet (only `decrease_rate_per_second` and
  `get_accrued_amount_on_chain` exist today) — these handlers are wired
  ahead of that landing, same as the Creator Earnings gap. Per the issue's
  acceptance criteria, a test suite is deferred until those entrypoints
  exist.

**#999 — cooperatives.js has no dedicated backend test suite**
- Adds `backend/tests/cooperatives.test.js` covering the core membership
  lifecycle (create, join, leave, list) plus authorization edge cases:
  non-admin attempting an admin transfer, transferring to a non-member,
  a non-member reading pending transactions, and a non-member configuring
  multisig signers.

**#1000 — messages.js has no backend test coverage**
- Adds `backend/tests/messages.test.js` covering sending a message,
  listing conversation history, the unread-count endpoint before and after
  marking as read, HTML sanitization of message content, and that every
  read/write is scoped to the authenticated `req.user.id` from the verified
  JWT — so no account can send or read as another.

## Note

I was unable to execute either new test suite locally: `backend/src/routes/categories.js`
currently has a pre-existing syntax error (two conflicting implementations
concatenated together with an unclosed `router.delete()` block), which
throws at require-time and crashes `app.js` for *any* test file that loads
the app — independent of this change. Left untouched as out of scope for
these four issues; flagging here in case it's worth a follow-up.

Closes #996
Closes #997
Closes #999
Closes #1000

## Test plan
- [ ] `npm test` in `backend/` once `categories.js`'s syntax error is fixed
      upstream (currently blocks the whole suite from loading)
- [ ] Run migration 032 against a scratch DB and confirm `.undo.sql` cleanly
      reverses it