### PR TITLE
fix(a11y): add skip-to-main-content link for keyboard users

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -77,11 +77,18 @@ function AppContent() {
 
   return (
     <>
+      <a
+        href="#main-content"
+        className="skip-link"
+        onClick={() => document.getElementById('main-content')?.focus()}
+      >
+        Skip to main content
+      </a>
       <AnnouncementBanner />
       <Navbar />
       <LoadingSpinner />
       <UpdatePrompt />
-      <main id="main-content" style={{ paddingTop: 24 }}>
+      <main id="main-content" tabIndex={-1} style={{ paddingTop: 24, outline: 'none' }}>
         <Suspense fallback={<PageLoader />}>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/frontend/src/accessibility.css
+++ b/frontend/src/accessibility.css
@@ -1,0 +1,23 @@
+/* "Skip to main content" link: the first focusable element on every page.
+   Visually hidden off-screen until it receives keyboard focus, so sighted
+   mouse users never see it but keyboard users can Tab straight to it. */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  z-index: 1000;
+  background: #1b4332;
+  color: #fff;
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 0 0 6px 0;
+  transition: top 0.15s ease-in-out;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid #95d5b2;
+  outline-offset: 2px;
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import React, { useState, useEffect, useRef } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
@@ -103,14 +102,9 @@ export default function Navbar() {
         to="/"
         end
         style={({ isActive }) => (isActive ? { ...s.brand, textDecoration: 'underline' } : s.brand)}
-        aria-current={undefined}
       >
         🌿 FarmersMarket
       </NavLink>
-    <nav style={s.nav} ref={navRef}>
-      <NavLink to="/" end style={({ isActive }) => (isActive ? s.activeLink : s.brand)}>🌿 FarmersMarket</NavLink>
-    <nav ref={navRef} style={s.nav}>
-      <Link to="/" style={s.brand}>🌿 FarmersMarket</Link>
       {network && (
         <span style={{
           background: network === 'mainnet' ? '#c0392b' : '#2d6a4f',

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import { HelmetProvider } from "react-helmet-async";
 import App from "./App";
 import "./browser-compat.css";
 import "./responsive.css";
+import "./accessibility.css";
 import "./i18n";
 
 if (import.meta.env.DEV) {

--- a/frontend/src/test/SkipToMainContent.test.jsx
+++ b/frontend/src/test/SkipToMainContent.test.jsx
@@ -1,0 +1,72 @@
+// #1052 – "Skip to main content" link for keyboard users
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import { vi } from 'vitest';
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { name: 'Alice', role: 'buyer' }, logout: vi.fn() }),
+}));
+vi.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    toggleTheme: vi.fn(),
+    useSystemTheme: vi.fn(),
+    isUsingSystemTheme: false,
+  }),
+}));
+vi.mock('../api/client', () => ({
+  api: { getNetwork: () => Promise.resolve({ network: 'testnet' }) },
+}));
+
+// Mirrors the DOM order actually rendered by App.jsx's AppContent: the skip
+// link first, then the navbar (with its own focusable links/buttons), then
+// the shared main-content landmark every route renders into.
+function TestLayout() {
+  return (
+    <MemoryRouter>
+      <a
+        href="#main-content"
+        className="skip-link"
+        onClick={() => document.getElementById('main-content')?.focus()}
+      >
+        Skip to main content
+      </a>
+      <Navbar />
+      <main id="main-content" tabIndex={-1} style={{ outline: 'none' }}>
+        <h1>Marketplace</h1>
+      </main>
+    </MemoryRouter>
+  );
+}
+
+describe('Skip to main content link', () => {
+  it('is the first Tab stop, ahead of every nav link', async () => {
+    const user = userEvent.setup();
+    render(<TestLayout />);
+
+    await user.tab();
+
+    expect(
+      screen.getByRole('link', { name: /skip to main content/i }),
+    ).toHaveFocus();
+  });
+
+  it('moves focus to the main content landmark when activated', async () => {
+    const user = userEvent.setup();
+    render(<TestLayout />);
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    await user.click(skipLink);
+
+    expect(document.getElementById('main-content')).toHaveFocus();
+  });
+
+  it('is visually hidden until it receives focus', () => {
+    render(<TestLayout />);
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skipLink).toHaveClass('skip-link');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1052.

- Adds a "Skip to main content" link as the first focusable element on every page, visually hidden until focused (new `frontend/src/accessibility.css`), targeting the existing shared `<main id="main-content">` landmark that every route already renders into (`AppContent` in `App.jsx`) - so criterion 2 (a main-content landmark to target) was already satisfied app-wide, no per-page changes needed there.
- Gave that `<main>` `tabIndex={-1}` and an explicit `onClick` on the skip link that calls `.focus()` on it directly, rather than relying solely on the browser's native "focus the fragment target" behavior - that behavior is inconsistent across browsers for non-natively-focusable elements even with `tabindex`, so this makes the focus move deterministic.

**Unrelated but blocking:** `frontend/src/components/Navbar.jsx` on `main` has a botched merge left in - two duplicate `import ... from 'react'` statements (a hard SyntaxError, duplicate binding) and three overlapping/unclosed `<nav>` openings stacked on top of each other, one of them referencing an unimported `Link` component. The file cannot compile as it stands on `main`, so this PR also deduplicates it down to the single intended nav structure (`NavLink` brand with active-route styling, network badge, hamburger + drawer, focus trap) - kept as minimal as possible, no behavior changes beyond making it valid again.

## Test plan
- [x] New `frontend/src/test/SkipToMainContent.test.jsx`: skip link is the first Tab stop ahead of every nav link, activating it moves focus to `#main-content`, link carries the visually-hidden-until-focus class
- [x] `frontend/src/test/NavbarActiveRoute.test.jsx` (pre-existing) passes again now that `Navbar.jsx` compiles
- [x] `pnpm exec vitest run` - no new failures introduced (16 pre-existing failures elsewhere in the suite, e.g. `api.getOrdersStreamUrl is not a function`, confirmed present on unmodified `main` too, unrelated to this change)