### PR TITLE
fix: form accessibility, reduced-motion, code splitting, bundle size CI (#1053 #1054 #1055 #1056)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,51 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  frontend-bundle-size:
+    name: Frontend Bundle Size Budget
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Check bundle size budgets
+        # BUNDLE_INITIAL_BUDGET_KB: max KiB for vendor+index (initial load, uncompressed)
+        # BUNDLE_TOTAL_BUDGET_KB:   max KiB for all JS chunks combined (uncompressed)
+        # Raise these intentionally and document the reason — never bump silently.
+        env:
+          BUNDLE_INITIAL_BUDGET_KB: 500
+          BUNDLE_TOTAL_BUDGET_KB: 5000
+        run: node scripts/check-bundle-size.js
+
+      - name: Upload bundle size report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-bundle-size
+          path: frontend/dist/assets/*.js
+          retention-days: 30
+
   smoke-test-testnet:
     name: Escrow Testnet Smoke Test
     # Only on merges to main — this touches live Stellar Testnet, not on every PR.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:report": "playwright show-report",
+    "check:bundle-size": "node scripts/check-bundle-size.js",
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --write . --ignore-path ../.prettierignore"
   },

--- a/frontend/scripts/check-bundle-size.js
+++ b/frontend/scripts/check-bundle-size.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * check-bundle-size.js  (#1056)
+ *
+ * Reads the Vite production build output from dist/assets/, measures the
+ * total size of all JS chunks and the combined initial-load chunk size
+ * (vendor + index), then fails with a non-zero exit code when either budget
+ * is exceeded.
+ *
+ * Budgets (uncompressed bytes):
+ *   INITIAL_BUDGET_KB  – vendor + index chunks that every page must download
+ *   TOTAL_BUDGET_KB    – all JS chunks combined
+ *
+ * Override budgets for a deliberate one-off increase:
+ *   BUNDLE_INITIAL_BUDGET_KB=600 BUNDLE_TOTAL_BUDGET_KB=6000 node scripts/check-bundle-size.js
+ */
+
+import { readdirSync, statSync, writeFileSync } from 'fs';
+import { join, basename } from 'path';
+
+const DIST_ASSETS = join(process.cwd(), 'dist', 'assets');
+
+// Budgets in kibibytes (1 KiB = 1024 bytes).
+const INITIAL_BUDGET_KB = Number(process.env.BUNDLE_INITIAL_BUDGET_KB ?? 500);
+const TOTAL_BUDGET_KB   = Number(process.env.BUNDLE_TOTAL_BUDGET_KB   ?? 5000);
+
+function kib(bytes) {
+  return (bytes / 1024).toFixed(1);
+}
+
+let files;
+try {
+  files = readdirSync(DIST_ASSETS);
+} catch {
+  console.error(`[bundle-size] dist/assets not found — run "npm run build" first.`);
+  process.exit(1);
+}
+
+const jsFiles = files
+  .filter(f => f.endsWith('.js'))
+  .map(f => ({ name: f, size: statSync(join(DIST_ASSETS, f)).size }))
+  .sort((a, b) => b.size - a.size);
+
+if (jsFiles.length === 0) {
+  console.error('[bundle-size] No JS files found in dist/assets.');
+  process.exit(1);
+}
+
+// Initial chunks = vendor chunk + index/main chunk (everything a user must
+// download before React can render, regardless of which route they visit).
+const initialChunks = jsFiles.filter(
+  f => f.name.startsWith('vendor') || f.name.startsWith('index') || f.name.startsWith('main')
+);
+const initialBytes  = initialChunks.reduce((s, f) => s + f.size, 0);
+const totalBytes    = jsFiles.reduce((s, f) => s + f.size, 0);
+
+// ── Report ──────────────────────────────────────────────────────────────────
+console.log('\n── Bundle size report ──────────────────────────────────────');
+console.log('Chunk                                        Size');
+console.log('─'.repeat(52));
+for (const f of jsFiles) {
+  const flag = initialChunks.some(c => c.name === f.name) ? ' ◀ initial' : '';
+  console.log(`  ${basename(f.name).padEnd(42)} ${kib(f.size).padStart(7)} KiB${flag}`);
+}
+console.log('─'.repeat(52));
+console.log(`  Initial load total${' '.repeat(23)} ${kib(initialBytes).padStart(7)} KiB  (budget: ${INITIAL_BUDGET_KB} KiB)`);
+console.log(`  All chunks total  ${' '.repeat(23)} ${kib(totalBytes).padStart(7)} KiB  (budget: ${TOTAL_BUDGET_KB} KiB)`);
+console.log();
+
+// ── Write GitHub step summary if running in CI ───────────────────────────────
+const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+if (summaryFile) {
+  const rows = jsFiles
+    .map(f => `| \`${f.name}\` | ${kib(f.size)} KiB | ${initialChunks.some(c => c.name === f.name) ? '✅ initial' : ''} |`)
+    .join('\n');
+  const md = [
+    '## 📦 Frontend Bundle Size Report',
+    '',
+    `| Chunk | Size | Initial? |`,
+    `|-------|------|----------|`,
+    rows,
+    '',
+    `**Initial load**: ${kib(initialBytes)} KiB (budget: ${INITIAL_BUDGET_KB} KiB)`,
+    `**Total JS**: ${kib(totalBytes)} KiB (budget: ${TOTAL_BUDGET_KB} KiB)`,
+  ].join('\n');
+  writeFileSync(summaryFile, md + '\n', { flag: 'a' });
+}
+
+// ── Budget enforcement ───────────────────────────────────────────────────────
+let failed = false;
+
+if (initialBytes / 1024 > INITIAL_BUDGET_KB) {
+  console.error(
+    `[bundle-size] ❌ Initial chunk ${kib(initialBytes)} KiB exceeds budget of ${INITIAL_BUDGET_KB} KiB.`
+  );
+  console.error(`   To raise the budget deliberately, set BUNDLE_INITIAL_BUDGET_KB in the CI workflow.`);
+  failed = true;
+} else {
+  console.log(`[bundle-size] ✅ Initial chunk ${kib(initialBytes)} KiB is within budget (${INITIAL_BUDGET_KB} KiB).`);
+}
+
+if (totalBytes / 1024 > TOTAL_BUDGET_KB) {
+  console.error(
+    `[bundle-size] ❌ Total bundle ${kib(totalBytes)} KiB exceeds budget of ${TOTAL_BUDGET_KB} KiB.`
+  );
+  console.error(`   To raise the budget deliberately, set BUNDLE_TOTAL_BUDGET_KB in the CI workflow.`);
+  failed = true;
+} else {
+  console.log(`[bundle-size] ✅ Total bundle ${kib(totalBytes)} KiB is within budget (${TOTAL_BUDGET_KB} KiB).`);
+}
+
+process.exit(failed ? 1 : 0);

--- a/frontend/src/browser-compat.css
+++ b/frontend/src/browser-compat.css
@@ -62,6 +62,24 @@ html {
   }
 }
 
+/* ── Reduce / disable non-essential motion for users who prefer it ─────────── */
+@media (prefers-reduced-motion: reduce) {
+  /*
+   * Kill every animation and transition by default so no component accidentally
+   * moves when the user has opted out of motion at the OS level.
+   * Components may still apply instant colour / opacity changes via
+   * transition: none overrides.
+   */
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ── Image rendering normalization ────────────────────────────────────────── */
 img {
   display: block;

--- a/frontend/src/components/FlashSaleCountdown.jsx
+++ b/frontend/src/components/FlashSaleCountdown.jsx
@@ -7,6 +7,14 @@ const css = `
 }
 .fsc-pulse { animation: fsc-pulse 1s ease-in-out infinite; }
 .fsc-pulse-fast { animation: fsc-pulse 0.5s ease-in-out infinite; }
+
+/* Respect prefers-reduced-motion — disable urgency animation */
+@media (prefers-reduced-motion: reduce) {
+  .fsc-pulse,
+  .fsc-pulse-fast {
+    animation: none;
+  }
+}
 `;
 
 function getRemaining(endAt) {

--- a/frontend/src/components/dashboard/ProductForm.jsx
+++ b/frontend/src/components/dashboard/ProductForm.jsx
@@ -381,12 +381,15 @@ export default function ProductForm({ harvestBatches, onProductAdded }) {
           <>
             <label style={s.label}>Expected Delivery Date</label>
             <input
+              id="prod-preorder-date"
               style={formErrors.preorder_delivery_date ? s.inputErr : s.input}
               type="date"
               value={form.preorder_delivery_date}
               onChange={e => { setForm({ ...form, preorder_delivery_date: e.target.value }); if (formErrors.preorder_delivery_date) setFormErrors(fe => ({ ...fe, preorder_delivery_date: '' })); }}
+              aria-invalid={!!formErrors.preorder_delivery_date}
+              aria-describedby={formErrors.preorder_delivery_date ? 'prod-preorder-date-err' : undefined}
             />
-            {formErrors.preorder_delivery_date && <div style={s.fieldErr} role="alert">{formErrors.preorder_delivery_date}</div>}
+            {formErrors.preorder_delivery_date && <div id="prod-preorder-date-err" style={s.fieldErr} role="alert">{formErrors.preorder_delivery_date}</div>}
           </>
         )}
 

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -89,15 +89,19 @@ export function LoginPage() {
           <div style={s.field}>
             <label style={s.label} htmlFor="login-email">{t('auth.email')}</label>
             <input id="login-email" style={errors.email ? s.inputErr : s.input} type="email"
-              value={form.email} onChange={e => handleChange('email', e.target.value)} autoComplete="email" />
-            {errors.email && <div style={s.err} role="alert">{errors.email}</div>}
+              value={form.email} onChange={e => handleChange('email', e.target.value)} autoComplete="email"
+              aria-invalid={!!errors.email}
+              aria-describedby={errors.email ? 'login-email-err' : undefined} />
+            {errors.email && <div id="login-email-err" style={s.err} role="alert">{errors.email}</div>}
           </div>
           <div style={s.field}>
             <label style={s.label} htmlFor="login-password">{t('auth.password')}</label>
             <input id="login-password" ref={passwordRef} style={errors.password ? s.inputErr : s.input} type="password"
-              value={form.password} onChange={e => handleChange('password', e.target.value)} autoComplete="current-password" />
+              value={form.password} onChange={e => handleChange('password', e.target.value)} autoComplete="current-password"
+              aria-invalid={!!errors.password}
+              aria-describedby={errors.password ? 'login-password-err' : undefined} />
             <PasswordStrength password={form.password} />
-            {errors.password && <div style={s.err} role="alert">{errors.password}</div>}
+            {errors.password && <div id="login-password-err" style={s.err} role="alert">{errors.password}</div>}
           </div>
           {formError && <div style={s.formErr} role="alert">{formError}</div>}
           <button style={s.btn} type="submit">{t('auth.loginBtn')}</button>
@@ -152,21 +156,27 @@ export function RegisterPage() {
           <div style={s.field}>
             <label style={s.label} htmlFor="reg-name">{t('auth.name')}</label>
             <input id="reg-name" style={errors.name ? s.inputErr : s.input} type="text"
-              value={form.name} onChange={e => handleChange('name', e.target.value)} autoComplete="name" />
-            {errors.name && <div style={s.err} role="alert">{errors.name}</div>}
+              value={form.name} onChange={e => handleChange('name', e.target.value)} autoComplete="name"
+              aria-invalid={!!errors.name}
+              aria-describedby={errors.name ? 'reg-name-err' : undefined} />
+            {errors.name && <div id="reg-name-err" style={s.err} role="alert">{errors.name}</div>}
           </div>
           <div style={s.field}>
             <label style={s.label} htmlFor="reg-email">{t('auth.email')}</label>
             <input id="reg-email" style={errors.email ? s.inputErr : s.input} type="email"
-              value={form.email} onChange={e => handleChange('email', e.target.value)} autoComplete="email" />
-            {errors.email && <div style={s.err} role="alert">{errors.email}</div>}
+              value={form.email} onChange={e => handleChange('email', e.target.value)} autoComplete="email"
+              aria-invalid={!!errors.email}
+              aria-describedby={errors.email ? 'reg-email-err' : undefined} />
+            {errors.email && <div id="reg-email-err" style={s.err} role="alert">{errors.email}</div>}
           </div>
           <div style={s.field}>
             <label style={s.label} htmlFor="reg-password">{t('auth.password')}</label>
             <input id="reg-password" style={errors.password ? s.inputErr : s.input} type="password"
-              value={form.password} onChange={e => handleChange('password', e.target.value)} autoComplete="new-password" />
+              value={form.password} onChange={e => handleChange('password', e.target.value)} autoComplete="new-password"
+              aria-invalid={!!errors.password}
+              aria-describedby={errors.password ? 'reg-password-err' : undefined} />
             <PasswordStrength password={form.password} />
-            {errors.password && <div style={s.err} role="alert">{errors.password}</div>}
+            {errors.password && <div id="reg-password-err" style={s.err} role="alert">{errors.password}</div>}
           </div>
           <div style={s.field}>
             <label style={s.label} htmlFor="reg-role">{t('auth.iAm')}</label>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -70,6 +70,10 @@ function Toast({ toast }) {
       }}
     >
       {toast.text}
+    </div>
+  );
+}
+
 function PasswordStrengthBar({ password }) {
   if (!password) return null;
   const issues = validatePassword(password);
@@ -131,10 +135,14 @@ function PasswordChangeForm() {
         <PasswordStrengthBar password={form.newPw} />
 
         <label style={{ ...s.label, marginTop: 12 }} htmlFor="cp-confirm">Confirm New Password</label>
-        <input id="cp-confirm" style={s.input} type="password" value={form.confirm}
-          onChange={e => setForm(f => ({ ...f, confirm: e.target.value }))} autoComplete="new-password" />
+        <input id="cp-confirm"
+          style={{ ...s.input, ...(form.confirm && form.newPw !== form.confirm ? { border: '1px solid #c0392b' } : {}) }}
+          type="password" value={form.confirm}
+          onChange={e => setForm(f => ({ ...f, confirm: e.target.value }))} autoComplete="new-password"
+          aria-invalid={!!(form.confirm && form.newPw !== form.confirm)}
+          aria-describedby={form.confirm && form.newPw !== form.confirm ? 'cp-confirm-err' : undefined} />
         {form.confirm && form.newPw !== form.confirm && (
-          <div style={{ fontSize: 12, color: '#c0392b', marginTop: 3 }}>Passwords do not match</div>
+          <div id="cp-confirm-err" style={{ fontSize: 12, color: '#c0392b', marginTop: 3 }} role="alert">Passwords do not match</div>
         )}
 
         {msg && (

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,15 +1,26 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// Bundle size budgets (kB, uncompressed).
+// Raise these deliberately and document the reason — do not bump silently.
+const INITIAL_CHUNK_BUDGET_KB = 500;   // vendor + index combined initial load
+const TOTAL_BUNDLE_BUDGET_KB  = 5000;  // whole dist/assets directory
+
 export default defineConfig({
   plugins: [react()],
   build: {
+    // Warn (and fail in CI via the check-bundle-size script) when any single
+    // chunk exceeds this limit.
+    chunkSizeWarningLimit: INITIAL_CHUNK_BUDGET_KB,
     rollupOptions: {
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom', 'react-router-dom'],
         },
       },
+      // Treat the optional Sentry SDK as external — it is loaded dynamically
+      // only when VITE_SENTRY_DSN is set, so it must never be bundled.
+      external: (id) => id === '@sentry/react',
     },
   },
   server: {


### PR DESCRIPTION
## Summary

Fixes four frontend issues in a single PR.

---

### #1053 — Form validation errors not programmatically associated with inputs

Every validated field now sets `aria-invalid="true"` and `aria-describedby` pointing at its error message element when invalid.

**Files changed:**
- `frontend/src/pages/Auth.jsx` — login email/password + register name/email/password
- `frontend/src/pages/Settings.jsx` — confirm-password mismatch in PasswordChangeForm
- `frontend/src/components/dashboard/ProductForm.jsx` — pre-order delivery date

---

### #1054 — FlashSaleCountdown and other animations don't respect prefers-reduced-motion

**Files changed:**
- `frontend/src/components/FlashSaleCountdown.jsx` — `@media (prefers-reduced-motion: reduce)` disables `.fsc-pulse` and `.fsc-pulse-fast` animations
- `frontend/src/browser-compat.css` — global `@media (prefers-reduced-motion: reduce)` block sets `animation-duration: 0.01ms` and `transition-duration: 0.01ms` on all elements

---

### #1055 — No route-based code splitting

Already implemented in `App.jsx`: all 14 route components use `React.lazy()` + `<Suspense fallback={<PageLoader />}>`. No additional changes needed.

---

### #1056 — No bundle-size budget tracked or enforced in CI

**Files changed:**
- `frontend/scripts/check-bundle-size.js` — reports initial-chunk (vendor+index) and total JS size; fails CI when either exceeds budget; writes GitHub step summary
- `frontend/package.json` — adds `check:bundle-size` script
- `frontend/vite.config.js` — adds `chunkSizeWarningLimit`, externalizes optional `@sentry/react`
- `.github/workflows/ci.yml` — adds `frontend-bundle-size` job (build → check → upload artifact)
  - Initial load budget: **500 KiB**
  - Total JS budget: **5000 KiB**

---

Closes #1053
Closes #1054
Closes #1055
Closes #1056