### PR TITLE
fix(dashboard): resolve issues #1029 #1030 #1031 #1032

### DIFF
--- a/frontend/src/components/dashboard/FlashSaleManager.jsx
+++ b/frontend/src/components/dashboard/FlashSaleManager.jsx
@@ -12,14 +12,24 @@ const s = {
 export default function FlashSaleManager({ products, onChanged }) {
   const [form, setForm] = useState({ product_id: '', flash_sale_price: '', flash_sale_ends_at: '' });
   const [msg, setMsg] = useState(null);
+  const [endsAtError, setEndsAtError] = useState('');
+  const [confirmCancel, setConfirmCancel] = useState(null); // { id, name } of product pending cancel
 
   async function handleSubmit(e) {
     e.preventDefault();
     setMsg(null);
+    setEndsAtError('');
+
+    const endsAt = new Date(form.flash_sale_ends_at);
+    if (!form.flash_sale_ends_at || endsAt <= new Date()) {
+      setEndsAtError('End time must be in the future.');
+      return;
+    }
+
     try {
       const res = await api.setFlashSale(parseInt(form.product_id, 10), {
         flash_sale_price: parseFloat(form.flash_sale_price),
-        flash_sale_ends_at: new Date(form.flash_sale_ends_at).toISOString(),
+        flash_sale_ends_at: endsAt.toISOString(),
       });
       setMsg({ type: 'ok', text: `Flash sale set for product #${res.data.id}` });
       onChanged?.();
@@ -28,14 +38,24 @@ export default function FlashSaleManager({ products, onChanged }) {
     }
   }
 
-  async function handleCancel(productId) {
+  function requestCancel(product) {
+    setConfirmCancel({ id: product.id, name: product.name });
+  }
+
+  async function confirmCancelSale() {
+    const { id } = confirmCancel;
+    setConfirmCancel(null);
     try {
-      await api.cancelFlashSale(productId);
-      setMsg({ type: 'ok', text: `Flash sale canceled for product #${productId}` });
+      await api.cancelFlashSale(id);
+      setMsg({ type: 'ok', text: `Flash sale canceled for product #${id}` });
       onChanged?.();
     } catch (e) {
       setMsg({ type: 'err', text: getErrorMessage(e) });
     }
+  }
+
+  function dismissConfirm() {
+    setConfirmCancel(null);
   }
 
   return (
@@ -46,6 +66,36 @@ export default function FlashSaleManager({ products, onChanged }) {
           {msg.text}
         </div>
       )}
+
+      {confirmCancel && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cancel-flash-sale-title"
+          style={{ background: '#fff7f7', border: '1px solid #c0392b', borderRadius: 10, padding: 20, marginBottom: 16 }}
+        >
+          <p id="cancel-flash-sale-title" style={{ marginBottom: 12, fontWeight: 600, color: '#333' }}>
+            Cancel flash sale for <strong>{confirmCancel.name}</strong>? This will end the promotion immediately.
+          </p>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button
+              type="button"
+              style={{ ...s.btn, background: '#c0392b' }}
+              onClick={confirmCancelSale}
+            >
+              Yes, cancel sale
+            </button>
+            <button
+              type="button"
+              style={{ ...s.btn, background: '#888' }}
+              onClick={dismissConfirm}
+            >
+              Keep sale
+            </button>
+          </div>
+        </div>
+      )}
+
       <form onSubmit={handleSubmit} style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr auto', gap: 10, alignItems: 'end' }}>
         <div>
           <label style={s.label}>Product</label>
@@ -60,7 +110,19 @@ export default function FlashSaleManager({ products, onChanged }) {
         </div>
         <div>
           <label style={s.label}>Ends At</label>
-          <input style={s.input} type="datetime-local" required value={form.flash_sale_ends_at} onChange={e => setForm(f => ({ ...f, flash_sale_ends_at: e.target.value }))} />
+          <input
+            style={{ ...s.input, ...(endsAtError ? { borderColor: '#c0392b' } : {}) }}
+            type="datetime-local"
+            required
+            value={form.flash_sale_ends_at}
+            onChange={e => { setEndsAtError(''); setForm(f => ({ ...f, flash_sale_ends_at: e.target.value })); }}
+            aria-describedby={endsAtError ? 'ends-at-error' : undefined}
+          />
+          {endsAtError && (
+            <span id="ends-at-error" role="alert" style={{ color: '#c0392b', fontSize: 12 }}>
+              {endsAtError}
+            </span>
+          )}
         </div>
         <button type="submit" style={s.btn}>Set Flash Sale</button>
       </form>
@@ -70,7 +132,7 @@ export default function FlashSaleManager({ products, onChanged }) {
             <div style={{ fontSize: 14 }}>
               <strong>{p.name}</strong> – {p.flash_sale_price} XLM until {new Date(p.flash_sale_ends_at).toLocaleString()}
             </div>
-            <button type="button" style={{ ...s.btn, background: '#c0392b' }} onClick={() => handleCancel(p.id)}>Cancel</button>
+            <button type="button" style={{ ...s.btn, background: '#c0392b' }} onClick={() => requestCancel(p)}>Cancel</button>
           </div>
         ))}
       </div>

--- a/frontend/src/components/dashboard/InlineEditField.jsx
+++ b/frontend/src/components/dashboard/InlineEditField.jsx
@@ -6,7 +6,7 @@ import React, { useState, useRef, useEffect } from 'react';
  * - Escape       → cancel, restore original value
  * - onSave must return a Promise; on rejection it reverts + calls onError(msg)
  */
-export default function InlineEditField({ value, type = 'number', min, step = 'any', format, onSave, onError, style }) {
+export default function InlineEditField({ value, type = 'number', min, max, step = 'any', format, onSave, onError, style }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
   const [saving, setSaving] = useState(false);
@@ -28,7 +28,12 @@ export default function InlineEditField({ value, type = 'number', min, step = 'a
 
   async function commit() {
     const parsed = type === 'number' ? parseFloat(draft) : draft;
-    if (type === 'number' && (isNaN(parsed) || (min !== undefined && parsed < min))) {
+    if (
+      type === 'number' &&
+      (isNaN(parsed) ||
+        (min !== undefined && parsed < min) ||
+        (max !== undefined && parsed > max))
+    ) {
       cancel();
       return;
     }
@@ -44,7 +49,8 @@ export default function InlineEditField({ value, type = 'number', min, step = 'a
   }
 
   function handleKeyDown(e) {
-    if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); commit(); }
+    if (e.key === 'Enter') { e.preventDefault(); commit(); }
+    if (e.key === 'Tab') { commit(); }
     if (e.key === 'Escape') cancel();
   }
 
@@ -70,6 +76,7 @@ export default function InlineEditField({ value, type = 'number', min, step = 'a
       ref={inputRef}
       type={type}
       min={min}
+      max={max}
       step={step}
       value={draft}
       disabled={saving}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1125,6 +1125,7 @@ export default function Dashboard() {
                             value={p.price}
                             type="number"
                             min={0.0000001}
+                            max={999999}
                             step="any"
                             format={(v) => `${v} XLM`}
                             onSave={(v) => handleInlineSave(p.id, 'price', v)}
@@ -1137,6 +1138,7 @@ export default function Dashboard() {
                         value={p.quantity}
                         type="number"
                         min={0}
+                        max={99999}
                         step={1}
                         format={(v) => `${v} ${p.unit}`}
                         onSave={(v) => handleInlineSave(p.id, 'quantity', Math.floor(v))}

--- a/frontend/src/test/Dashboard.test.jsx
+++ b/frontend/src/test/Dashboard.test.jsx
@@ -88,4 +88,52 @@ describe('InlineEditField', () => {
     });
     expect(onSave).not.toHaveBeenCalled();
   });
+
+  // #1030 — max prop
+  it('respects max — reverts field when value exceeds max', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(<InlineEditField value={5} type="number" max={100} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '999' } });
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole('spinbutton'), { key: 'Enter' });
+    });
+    expect(onSave).not.toHaveBeenCalled();
+    // back to display mode (reverted)
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+  });
+
+  it('accepts a value exactly at max', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(<InlineEditField value={5} type="number" max={100} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '100' } });
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole('spinbutton'), { key: 'Enter' });
+    });
+    expect(onSave).toHaveBeenCalledWith(100);
+  });
+
+  // #1029 — Tab must NOT call preventDefault (focus advances)
+  it('Tab commits but does not call preventDefault — focus can advance', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(
+      <div>
+        <InlineEditField value={10} onSave={onSave} />
+        <button data-testid="next-field">Next</button>
+      </div>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /click to edit/i }));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '20' } });
+
+    // Simulate Tab key — defaultPrevented must remain false
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    await act(async () => {
+      input.dispatchEvent(tabEvent);
+    });
+
+    expect(tabEvent.defaultPrevented).toBe(false);
+    expect(onSave).toHaveBeenCalledWith(20);
+  });
 });

--- a/frontend/src/test/FlashSaleManager.test.jsx
+++ b/frontend/src/test/FlashSaleManager.test.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import FlashSaleManager from '../../components/dashboard/FlashSaleManager';
+import { api } from '../../api/client';
+
+jest.mock('../../api/client', () => ({
+  api: {
+    setFlashSale: jest.fn(),
+    cancelFlashSale: jest.fn(),
+  },
+}));
+
+const PRODUCTS = [
+  { id: 1, name: 'Apples', flash_sale_price: 2.5, flash_sale_ends_at: new Date(Date.now() + 3600000).toISOString() },
+  { id: 2, name: 'Oranges', flash_sale_price: null, flash_sale_ends_at: null },
+];
+
+function futureDateTime() {
+  // Returns a datetime-local string 1 hour from now
+  const d = new Date(Date.now() + 3600000);
+  // datetime-local format: YYYY-MM-DDTHH:mm
+  return d.toISOString().slice(0, 16);
+}
+
+function pastDateTime() {
+  const d = new Date(Date.now() - 3600000);
+  return d.toISOString().slice(0, 16);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── #1031 — Cancel confirmation dialog ───────────────────────────────────────
+
+describe('FlashSaleManager — cancel confirmation (#1031)', () => {
+  it('does not call api.cancelFlashSale immediately on cancel click', () => {
+    render(<FlashSaleManager products={PRODUCTS} onChanged={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(api.cancelFlashSale).not.toHaveBeenCalled();
+  });
+
+  it('shows a confirmation dialog mentioning the product name after cancel click', () => {
+    render(<FlashSaleManager products={PRODUCTS} onChanged={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/apples/i)).toBeInTheDocument();
+  });
+
+  it('calls api.cancelFlashSale after confirming in the dialog', async () => {
+    api.cancelFlashSale.mockResolvedValue({});
+    render(<FlashSaleManager products={PRODUCTS} onChanged={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /yes, cancel sale/i }));
+    });
+    expect(api.cancelFlashSale).toHaveBeenCalledWith(1);
+  });
+
+  it('does NOT call api.cancelFlashSale if the user dismisses the confirmation', async () => {
+    render(<FlashSaleManager products={PRODUCTS} onChanged={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    fireEvent.click(screen.getByRole('button', { name: /keep sale/i }));
+    expect(api.cancelFlashSale).not.toHaveBeenCalled();
+    // Dialog should be gone
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+// ── #1032 — Future date validation ───────────────────────────────────────────
+
+describe('FlashSaleManager — future date validation (#1032)', () => {
+  function fillForm(endsAt) {
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '2' } });
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '1.5' } });
+    // datetime-local input has no accessible role; query by label text
+    const endsAtInput = screen.getByLabelText(/ends at/i);
+    fireEvent.change(endsAtInput, { target: { value: endsAt } });
+  }
+
+  it('does not call api.setFlashSale and shows an error for a past end time', async () => {
+    render(<FlashSaleManager products={PRODUCTS} onChanged={jest.fn()} />);
+    fillForm(pastDateTime());
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /set flash sale/i }).closest('form'));
+    });
+    expect(api.setFlashSale).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert').textContent).toMatch(/future/i);
+  });
+
+  it('calls api.setFlashSale when end time is in the future', async () => {
+    api.setFlashSale.mockResolvedValue({ data: { id: 2 } });
+    render(<FlashSaleManager products={PRODUCTS} onChanged={jest.fn()} />);
+    fillForm(futureDateTime());
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /set flash sale/i }).closest('form'));
+    });
+    expect(api.setFlashSale).toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clears the error message when the user corrects the end time', async () => {
+    render(<FlashSaleManager products={PRODUCTS} onChanged={jest.fn()} />);
+    fillForm(pastDateTime());
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /set flash sale/i }).closest('form'));
+    });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    // Now update to a future time — error should clear
+    const endsAtInput = screen.getByLabelText(/ends at/i);
+    fireEvent.change(endsAtInput, { target: { value: futureDateTime() } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#1029 - InlineEditField: Tab key no longer calls preventDefault
- Remove e.preventDefault() from the Tab branch in handleKeyDown
- Tab still commits the edit but now allows focus to advance to the next focusable element, restoring WCAG 2.1.1 keyboard compliance
- Enter retains preventDefault (no competing native behavior)

#1030 - InlineEditField: add max prop for upper-bound validation
- Accept optional max prop alongside existing min
- commit() now rejects values above max via cancel(), matching the existing min behavior (no onSave call, field reverts)
- max forwarded to the native <input max> attribute for browser hint
- Dashboard price field capped at 999999 XLM
- Dashboard quantity field capped at 99999 units

#1031 - FlashSaleManager: cancel flash sale requires confirmation
- Replace direct api.cancelFlashSale() call with a two-step flow
- Clicking Cancel sets confirmCancel state {id, name} instead of immediately calling the API
- Inline role=dialog confirmation renders with the product name, a confirm button and a dismiss button
- api.cancelFlashSale is only invoked after explicit user confirmation

#1032 - FlashSaleManager: validate flash_sale_ends_at is in the future
- handleSubmit now compares parsed endsAt against new Date() before calling the API
- Past or empty dates set endsAtError state and return early; api.setFlashSale is never called
- Inline role=alert error message shown below the Ends At input with red border highlight
- Error clears immediately when the user changes the field

Tests:
- Dashboard.test.jsx: added max revert test, exact-max boundary test, and Tab defaultPrevented===false assertion
- FlashSaleManager.test.jsx (new): 4 cancel-confirmation tests covering no-immediate-call, dialog render, confirm path, and dismiss path; 3 future-date validation tests covering past rejection, future acceptance, and error clearance on correction

Closes #1029 
Closes #1030 
Closes #1031 
Closes #1032 