### PR TITLE
test(e2e): admin dispute, auction bidding, subscription lifecycle, and bundle checkout coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,12 +75,21 @@ jobs:
         run: npx wait-on http://localhost:4000/api/products http://localhost:3000 --timeout 60000
         working-directory: frontend
 
+      - name: Seed admin user
+        run: node scripts/seed-admin.js
+        working-directory: backend
+        env:
+          ADMIN_EMAIL: e2e-admin@test.invalid
+          ADMIN_PASSWORD: TestPass1!
+
       - name: Run E2E tests
         run: npx playwright test
         working-directory: e2e
         env:
           BASE_URL: http://localhost:3000
           CI: "true"
+          ADMIN_EMAIL: e2e-admin@test.invalid
+          ADMIN_PASSWORD: TestPass1!
 
       - name: Upload Playwright report
         if: always()

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -385,6 +385,7 @@ registerRoute('/', '/farmers/bundles', require('./bundleDiscounts'));
 registerRoute('/', '', require('./export'));
 registerRoute('/', '/announcements', require('./announcements'));
 registerRoute('/', '/auctions', require('./auctions'));
+registerRoute('/', '/disputes', require('./disputes'));
 
 registerRoute('/', '/categories', require('./categories'));
 

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+
+const ts = Date.now();
+const FARMER_EMAIL = `farmer_admin_${ts}@test.invalid`;
+const BUYER_EMAIL = `buyer_admin_${ts}@test.invalid`;
+const PASS = 'TestPass1!';
+const PRODUCT_NAME = `E2E Dispute Melons ${ts}`;
+const DISPUTE_REASON = `Produce arrived damaged ${ts}`;
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'e2e-admin@test.invalid';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPass1!';
+
+async function apiLogin(request: APIRequestContext, email: string, password: string) {
+  const res = await request.post('/api/v1/auth/login', { data: { email, password } });
+  const body = await res.json();
+  return body.token as string;
+}
+
+async function fetchCsrfToken(request: APIRequestContext) {
+  const res = await request.get('/api/auth/csrf-token');
+  const body = await res.json();
+  return body.csrfToken as string;
+}
+
+// Seeds a paid order and an open dispute directly against the API — there is no
+// buyer-facing "file a dispute" UI yet, only the admin-facing resolution screen.
+test.describe('Admin dispute resolution', () => {
+  test.beforeAll(async ({ browser }) => {
+    const farmerCtx = await browser.newContext();
+    const farmerPage = await farmerCtx.newPage();
+
+    await farmerPage.goto('/register');
+    await farmerPage.fill('#reg-name', `Farmer ${ts}`);
+    await farmerPage.fill('#reg-email', FARMER_EMAIL);
+    await farmerPage.fill('#reg-password', PASS);
+    await farmerPage.selectOption('#reg-role', 'farmer');
+    await farmerPage.click('button[type="submit"]');
+    await expect(farmerPage).toHaveURL(/\/dashboard/);
+
+    await farmerPage.fill('#prod-name', PRODUCT_NAME);
+    await farmerPage.fill('#prod-price', '2');
+    await farmerPage.fill('#prod-qty', '50');
+    await farmerPage.fill('#prod-unit', 'kg');
+    await farmerPage.click('form button[type="submit"]:has-text("List Product")');
+    await expect(farmerPage.locator(`text=${PRODUCT_NAME}`)).toBeVisible({ timeout: 10_000 });
+    await farmerCtx.close();
+
+    const buyerCtx = await browser.newContext();
+    const buyerPage = await buyerCtx.newPage();
+
+    await buyerPage.goto('/register');
+    await buyerPage.fill('#reg-name', `Buyer ${ts}`);
+    await buyerPage.fill('#reg-email', BUYER_EMAIL);
+    await buyerPage.fill('#reg-password', PASS);
+    await buyerPage.selectOption('#reg-role', 'buyer');
+    await buyerPage.click('button[type="submit"]');
+    await expect(buyerPage).toHaveURL(/\/marketplace/);
+
+    await buyerPage.goto('/wallet');
+    await buyerPage.click('button:has-text("Fund")');
+    await buyerPage.waitForTimeout(5_000);
+
+    await buyerPage.goto('/marketplace');
+    await buyerPage.fill('input[aria-label*="earch"]', PRODUCT_NAME);
+    await buyerPage.waitForTimeout(1_000);
+    await buyerPage.locator(`[aria-label="View ${PRODUCT_NAME}"]`).first().click();
+    await buyerPage.waitForURL(/\/product\//);
+    await buyerPage.click('button:has-text("Buy Now")');
+    await buyerPage.waitForTimeout(15_000); // Stellar tx confirmation
+
+    const token = await apiLogin(buyerPage.request, BUYER_EMAIL, PASS);
+    const csrfToken = await fetchCsrfToken(buyerPage.request);
+    const ordersRes = await buyerPage.request.get('/api/v1/orders', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const { data: orders } = await ordersRes.json();
+    const order = orders.find((o: any) => o.product_name === PRODUCT_NAME);
+    expect(order, 'seeded order for the disputed product should exist').toBeTruthy();
+
+    const disputeRes = await buyerPage.request.post('/api/v1/disputes', {
+      headers: { Authorization: `Bearer ${token}`, 'x-csrf-token': csrfToken },
+      data: { order_id: order.id, reason: DISPUTE_REASON },
+    });
+    expect(disputeRes.ok()).toBeTruthy();
+
+    await buyerCtx.close();
+  });
+
+  test('admin logs in, views the open dispute, and resolves it', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('#login-email', ADMIN_EMAIL);
+    await page.fill('#login-password', ADMIN_PASSWORD);
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/admin/);
+
+    const disputeRow = page.locator('tr').filter({ hasText: DISPUTE_REASON });
+    await expect(disputeRow).toBeVisible({ timeout: 10_000 });
+    await expect(disputeRow.locator('text=open')).toBeVisible();
+    await expect(disputeRow.locator(`text=${PRODUCT_NAME}`)).toBeVisible();
+
+    await disputeRow.locator('button:has-text("Resolve")').click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await dialog.locator('select').selectOption('farmer');
+    await dialog.locator('button:has-text("Confirm")').click();
+    await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+    const resolvedRow = page.locator('tr').filter({ hasText: DISPUTE_REASON });
+    await expect(resolvedRow.locator('text=resolved')).toBeVisible({ timeout: 10_000 });
+    await expect(resolvedRow.locator('text=farmer')).toBeVisible();
+    await expect(resolvedRow.locator('button:has-text("Resolve")')).toHaveCount(0);
+  });
+});

--- a/e2e/auction.spec.ts
+++ b/e2e/auction.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+const ts = Date.now();
+const FARMER_EMAIL = `farmer_auction_${ts}@test.invalid`;
+const BUYER_EMAIL = `buyer_auction_${ts}@test.invalid`;
+const PASS = 'TestPass1!';
+const PRODUCT_NAME = `E2E Auction Squash ${ts}`;
+const START_PRICE = 5;
+const BID_AMOUNT = 8.5;
+
+function farFutureLocalDateTime() {
+  const d = new Date(Date.now() + 60 * 60 * 1000); // ends in 1 hour
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+test.describe('Auction bidding flow', () => {
+  test('farmer creates an auction, buyer bids, and the updated leaderboard is reflected for both', async ({ browser }) => {
+    const farmerCtx = await browser.newContext();
+    const farmerPage = await farmerCtx.newPage();
+
+    await farmerPage.goto('/register');
+    await farmerPage.fill('#reg-name', `Farmer ${ts}`);
+    await farmerPage.fill('#reg-email', FARMER_EMAIL);
+    await farmerPage.fill('#reg-password', PASS);
+    await farmerPage.selectOption('#reg-role', 'farmer');
+    await farmerPage.click('button[type="submit"]');
+    await expect(farmerPage).toHaveURL(/\/dashboard/);
+
+    await farmerPage.fill('#prod-name', PRODUCT_NAME);
+    await farmerPage.fill('#prod-price', '1');
+    await farmerPage.fill('#prod-qty', '50');
+    await farmerPage.fill('#prod-unit', 'kg');
+    await farmerPage.click('form button[type="submit"]:has-text("List Product")');
+    await expect(farmerPage.locator(`text=${PRODUCT_NAME}`)).toBeVisible({ timeout: 10_000 });
+
+    // Create an auction for the product via the Dashboard's auction manager
+    const auctionForm = farmerPage.locator('h3:has-text("Create Auction")').locator('..');
+    await auctionForm.locator('select').selectOption({ label: PRODUCT_NAME });
+    await auctionForm.locator('input[type="number"]').fill(String(START_PRICE));
+    await auctionForm.locator('input[type="datetime-local"]').fill(farFutureLocalDateTime());
+    await auctionForm.locator('button:has-text("Create Auction")').click();
+    await expect(auctionForm.locator('text=Auction created!')).toBeVisible({ timeout: 10_000 });
+
+    // Buyer registers, funds their wallet, and places a bid from the Marketplace
+    const buyerCtx = await browser.newContext();
+    const buyerPage = await buyerCtx.newPage();
+
+    await buyerPage.goto('/register');
+    await buyerPage.fill('#reg-name', `Buyer ${ts}`);
+    await buyerPage.fill('#reg-email', BUYER_EMAIL);
+    await buyerPage.fill('#reg-password', PASS);
+    await buyerPage.selectOption('#reg-role', 'buyer');
+    await buyerPage.click('button[type="submit"]');
+    await expect(buyerPage).toHaveURL(/\/marketplace/);
+
+    await buyerPage.goto('/wallet');
+    await buyerPage.click('button:has-text("Fund")');
+    await buyerPage.waitForTimeout(5_000);
+
+    await buyerPage.goto('/marketplace');
+    const auctionCard = buyerPage
+      .locator('div')
+      .filter({ hasText: PRODUCT_NAME })
+      .filter({ has: buyerPage.locator('button:has-text("Place Bid")') })
+      .last();
+    await expect(auctionCard).toBeVisible({ timeout: 10_000 });
+
+    await auctionCard.locator('input[type="number"]').fill(String(BID_AMOUNT));
+    await auctionCard.locator('button:has-text("Place Bid")').click();
+    await expect(auctionCard.locator('text=✓ Bid placed!')).toBeVisible({ timeout: 10_000 });
+    await expect(auctionCard.locator(`text=${BID_AMOUNT} XLM`)).toBeVisible();
+    await expect(auctionCard.locator('text=1 bid')).toBeVisible();
+
+    // The farmer sees the updated highest bid after refreshing the Marketplace
+    await farmerPage.goto('/marketplace');
+    const farmerAuctionCard = farmerPage
+      .locator('div')
+      .filter({ hasText: PRODUCT_NAME })
+      .filter({ has: farmerPage.locator('button:has-text("Place Bid")') })
+      .last();
+    await expect(farmerAuctionCard.locator(`text=${BID_AMOUNT} XLM`)).toBeVisible({ timeout: 10_000 });
+    await expect(farmerAuctionCard.locator('text=1 bid')).toBeVisible();
+
+    await farmerCtx.close();
+    await buyerCtx.close();
+  });
+});

--- a/e2e/bundle.spec.ts
+++ b/e2e/bundle.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+
+const ts = Date.now();
+const FARMER_EMAIL = `farmer_bundle_${ts}@test.invalid`;
+const BUYER_EMAIL = `buyer_bundle_${ts}@test.invalid`;
+const PASS = 'TestPass1!';
+const ITEM_NAME = `E2E Bundle Peppers ${ts}`;
+const BUNDLE_NAME = `E2E Deal Bundle ${ts}`;
+const ITEM_PRICE = 2;
+const ITEM_QTY_IN_BUNDLE = 3;
+const BUNDLE_PRICE = 4.5; // discounted vs. ITEM_PRICE * ITEM_QTY_IN_BUNDLE = 6
+
+async function apiLogin(request: APIRequestContext, email: string, password: string) {
+  const res = await request.post('/api/v1/auth/login', { data: { email, password } });
+  const body = await res.json();
+  return body.token as string;
+}
+
+async function fetchCsrfToken(request: APIRequestContext) {
+  const res = await request.get('/api/auth/csrf-token');
+  const body = await res.json();
+  return body.csrfToken as string;
+}
+
+// Bundle creation has no farmer-facing UI yet, so the bundle itself is seeded via the API.
+// The test's actual coverage is the buyer-facing purchase and discount-total flow.
+test.describe('Bundle checkout and discount calculation', () => {
+  test.beforeAll(async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto('/register');
+    await page.fill('#reg-name', `Farmer ${ts}`);
+    await page.fill('#reg-email', FARMER_EMAIL);
+    await page.fill('#reg-password', PASS);
+    await page.selectOption('#reg-role', 'farmer');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    await page.fill('#prod-name', ITEM_NAME);
+    await page.fill('#prod-price', String(ITEM_PRICE));
+    await page.fill('#prod-qty', '100');
+    await page.fill('#prod-unit', 'kg');
+    await page.click('form button[type="submit"]:has-text("List Product")');
+    await expect(page.locator(`text=${ITEM_NAME}`)).toBeVisible({ timeout: 10_000 });
+
+    const token = await apiLogin(page.request, FARMER_EMAIL, PASS);
+    const csrfToken = await fetchCsrfToken(page.request);
+    const productsRes = await page.request.get(`/api/v1/products?q=${encodeURIComponent(ITEM_NAME)}`);
+    const { data: products } = await productsRes.json();
+    const productId = products[0].id;
+    expect(productId).toBeTruthy();
+
+    const bundleRes = await page.request.post('/api/v1/bundles', {
+      headers: { Authorization: `Bearer ${token}`, 'x-csrf-token': csrfToken },
+      data: {
+        name: BUNDLE_NAME,
+        description: 'E2E seeded bundle',
+        price: BUNDLE_PRICE,
+        items: [{ product_id: productId, quantity: ITEM_QTY_IN_BUNDLE }],
+      },
+    });
+    expect(bundleRes.ok()).toBeTruthy();
+
+    await ctx.close();
+  });
+
+  test('buyer purchases a bundle and sees the discounted total before paying', async ({ page }) => {
+    await page.goto('/register');
+    await page.fill('#reg-name', `Buyer ${ts}`);
+    await page.fill('#reg-email', BUYER_EMAIL);
+    await page.fill('#reg-password', PASS);
+    await page.selectOption('#reg-role', 'buyer');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/marketplace/);
+
+    await page.goto('/wallet');
+    await page.click('button:has-text("Fund")');
+    await page.waitForTimeout(5_000);
+
+    await page.goto('/marketplace');
+    const bundleCard = page
+      .locator('div')
+      .filter({ hasText: BUNDLE_NAME })
+      .filter({ has: page.locator('button:has-text("Buy Bundle")') })
+      .last();
+    await expect(bundleCard).toBeVisible({ timeout: 10_000 });
+
+    // Checkout total reflects the discounted bundle price, not the sum of individual item prices
+    const individualTotal = ITEM_PRICE * ITEM_QTY_IN_BUNDLE;
+    expect(BUNDLE_PRICE).toBeLessThan(individualTotal);
+    await expect(bundleCard.locator(`text=${BUNDLE_PRICE} XLM`)).toBeVisible();
+
+    await bundleCard.locator('button:has-text("Included Items")').click();
+    await expect(bundleCard.locator(`text=${ITEM_QTY_IN_BUNDLE} × ${ITEM_NAME}`)).toBeVisible();
+
+    await bundleCard.locator('button:has-text("Buy Bundle")').click();
+    await expect(bundleCard.locator('text=Paid!')).toBeVisible({ timeout: 20_000 });
+  });
+});

--- a/e2e/subscription.spec.ts
+++ b/e2e/subscription.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+const ts = Date.now();
+const FARMER_EMAIL = `farmer_sub_${ts}@test.invalid`;
+const BUYER_EMAIL = `buyer_sub_${ts}@test.invalid`;
+const PASS = 'TestPass1!';
+const PRODUCT_NAME = `E2E Subscription Kale ${ts}`;
+
+test.describe('Subscription pause/resume/cancel lifecycle', () => {
+  let productId: number;
+
+  test.beforeAll(async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto('/register');
+    await page.fill('#reg-name', `Farmer ${ts}`);
+    await page.fill('#reg-email', FARMER_EMAIL);
+    await page.fill('#reg-password', PASS);
+    await page.selectOption('#reg-role', 'farmer');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    await page.fill('#prod-name', PRODUCT_NAME);
+    await page.fill('#prod-price', '3');
+    await page.fill('#prod-qty', '200');
+    await page.fill('#prod-unit', 'kg');
+    await page.click('form button[type="submit"]:has-text("List Product")');
+    await expect(page.locator(`text=${PRODUCT_NAME}`)).toBeVisible({ timeout: 10_000 });
+
+    const res = await page.request.get(`/api/v1/products?q=${encodeURIComponent(PRODUCT_NAME)}`);
+    const { data } = await res.json();
+    productId = data[0].id;
+    expect(productId).toBeTruthy();
+
+    await ctx.close();
+  });
+
+  test('create, pause, resume, and cancel a subscription', async ({ page }) => {
+    await page.goto('/register');
+    await page.fill('#reg-name', `Buyer ${ts}`);
+    await page.fill('#reg-email', BUYER_EMAIL);
+    await page.fill('#reg-password', PASS);
+    await page.selectOption('#reg-role', 'buyer');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/marketplace/);
+
+    await page.goto('/subscriptions');
+
+    // Create the subscription (Product ID, then Quantity — the only two number inputs on the page)
+    await page.locator('input[type="number"]').nth(0).fill(String(productId));
+    await page.locator('input[type="number"]').nth(1).fill('2');
+    await page.selectOption('select', 'weekly');
+    await page.click('button:has-text("Subscribe")');
+    await expect(page.locator('text=Subscription created!')).toBeVisible({ timeout: 10_000 });
+
+    const subRow = page.locator('div').filter({ hasText: PRODUCT_NAME }).filter({ hasText: 'Next billing' }).last();
+    await expect(subRow).toBeVisible({ timeout: 10_000 });
+    await expect(subRow.locator('text=active')).toBeVisible();
+    await expect(subRow.locator('text=Next billing')).toBeVisible();
+
+    // Pause
+    await subRow.locator('button:has-text("Pause")').click();
+    await expect(subRow.locator('text=paused')).toBeVisible({ timeout: 10_000 });
+    await expect(subRow.locator('text=Next billing')).toBeVisible();
+
+    // Resume
+    await subRow.locator('button:has-text("Resume")').click();
+    await expect(subRow.locator('text=active')).toBeVisible({ timeout: 10_000 });
+    await expect(subRow.locator('text=Next billing')).toBeVisible();
+
+    // Cancel
+    await subRow.locator('button:has-text("Cancel")').click();
+    const cancelDialog = page.locator('[role="dialog"]');
+    await expect(cancelDialog).toBeVisible();
+    await cancelDialog.locator('button:has-text("Cancel Subscription")').click();
+    await expect(page.locator('text=Subscription cancelled.')).toBeVisible({ timeout: 10_000 });
+    await expect(subRow.locator('text=cancelled')).toBeVisible({ timeout: 10_000 });
+    await expect(subRow.locator('text=Next billing')).toBeVisible();
+  });
+});

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -280,7 +280,7 @@ export const api = {
   adminUnbanUser: (id) => request(`/admin/users/${id}/ban`, { method: 'DELETE' }),
   adminGetStats: () => request('/admin/stats'),
   adminGetDisputes: () => request('/disputes'),
-  adminResolveDispute: (id, body) => request(`/disputes/${id}`, { method: 'PATCH', body }),
+  adminResolveDispute: (id, body) => request(`/disputes/${id}/resolve`, { method: 'PATCH', body }),
   adminGetContracts: (qs = '') => request(`/admin/contracts${qs}`),
   adminRegisterContract: (body) => request('/admin/contracts', { method: 'POST', body }),
   adminDeployContract: (formData) => request('/admin/contracts/deploy', { method: 'POST', body: formData }),

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -80,27 +80,28 @@ function BanModal({ user, onConfirm, onCancel, loading }) {
 
 function ResolveDisputeModal({ dispute, onConfirm, onCancel }) {
   const confirmRef = useRef(null);
-  const [status, setStatus] = useState(dispute.status === 'open' ? 'under_review' : 'resolved');
-  const [resolution, setResolution] = useState('');
+  const [resolution, setResolution] = useState('farmer');
+  const [splitPercentBuyer, setSplitPercentBuyer] = useState('50');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
   useEffect(() => { confirmRef.current?.focus(); }, []);
   async function handleSubmit(e) {
     e.preventDefault();
-    if (status === 'resolved' && !resolution.trim()) { setErr('Resolution note is required.'); return; }
     setBusy(true);
     setErr('');
-    try { await onConfirm(dispute.id, { status, resolution: resolution.trim() || undefined }); }
+    const body = resolution === 'split'
+      ? { resolution, split_percent_buyer: Number(splitPercentBuyer) }
+      : { resolution };
+    try { await onConfirm(dispute.id, body); }
     catch (e) { setErr(e.message); setBusy(false); }
   }
-  const nextStatuses = dispute.status === 'open' ? ['under_review'] : dispute.status === 'under_review' ? ['resolved'] : [];
   return (
     <div role="dialog" aria-modal="true" aria-labelledby="resolve-modal-title"
       onKeyDown={e => e.key === 'Escape' && onCancel()}
       style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
       <div style={{ background: '#fff', borderRadius: 12, padding: 28, maxWidth: 460, width: '90%', boxShadow: '0 4px 24px #0003' }}>
         <div id="resolve-modal-title" style={{ fontWeight: 700, fontSize: 17, marginBottom: 6, color: '#333' }}>
-          Update Dispute #{dispute.id}
+          Resolve Dispute #{dispute.id}
         </div>
         <div style={{ fontSize: 13, color: '#666', marginBottom: 16 }}>
           <strong>{dispute.product_name}</strong> · {dispute.buyer_name} · {Number(dispute.total_price).toFixed(2)} XLM
@@ -109,23 +110,25 @@ function ResolveDisputeModal({ dispute, onConfirm, onCancel }) {
           <strong>Reason:</strong> {dispute.reason}
         </div>
         <form onSubmit={handleSubmit}>
-          <label style={{ display: 'block', fontSize: 13, color: '#555', marginBottom: 4 }}>New Status</label>
-          <select value={status} onChange={e => setStatus(e.target.value)}
+          <label style={{ display: 'block', fontSize: 13, color: '#555', marginBottom: 4 }}>Resolve in favor of</label>
+          <select ref={confirmRef} value={resolution} onChange={e => setResolution(e.target.value)}
             style={{ width: '100%', padding: '8px 12px', border: '1px solid #ddd', borderRadius: 8, fontSize: 14, marginBottom: 14 }}>
-            {nextStatuses.map(s => <option key={s} value={s}>{s.replace('_', ' ')}</option>)}
+            <option value="farmer">Farmer (release funds)</option>
+            <option value="buyer">Buyer (refund)</option>
+            <option value="split">Split</option>
           </select>
-          {status === 'resolved' && (
+          {resolution === 'split' && (
             <>
-              <label style={{ display: 'block', fontSize: 13, color: '#555', marginBottom: 4 }}>Resolution Note</label>
-              <textarea ref={confirmRef} required value={resolution} onChange={e => setResolution(e.target.value)}
-                placeholder="Describe the resolution (release/refund/other)…"
-                style={{ width: '100%', padding: '8px 12px', border: '1px solid #ddd', borderRadius: 8, fontSize: 14, resize: 'vertical', minHeight: 80, boxSizing: 'border-box', marginBottom: 14 }} />
+              <label style={{ display: 'block', fontSize: 13, color: '#555', marginBottom: 4 }}>Buyer share (%)</label>
+              <input type="number" min="0" max="100" required value={splitPercentBuyer}
+                onChange={e => setSplitPercentBuyer(e.target.value)}
+                style={{ width: '100%', padding: '8px 12px', border: '1px solid #ddd', borderRadius: 8, fontSize: 14, marginBottom: 14, boxSizing: 'border-box' }} />
             </>
           )}
           {err && <div style={{ color: '#c0392b', fontSize: 13, marginBottom: 10 }}>{err}</div>}
           <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
             <button type="button" onClick={onCancel} style={{ padding: '8px 18px', borderRadius: 8, border: '1px solid #ddd', background: '#fff', cursor: 'pointer', fontWeight: 600 }}>Cancel</button>
-            <button type="submit" ref={status !== 'resolved' ? confirmRef : undefined} disabled={busy}
+            <button type="submit" disabled={busy}
               style={{ padding: '8px 18px', borderRadius: 8, border: 'none', background: busy ? '#ccc' : '#2d6a4f', color: '#fff', cursor: busy ? 'not-allowed' : 'pointer', fontWeight: 600 }}>
               {busy ? 'Saving…' : 'Confirm'}
             </button>


### PR DESCRIPTION
## Summary
- Adds `e2e/admin.spec.ts`: admin login, viewing a seeded open dispute, and resolving it in favor of a party
- Adds `e2e/auction.spec.ts`: farmer creates an auction, buyer places a bid, updated leaderboard is reflected for both
- Adds `e2e/subscription.spec.ts`: full create → pause → resume → cancel lifecycle, asserting status and next-billing text at each step
- Adds `e2e/bundle.spec.ts`: buyer purchases a bundle and the checkout total reflects the expected per-item discount
- Mounts the previously-orphaned `disputes` router (`backend/src/routes/index.js`) — it existed but was never wired into the app, so the admin dispute list/resolve UI was unreachable
- Aligns the "Resolve Dispute" modal and `api.adminResolveDispute` with the actual backend contract (`PATCH /disputes/:id/resolve`, `resolution: buyer|farmer|split`), since the previous modal called a route/shape that didn't exist server-side
- Seeds a CI admin account (`backend/scripts/seed-admin.js`) in the E2E workflow so `admin.spec.ts` has a real admin to log in as

Closes #1041, closes #1042, closes #1043, closes #1044.

## Test plan
- [ ] `npx playwright test` in `e2e/` against a running backend + frontend preview
- [ ] Verify admin can view and resolve a seeded dispute via `/admin`
- [ ] Verify auction bid updates reflect on both buyer and farmer views
- [ ] Verify subscription pause/resume/cancel updates status + next-billing text
- [ ] Verify bundle checkout total matches the discounted bundle price

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01GBkRQuYNDpuaHGaSA9uYmL