### PR TITLE
test: add backend coverage for bundles, productImport, productVideos,…

### DIFF
--- a/backend/tests/bundles.test.js
+++ b/backend/tests/bundles.test.js
@@ -1,0 +1,340 @@
+'use strict';
+
+/**
+ * Tests for backend/src/routes/bundles.js and bundleDiscounts.js
+ * Closes #1004
+ */
+
+const jwt = require('jsonwebtoken');
+const { request, app, mockDb, mockQuery, getCsrf } = require('./setup');
+
+const SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
+const buyerToken  = jwt.sign({ id: 2, role: 'buyer'  }, SECRET);
+
+function mockPrepare(getResult, allResult, runResult) {
+  mockDb.prepare.mockReturnValue({
+    get:  jest.fn().mockReturnValue(getResult),
+    all:  jest.fn().mockReturnValue(allResult  ?? []),
+    run:  jest.fn().mockReturnValue(runResult  ?? { lastInsertRowid: 1, changes: 1 }),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.query.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+// ── GET /api/bundles ──────────────────────────────────────────────────────────
+describe('GET /api/bundles', () => {
+  it('returns empty list when no bundles exist', async () => {
+    mockPrepare(null, []);
+    const res = await request(app).get('/api/bundles');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('returns bundles with their items', async () => {
+    const bundle = { id: 1, name: 'Veggie Box', price: 20, farmer_name: 'Alice' };
+    const items  = [{ product_id: 5, quantity: 2, product_name: 'Carrot', unit: 'kg', stock: 10 }];
+
+    // first prepare call → .all() for bundles; second → .all(id) for items
+    mockDb.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([bundle]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(items) });
+
+    const res = await request(app).get('/api/bundles');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].items).toHaveLength(1);
+  });
+});
+
+// ── POST /api/bundles ─────────────────────────────────────────────────────────
+describe('POST /api/bundles', () => {
+  const validPayload = {
+    name: 'Fruit Box',
+    description: 'Mixed fruits',
+    price: 15,
+    items: [{ product_id: 3, quantity: 2 }],
+  };
+
+  it('returns 401 without auth', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/bundles')
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send(validPayload);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for buyers', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/bundles')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send(validPayload);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/bundles')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ price: 10, items: [{ product_id: 1, quantity: 1 }] });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('returns 400 when price is invalid', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/bundles')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ name: 'Box', price: -5, items: [{ product_id: 1, quantity: 1 }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when items array is empty', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/bundles')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ name: 'Box', price: 10, items: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when a product does not belong to the farmer', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    // product exists but belongs to farmer_id 99, not 1
+    mockDb.prepare.mockReturnValue({
+      get: jest.fn().mockReturnValue({ id: 3, farmer_id: 99 }),
+      all: jest.fn().mockReturnValue([]),
+      run: jest.fn().mockReturnValue({ lastInsertRowid: 1, changes: 1 }),
+    });
+    const res = await request(app)
+      .post('/api/bundles')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send(validPayload);
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a bundle and returns 201', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    // product ownership check passes (farmer_id === 1)
+    mockDb.prepare.mockReturnValue({
+      get: jest.fn().mockReturnValue({ id: 3, farmer_id: 1 }),
+      all: jest.fn().mockReturnValue([]),
+      run: jest.fn().mockReturnValue({ lastInsertRowid: 7, changes: 1 }),
+    });
+    mockDb.transaction.mockImplementation((fn) => () => fn());
+
+    const res = await request(app)
+      .post('/api/bundles')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send(validPayload);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.id).toBeDefined();
+  });
+});
+
+// ── DELETE /api/bundles/:id ───────────────────────────────────────────────────
+describe('DELETE /api/bundles/:id', () => {
+  it('returns 403 for buyers', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .delete('/api/bundles/1')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when bundle not found', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockPrepare(null);
+    const res = await request(app)
+      .delete('/api/bundles/999')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf);
+    expect(res.status).toBe(404);
+  });
+
+  it('deletes own bundle and returns 200', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockDb.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ id: 1, farmer_id: 1 }) })
+      .mockReturnValueOnce({ run: jest.fn().mockReturnValue({ changes: 1 }) });
+    const res = await request(app)
+      .delete('/api/bundles/1')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ── POST /api/bundles/purchase ────────────────────────────────────────────────
+describe('POST /api/bundles/purchase', () => {
+  it('returns 403 for farmers', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/bundles/purchase')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ bundle_id: 1 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when bundle_id is missing', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/bundles/purchase')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when bundle does not exist', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockPrepare(null);
+    const res = await request(app)
+      .post('/api/bundles/purchase')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ bundle_id: 999 });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── GET /api/bundles/orders ───────────────────────────────────────────────────
+describe('GET /api/bundles/orders', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/bundles/orders');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns buyer order history', async () => {
+    mockPrepare(null, [{ id: 1, bundle_name: 'Fruit Box', total_price: 15 }]);
+    const res = await request(app)
+      .get('/api/bundles/orders')
+      .set('Authorization', `Bearer ${buyerToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+});
+
+// ── Bundle Discount CRUD (bundleDiscounts.js) ─────────────────────────────────
+describe('GET /api/farmers/me/bundle-discounts', () => {
+  it('returns 403 for buyers', async () => {
+    const res = await request(app)
+      .get('/api/farmers/me/bundle-discounts')
+      .set('Authorization', `Bearer ${buyerToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns discount tiers for the farmer', async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: 1, min_products: 3, discount_percent: 10 }],
+      rowCount: 1,
+    });
+    const res = await request(app)
+      .get('/api/farmers/me/bundle-discounts')
+      .set('Authorization', `Bearer ${farmerToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+});
+
+describe('POST /api/farmers/me/bundle-discounts', () => {
+  it('returns 403 for buyers', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/farmers/me/bundle-discounts')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ min_products: 3, discount_percent: 10 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when min_products < 2', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/farmers/me/bundle-discounts')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ min_products: 1, discount_percent: 10 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('returns 400 when discount_percent is out of range', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/farmers/me/bundle-discounts')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ min_products: 3, discount_percent: 75 });
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a discount tier and returns 201', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: 5, farmer_id: 1, min_products: 3, discount_percent: 10 }],
+      rowCount: 1,
+    });
+    const res = await request(app)
+      .post('/api/farmers/me/bundle-discounts')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ min_products: 3, discount_percent: 10 });
+    expect(res.status).toBe(201);
+    expect(res.body.data.min_products).toBe(3);
+  });
+
+  it('returns 409 on duplicate tier', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockDb.query.mockRejectedValueOnce(
+      Object.assign(new Error('UNIQUE constraint failed'), { code: '23505' })
+    );
+    const res = await request(app)
+      .post('/api/farmers/me/bundle-discounts')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ min_products: 3, discount_percent: 10 });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('DELETE /api/farmers/me/bundle-discounts/:id', () => {
+  it('returns 404 when tier not found', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const res = await request(app)
+      .delete('/api/farmers/me/bundle-discounts/99')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf);
+    expect(res.status).toBe(404);
+  });
+
+  it('deletes tier and returns 200', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    const res = await request(app)
+      .delete('/api/farmers/me/bundle-discounts/1')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/backend/tests/jest.setup.js
+++ b/backend/tests/jest.setup.js
@@ -118,6 +118,15 @@ jest.mock('../src/routes', () => {
   router.use('/api/notifications', require('../src/routes/notifications'));
   router.use('/api/creator-earnings', require('../src/routes/creatorEarnings'));
   router.use('/api/admin', require('../src/routes/admin'));
+  // #1004 bundles & bundle-discounts
+  router.use('/api/bundles', require('../src/routes/bundles'));
+  router.use('/api/farmers', require('../src/routes/bundleDiscounts'));
+  // #1005 product import
+  router.use('/api/products/import', require('../src/routes/productImport'));
+  // #1006 product videos
+  router.use('/api/products', require('../src/routes/productVideos'));
+  // #1007 product share
+  router.use('/api/products', require('../src/routes/productShare'));
   return router;
 });
 

--- a/backend/tests/productImport.test.js
+++ b/backend/tests/productImport.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+/**
+ * Tests for backend/src/routes/productImport.js
+ * Closes #1005
+ */
+
+const jwt = require('jsonwebtoken');
+const { request, app, mockQuery, getCsrf } = require('./setup');
+
+const SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
+const buyerToken  = jwt.sign({ id: 2, role: 'buyer'  }, SECRET);
+
+// Minimal valid CSV content
+const VALID_CSV = 'name,price,quantity,unit,category\nApple,1.5,100,kg,fruit\nBanana,0.8,200,kg,fruit\n';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+// ── Authorization ─────────────────────────────────────────────────────────────
+describe('POST /api/products/import — auth', () => {
+  it('returns 401 without auth', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([{ name: 'Apple', price: 1, quantity: 10 }]);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for buyers', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([{ name: 'Apple', price: 1, quantity: 10 }]);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── JSON import ───────────────────────────────────────────────────────────────
+describe('POST /api/products/import — JSON', () => {
+  it('returns 400 for empty body', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([]);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('imports well-formed JSON and returns counts', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    // existing names query returns empty → no duplicates
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })  // SELECT existing names
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })  // INSERT row 1
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // INSERT row 2
+
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([
+        { name: 'Apple', price: 1.5, quantity: 100, unit: 'kg', category: 'fruit' },
+        { name: 'Banana', price: 0.8, quantity: 200, unit: 'kg', category: 'fruit' },
+      ]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.imported).toBe(2);
+    expect(res.body.skipped).toBe(0);
+  });
+
+  it('skips rows with invalid price and reports errors', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // existing names
+
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([{ name: 'BadProduct', price: -1, quantity: 10 }]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.skipped).toBe(1);
+    expect(res.body.errors[0].row).toBe(1);
+  });
+
+  it('skips rows with invalid allergen values', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([{ name: 'Exotic', price: 2, quantity: 5, allergens: 'unknown_allergen' }]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.skipped).toBe(1);
+    expect(res.body.errors[0].error).toMatch(/allergen/i);
+  });
+});
+
+// ── Duplicate detection ───────────────────────────────────────────────────────
+describe('POST /api/products/import — duplicate detection', () => {
+  it('skips a product whose name already exists for this farmer', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    // existing names returns 'apple'
+    mockQuery.mockResolvedValueOnce({ rows: [{ lname: 'apple' }], rowCount: 1 });
+
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([{ name: 'Apple', price: 1.5, quantity: 50 }]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.skipped).toBe(1);
+    expect(res.body.errors[0].skipped).toBe(true);
+  });
+
+  it('skips a second occurrence of the same name within the same batch', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // no pre-existing products
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // INSERT first Apple succeeds
+
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .set('Content-Type', 'application/json')
+      .send([
+        { name: 'Apple', price: 1.5, quantity: 50 },
+        { name: 'Apple', price: 2.0, quantity: 30 }, // duplicate in same batch
+      ]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.imported).toBe(1);
+    expect(res.body.skipped).toBe(1);
+  });
+});
+
+// ── CSV import ────────────────────────────────────────────────────────────────
+describe('POST /api/products/import — CSV', () => {
+  it('returns 400 when no file is provided for multipart request', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf);
+    // Without JSON content-type or file, route returns 400
+    expect([400, 415]).toContain(res.status);
+  });
+
+  it('imports a well-formed CSV file', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = await request(app)
+      .post('/api/products/import')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .attach('file', Buffer.from(VALID_CSV), { filename: 'products.csv', contentType: 'text/csv' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.imported).toBe(2);
+  });
+});

--- a/backend/tests/productShare.test.js
+++ b/backend/tests/productShare.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * Tests for backend/src/routes/productShare.js
+ * Closes #1007
+ */
+
+const jwt = require('jsonwebtoken');
+const { request, app, mockQuery, getCsrf } = require('./setup');
+
+const SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const buyerToken = jwt.sign({ id: 2, role: 'buyer' }, SECRET);
+
+const productRow = {
+  id: 1,
+  name: 'Fresh Tomatoes',
+  description: 'Organic tomatoes',
+  image_url: '/uploads/tomato.jpg',
+  farmer_name: 'Alice',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+// ── GET /api/products/:id/share ───────────────────────────────────────────────
+describe('GET /api/products/:id/share', () => {
+  it('returns 400 for a non-numeric product id', async () => {
+    const res = await request(app).get('/api/products/abc/share');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('returns 404 when the product does not exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const res = await request(app).get('/api/products/999/share');
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('not_found');
+  });
+
+  it('returns share metadata for a valid product', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [productRow], rowCount: 1 });
+    const res = await request(app).get('/api/products/1/share');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.productId).toBe(1);
+    expect(res.body.data.title).toContain('Fresh Tomatoes');
+    expect(res.body.data.url).toMatch(/\/product\/1/);
+  });
+
+  it('uses farmer name in description when product has no description', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...productRow, description: null }],
+      rowCount: 1,
+    });
+    const res = await request(app).get('/api/products/1/share');
+    expect(res.status).toBe(200);
+    expect(res.body.data.description).toContain('Alice');
+  });
+});
+
+// ── POST /api/products/:id/share ──────────────────────────────────────────────
+describe('POST /api/products/:id/share', () => {
+  it('returns 400 for a non-numeric product id', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/abc/share')
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ platform: 'twitter' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an unsupported platform', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/1/share')
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ platform: 'myspace' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('validation_error');
+  });
+
+  it('records a share event for an authenticated user', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // INSERT share_events
+
+    const res = await request(app)
+      .post('/api/products/1/share')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ platform: 'twitter' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO share_events'),
+      [1, 2, 'twitter', expect.anything()]
+    );
+  });
+
+  it('records a share event for an unauthenticated visitor (user_id null)', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = await request(app)
+      .post('/api/products/1/share')
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .send({ platform: 'whatsapp' });
+
+    expect(res.status).toBe(201);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO share_events'),
+      [1, null, 'whatsapp', expect.anything()]
+    );
+  });
+
+  it('accepts all supported platforms', async () => {
+    const platforms = ['whatsapp', 'twitter', 'facebook', 'copy_link', 'native_share'];
+    for (const platform of platforms) {
+      const { token: csrf, cookieStr } = await getCsrf();
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      const res = await request(app)
+        .post('/api/products/1/share')
+        .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+        .send({ platform });
+      expect(res.status).toBe(201);
+    }
+  });
+});

--- a/backend/tests/productVideos.test.js
+++ b/backend/tests/productVideos.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * Tests for backend/src/routes/productVideos.js
+ * Closes #1006
+ */
+
+const jwt = require('jsonwebtoken');
+const path = require('path');
+const { request, app, mockQuery, getCsrf } = require('./setup');
+
+const SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const farmerToken = jwt.sign({ id: 1, role: 'farmer' }, SECRET);
+const buyerToken  = jwt.sign({ id: 2, role: 'buyer'  }, SECRET);
+
+// Mock child_process.execFile so ffprobe never runs in tests
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFile: jest.fn(),
+}));
+
+const { execFile } = require('child_process');
+
+// Helper: make ffprobe report a given duration (seconds)
+function mockFfprobe(durationSecs) {
+  execFile.mockImplementation((_bin, _args, cb) => cb(null, String(durationSecs), ''));
+}
+
+// Helper: make ffprobe fail (simulates missing binary)
+function mockFfprobeError(message = 'ffprobe not found') {
+  execFile.mockImplementation((_bin, _args, cb) => cb(new Error(message), '', ''));
+}
+
+// A tiny valid MP4 buffer (just needs to pass multer's mimetype check)
+const DUMMY_VIDEO = Buffer.from('dummy-video-content');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  execFile.mockReset();
+});
+
+// ── GET /api/products/:id/videos ──────────────────────────────────────────────
+describe('GET /api/products/:id/videos', () => {
+  it('returns empty list when no videos exist', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const res = await request(app).get('/api/products/1/videos');
+    expect(res.status).toBe(200);
+    expect(res.body.videos).toEqual([]);
+  });
+
+  it('returns existing video entries', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, video_url: '/uploads/videos/test.mp4', created_at: '2026-01-01' }],
+      rowCount: 1,
+    });
+    const res = await request(app).get('/api/products/1/videos');
+    expect(res.status).toBe(200);
+    expect(res.body.videos).toHaveLength(1);
+    expect(res.body.videos[0].video_url).toBe('/uploads/videos/test.mp4');
+  });
+});
+
+// ── POST /api/products/:id/videos ─────────────────────────────────────────────
+describe('POST /api/products/:id/videos — auth & ownership', () => {
+  it('returns 403 for buyers', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/1/videos')
+      .set('Authorization', `Bearer ${buyerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .attach('video', DUMMY_VIDEO, { filename: 'clip.mp4', contentType: 'video/mp4' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when no file is attached', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/1/videos')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 415 for an unsupported file type', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    const res = await request(app)
+      .post('/api/products/1/videos')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .attach('video', DUMMY_VIDEO, { filename: 'clip.avi', contentType: 'video/avi' });
+    expect(res.status).toBe(415);
+  });
+
+  it('returns 404 when the product does not belong to the farmer', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockFfprobe(30); // duration fine, but ownership check fails
+    // ownership query → no rows
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const res = await request(app)
+      .post('/api/products/1/videos')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .attach('video', DUMMY_VIDEO, { filename: 'clip.mp4', contentType: 'video/mp4' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when the product already has 3 videos', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockFfprobe(30);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })   // ownership OK
+      .mockResolvedValueOnce({ rows: [{ cnt: 3 }], rowCount: 1 });  // count = 3
+
+    const res = await request(app)
+      .post('/api/products/1/videos')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .attach('video', DUMMY_VIDEO, { filename: 'clip.mp4', contentType: 'video/mp4' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('video_limit_exceeded');
+  });
+
+  it('returns 400 when the video exceeds the 120-second limit', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockFfprobe(200); // 200 s > 120 s
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })  // ownership OK
+      .mockResolvedValueOnce({ rows: [{ cnt: 0 }], rowCount: 1 }); // count OK
+
+    const res = await request(app)
+      .post('/api/products/1/videos')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .attach('video', DUMMY_VIDEO, { filename: 'clip.mp4', contentType: 'video/mp4' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('video_too_long');
+  });
+
+  it('uploads successfully and rewrites URL via CDN mock', async () => {
+    const { token: csrf, cookieStr } = await getCsrf();
+    mockFfprobe(60); // 60 s — within limit
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 })              // ownership
+      .mockResolvedValueOnce({ rows: [{ cnt: 0 }], rowCount: 1 })              // count
+      .mockResolvedValueOnce({ rows: [{ id: 9, lastID: 9 }], rowCount: 1 });  // INSERT
+
+    const res = await request(app)
+      .post('/api/products/1/videos')
+      .set('Authorization', `Bearer ${farmerToken}`)
+      .set('Cookie', cookieStr).set('X-CSRF-Token', csrf)
+      .attach('video', DUMMY_VIDEO, { filename: 'clip.mp4', contentType: 'video/mp4' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.videoUrl).toMatch(/\/uploads\/videos\//);
+  });
+});


### PR DESCRIPTION
This PR adds Jest test coverage for four route modules that had none, resolving four open issues in a single pass.

## Changes

- **bundles.test.js** — covers \`GET /api/bundles\`, \`POST /api/bundles\` (validation, ownership, happy path), \`DELETE /api/bundles/:id\`, \`POST /api/bundles/purchase\` (auth, missing bundle_id, 404), \`GET /api/bundles/orders\`, and the full bundle-discount CRUD on \`/api/farmers/me/bundle-discounts\` including duplicate-tier 409 and validation edge cases
- **productImport.test.js** — covers JSON import (empty body, well-formed, bad price, invalid allergen), CSV file import, duplicate detection against the DB, and intra-batch duplicate detection
- **productVideos.test.js** — covers \`GET /:id/videos\`, upload auth/ownership, unsupported MIME type (415), 3-video-per-product limit (409), duration enforcement via mocked \`ffprobe\` (> 120 s → 400), and successful upload with CDN URL rewrite
- **productShare.test.js** — covers share metadata GET (404 / invalid id), share event POST for all five platforms, unauthenticated visitor (null user_id), and invalid platform rejection
- **jest.setup.js** — registers the four new routes (\`/api/bundles\`, \`/api/farmers\`, \`/api/products/import\`, \`/api/products\`) in the global routes mock so the shared \`app\` instance resolves them

## Closes

Closes #1004
Closes #1005
Closes #1006
Closes #1007

" --base main --head test/backend-coverage-1004-1005-1006-1007 2>&1