### PR TITLE
#1033 Fix Pagination.jsx buildPageList clamping when totalPages shrinks

### DIFF
--- a/Somzilla.md
+++ b/Somzilla.md
@@ -1,0 +1,15 @@
+Issue:#1033 Pagination.jsx's buildPageList does not clamp the current page to a valid range, rendering an invalid page button when totalPages shrinks
+
+Project
+FarmersMarketplace — Frontend (Shared Components)
+
+Description
+frontend/src/components/Pagination.jsx's buildPageList(current, total) always includes the caller-supplied current page in its displayed set:
+
+const pages = new Set([1, total, current]);
+If a parent component's page prop becomes stale relative to a shrinking totalPages — for example, a user is on page 8 of a filtered product list, then changes a filter that reduces the result set to 3 total pages, and the parent hasn't yet clamped page back into range before re-rendering Pagination — buildPageList will happily include 8 in the rendered button list even though 8 > totalPages. Clicking that button calls onChange(8), requesting a page that doesn't exist.
+
+Acceptance Criteria
+ buildPageList (or the component itself) clamps current to [1, total] before building the page-button set.
+ A test passes current=8, total=3 and asserts no button for page 8 is rendered, and that a valid page (e.g. page 3) is shown/marked current instead.
+ Callers of Pagination are checked to confirm they clamp page in their own state when totalPages changes, as defense in depth.

--- a/frontend/src/components/Pagination.jsx
+++ b/frontend/src/components/Pagination.jsx
@@ -18,15 +18,17 @@ export default function Pagination({ page, totalPages, total, limit, onChange })
 
   if (!totalPages || totalPages <= 1) return null;
 
-  const pages = buildPageList(page, totalPages);
+  // Clamp page to a valid range so stale props don't render out-of-range buttons
+  const safePage = Math.max(1, Math.min(page, totalPages));
+  const pages = buildPageList(safePage, totalPages);
 
   const goPrev = useCallback(() => {
-    if (page > 1) onChange(page - 1);
-  }, [page, onChange]);
+    if (safePage > 1) onChange(safePage - 1);
+  }, [safePage, onChange]);
 
   const goNext = useCallback(() => {
-    if (page < totalPages) onChange(page + 1);
-  }, [page, totalPages, onChange]);
+    if (safePage < totalPages) onChange(safePage + 1);
+  }, [safePage, totalPages, onChange]);
 
   // Keyboard navigation: left/right arrow keys
   const handleKeyDown = useCallback((e) => {
@@ -50,8 +52,8 @@ export default function Pagination({ page, totalPages, total, limit, onChange })
     <nav aria-label="Pagination" ref={containerRef}>
       <div style={s.wrap}>
         <button
-          style={{ ...s.btn, ...(page <= 1 ? s.disabled : {}) }}
-          disabled={page <= 1}
+          style={{ ...s.btn, ...(safePage <= 1 ? s.disabled : {}) }}
+          disabled={safePage <= 1}
           onClick={goPrev}
           aria-label="Previous page"
         >
@@ -64,10 +66,10 @@ export default function Pagination({ page, totalPages, total, limit, onChange })
           ) : (
             <button
               key={p}
-              style={{ ...s.btn, ...(p === page ? s.active : {}) }}
-              onClick={() => p !== page && onChange(p)}
+              style={{ ...s.btn, ...(p === safePage ? s.active : {}) }}
+              onClick={() => p !== safePage && onChange(p)}
               aria-label={`Page ${p}`}
-              aria-current={p === page ? 'page' : undefined}
+              aria-current={p === safePage ? 'page' : undefined}
             >
               {p}
             </button>
@@ -75,8 +77,8 @@ export default function Pagination({ page, totalPages, total, limit, onChange })
         )}
 
         <button
-          style={{ ...s.btn, ...(page >= totalPages ? s.disabled : {}) }}
-          disabled={page >= totalPages}
+          style={{ ...s.btn, ...(safePage >= totalPages ? s.disabled : {}) }}
+          disabled={safePage >= totalPages}
           onClick={goNext}
           aria-label="Next page"
         >
@@ -93,6 +95,10 @@ export default function Pagination({ page, totalPages, total, limit, onChange })
 
 /** Returns a compact page list with ellipsis for large ranges. */
 function buildPageList(current, total) {
+  // Clamp current to a valid range so stale callers don't produce out-of-range buttons
+  if (current < 1) current = 1;
+  if (current > total) current = total;
+
   if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
 
   const pages = new Set([1, total, current]);

--- a/frontend/src/pages/Marketplace.jsx
+++ b/frontend/src/pages/Marketplace.jsx
@@ -532,6 +532,12 @@ export default function Marketplace() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Clamp page when totalPages shrinks (defense in depth)
+  useEffect(() => {
+    if (pageRef.current > totalPages) {
+      pageRef.current = totalPages;
+    }
+  }, [totalPages]);
   // Save scroll position continuously for SPA back-navigation
   useEffect(() => {
     const saveScroll = () => sessionStorage.setItem(SCROLL_KEY + '_y', String(window.scrollY));

--- a/frontend/src/test/Pagination.test.jsx
+++ b/frontend/src/test/Pagination.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import Pagination from '../components/Pagination';
+
+describe('#1033 Pagination buildPageList clamping', () => {
+  it('clamps current=8 when totalPages=3 and does not render an invalid page-8 button', () => {
+    const onChange = vi.fn();
+    render(
+      <Pagination
+        page={8}
+        totalPages={3}
+        total={30}
+        limit={10}
+        onChange={onChange}
+      />,
+    );
+
+    // Should NOT have a page-8 button
+    expect(screen.queryByLabelText('Page 8')).toBeNull();
+
+    // Should have a page-3 button marked as current instead
+    const page3btn = screen.getByLabelText('Page 3');
+    expect(page3btn).toBeTruthy();
+    expect(page3btn.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('clamps current=0 to page 1 when totalPages>=1', () => {
+    const onChange = vi.fn();
+    render(
+      <Pagination
+        page={0}
+        totalPages={5}
+        total={50}
+        limit={10}
+        onChange={onChange}
+      />,
+    );
+
+    // Page 1 is rendered and marked current
+    const page1btn = screen.getByLabelText('Page 1');
+    expect(page1btn).toBeTruthy();
+    expect(page1btn.getAttribute('aria-current')).toBe('page');
+
+    // Page 0 is not rendered
+    expect(screen.queryByLabelText('Page 0')).toBeNull();
+  });
+
+  it('does not render any buttons when totalPages <= 1', () => {
+    render(
+      <Pagination
+        page={1}
+        totalPages={1}
+        total={5}
+        limit={10}
+        onChange={vi.fn()}
+      />,
+    );
+
+    // aria-label for prev/next/page buttons should not exist
+    expect(screen.queryByLabelText('Previous page')).toBeNull();
+    expect(screen.queryByLabelText('Next page')).toBeNull();
+    expect(screen.queryByLabelText('Page 1')).toBeNull();
+  });
+
+  it('prev button navigates from clamped safePage (3) not stale page (8)', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Pagination
+        page={8}
+        totalPages={3}
+        total={30}
+        limit={10}
+        onChange={onChange}
+      />,
+    );
+
+    // Prev button is NOT disabled because safePage=3 (clamped) > 1
+    const prevBtn = screen.getByLabelText('Previous page');
+    expect(prevBtn).not.toBeDisabled();
+
+    // Clicking Prev goes to safePage-1 = 2, not 7
+    await user.click(prevBtn);
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it('clicking a valid page calls onChange with that page number', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Pagination
+        page={3}
+        totalPages={5}
+        total={50}
+        limit={10}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Page 4'));
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it('renders correct button set for large page range with ellipsis', () => {
+    render(
+      <Pagination
+        page={10}
+        totalPages={20}
+        total={200}
+        limit={10}
+        onChange={vi.fn()}
+      />,
+    );
+
+    // Buttons around page 10 should exist (8,9,10,11,12)
+    expect(screen.getByLabelText('Page 8')).toBeTruthy();
+    expect(screen.getByLabelText('Page 9')).toBeTruthy();
+    expect(screen.getByLabelText('Page 10')).toBeTruthy();
+    expect(screen.getByLabelText('Page 11')).toBeTruthy();
+    expect(screen.getByLabelText('Page 12')).toBeTruthy();
+    // First and last page buttons
+    expect(screen.getByLabelText('Page 1')).toBeTruthy();
+    expect(screen.getByLabelText('Page 20')).toBeTruthy();
+  });
+
+  it('buildPageList returns correct range for small totalPages (≤7)', () => {
+    render(
+      <Pagination
+        page={3}
+        totalPages={5}
+        total={25}
+        limit={5}
+        onChange={vi.fn()}
+      />,
+    );
+
+    // All 5 page buttons rendered directly (no ellipsis)
+    for (let i = 1; i <= 5; i++) {
+      expect(screen.getByLabelText(`Page ${i}`)).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
This PR 
Closes #1033 

- Clamp `current` in buildPageList() to [1, total] range
- Clamp `page` prop as `safePage` in the component for defense in depth
- Add comprehensive Pagination.test.jsx with 7 tests validating clamping behavior
- Add defense-in-depth useEffect in Marketplace.jsx to clamp pageRef.current when totalPages changes

Fixes issue where a stale page prop (e.g. page=8) would render an invalid page button when totalPages shrank (e.g. to 3), causing onChange(8) to be called for a page that does not exist.