### PR TITLE
feat(i18n): migrate count-based strings to i18next plural API (#1062)

### DIFF
--- a/frontend/src/components/Pagination.jsx
+++ b/frontend/src/components/Pagination.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const s = {
   wrap:    { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, marginTop: 24, flexWrap: 'wrap' },
@@ -15,6 +16,7 @@ const s = {
  */
 export default function Pagination({ page, totalPages, total, limit, onChange }) {
   const containerRef = useRef(null);
+  const { t } = useTranslation();
 
   if (!totalPages || totalPages <= 1) return null;
 
@@ -85,8 +87,8 @@ export default function Pagination({ page, totalPages, total, limit, onChange })
           Next ›
         </button>
 
-        <span style={s.info} aria-hidden="true">
-          {total} result{total !== 1 ? 's' : ''}
+        <span style={s.info} className="pagination-info" aria-hidden="true">
+          {t('pagination.resultCount', { count: total })}
         </span>
       </div>
     </nav>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -208,5 +208,9 @@
     "errors": "Errors",
     "row": "Row {{n}}",
     "andMore": "...and {{n}} more errors"
+  },
+  "pagination": {
+    "resultCount_one": "{{count}} result",
+    "resultCount_other": "{{count}} results"
   }
 }

--- a/frontend/src/i18n/sw.json
+++ b/frontend/src/i18n/sw.json
@@ -208,5 +208,9 @@
     "errors": "Makosa",
     "row": "Safu {{n}}",
     "andMore": "...na makosa {{n}} zaidi"
+  },
+  "pagination": {
+    "resultCount_one": "tokeo {{count}}",
+    "resultCount_other": "matokeo {{count}}"
   }
 }

--- a/frontend/src/test/swahiliPluralization.test.js
+++ b/frontend/src/test/swahiliPluralization.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from '../i18n/en.json';
+import sw from '../i18n/sw.json';
+
+let testI18n;
+
+beforeAll(async () => {
+  testI18n = i18n.createInstance();
+  await testI18n.use(initReactI18next).init({
+    resources: {
+      en: { translation: en },
+      sw: { translation: sw },
+    },
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+});
+
+describe('Swahili pluralization (#1062)', () => {
+  describe('English locale', () => {
+    it('renders singular for count=1', () => {
+      testI18n.changeLanguage('en');
+      expect(testI18n.t('pagination.resultCount', { count: 1 })).toBe('1 result');
+    });
+
+    it('renders plural for count=0', () => {
+      testI18n.changeLanguage('en');
+      expect(testI18n.t('pagination.resultCount', { count: 0 })).toBe('0 results');
+    });
+
+    it('renders plural for count=many (e.g. 42)', () => {
+      testI18n.changeLanguage('en');
+      expect(testI18n.t('pagination.resultCount', { count: 42 })).toBe('42 results');
+    });
+  });
+
+  describe('Swahili locale', () => {
+    it('renders singular (tokeo) for count=1', () => {
+      testI18n.changeLanguage('sw');
+      expect(testI18n.t('pagination.resultCount', { count: 1 })).toBe('tokeo 1');
+    });
+
+    it('renders plural (matokeo) for count=0', () => {
+      testI18n.changeLanguage('sw');
+      expect(testI18n.t('pagination.resultCount', { count: 0 })).toBe('matokeo 0');
+    });
+
+    it('renders plural (matokeo) for count=many (e.g. 10)', () => {
+      testI18n.changeLanguage('sw');
+      expect(testI18n.t('pagination.resultCount', { count: 10 })).toBe('matokeo 10');
+    });
+  });
+
+  describe('Key parity', () => {
+    it('en.json and sw.json both have pagination.resultCount plural keys', () => {
+      expect(en.pagination).toBeDefined();
+      expect(en.pagination.resultCount_one).toBeDefined();
+      expect(en.pagination.resultCount_other).toBeDefined();
+      expect(sw.pagination).toBeDefined();
+      expect(sw.pagination.resultCount_one).toBeDefined();
+      expect(sw.pagination.resultCount_other).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
- Audit count-dependent UI strings; Pagination.jsx had a hardcoded English-only ternary: {total !== 1 ? 's' : ''}
- Add pagination.resultCount_one / resultCount_other to en.json with correct English singular/plural forms
- Add pagination.resultCount_one / resultCount_other to sw.json with correct Swahili forms (tokeo 1 / matokeo N) following Swahili singular-vs-plural noun-class conventions
- Replace the JSX ternary in Pagination.jsx with t('pagination.resultCount', { count: total }) so the active locale's plural rules are applied automatically via react-i18next
- Add swahiliPluralization.test.js covering count=0, 1, and many for both en and sw locales, plus a key-parity assertion

  Closes #1062 
  Closes #1063 